### PR TITLE
[#69] Fixes spell component tag issue when using languages with different abbreviations

### DIFF
--- a/src/components/spellbook/SpellComponents.svelte
+++ b/src/components/spellbook/SpellComponents.svelte
@@ -8,14 +8,14 @@
 
 {#each spell.labels.components.all as component}
   <span
-    class="spell-component {component.tag ? component.abbr : ''}"
+    class="spell-component"
+    class:tag={component.tag}
     title={spellAbbreviationMap.get(component.abbr)}>{component.abbr}</span
   >
 {/each}
 
 <style lang="scss">
-  .spell-component.C,
-  .spell-component.R {
+  .spell-component.tag {
     color: var(--t5ek-background);
     background: var(--t5ek-tertiary-color);
     border-radius: 0.125rem;


### PR DESCRIPTION
Replaced CSS that relied on abbreviations with a simple tag class that applies the style in a language-agnostic way.