### PR TITLE
[#67] Fixed "Move Traits" bug

### DIFF
--- a/src/components/item-list/ItemSummary.svelte
+++ b/src/components/item-list/ItemSummary.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <div
-  transition:slide|global={{
+  transition:slide={{
     duration: useTransition ? 200 : 0,
     easing: quadInOut,
   }}

--- a/src/components/item-list/ItemTableRowSummary.svelte
+++ b/src/components/item-list/ItemTableRowSummary.svelte
@@ -1,7 +1,0 @@
-<script>
-  import { slide } from 'svelte/transition';
-</script>
-
-<div class="item-table-summary" transition:slide|global={{ duration: 200 }}>
-  <slot>(Item table summary here!)</slot>
-</div>

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -484,7 +484,9 @@ export function createSettings() {
           type: Boolean,
         },
         get() {
-          return FoundryAdapter.getTidySetting<boolean>('toggleEmptyCharacterTraits');
+          return FoundryAdapter.getTidySetting<boolean>(
+            'toggleEmptyCharacterTraits'
+          );
         },
       },
 
@@ -929,7 +931,9 @@ export function createSettings() {
           type: Boolean,
         },
         get() {
-          return FoundryAdapter.getTidySetting<boolean>('useCharacterInspiration');
+          return FoundryAdapter.getTidySetting<boolean>(
+            'useCharacterInspiration'
+          );
         },
       },
 

--- a/src/sheets/actor/TraitSection.svelte
+++ b/src/sheets/actor/TraitSection.svelte
@@ -35,7 +35,7 @@
 {#if show}
   <div
     class="trait-form-group {traitCssClass ?? ''}"
-    transition:slide|global={{ duration: 200, easing: quadInOut }}
+    transition:slide={{ duration: 200, easing: quadInOut }}
   >
     <span class="trait-icon" aria-label={title} {title}>
       {#if iconCssClass !== undefined}

--- a/src/sheets/vehicle/parts/VehicleAttributes.svelte
+++ b/src/sheets/vehicle/parts/VehicleAttributes.svelte
@@ -84,7 +84,7 @@
   {#if !$context.system.attributes.actions.stations}
     <div
       class="counter-flex"
-      transition:slide|global={{ duration: 200, easing: quadInOut }}
+      transition:slide={{ duration: 200, easing: quadInOut }}
     >
       <HorizontalLineSeparator />
       <div class="counter actions">


### PR DESCRIPTION
#67 

Removed the global directive from all transitions so that they properly remove when a parent element removes them. Having them use `|global` was causing them to animate while trying to be removed, resulting in them staying there.

Also removed unused component.