### PR TITLE
[#63] Fixed missing Creature Type for new NPCs

### DIFF
--- a/src/sheets/shared/InlineCreatureType.svelte
+++ b/src/sheets/shared/InlineCreatureType.svelte
@@ -7,7 +7,7 @@
 
   let context = getContext<Readable<ActorSheetContext>>('context');
 
-  $: text = coalesce($context.labels.type, '');
+  $: text = coalesce($context.labels.type, localize('DND5E.CreatureType'));
 
   $: configFn =
     $context.actor.type === 'character'


### PR DESCRIPTION
#63 

Added placeholder text for all creature types when a type is not present.