### PR TITLE
[#82] Actions Tab refinements, round 1

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -471,6 +471,10 @@
     "name": "Include Consumables as Actions",
     "hint": "Includes consumables which have an activation cost (Action, Bonus Action, etc) in the Actions list by default."
   },
+  "T5EK.Settings.ActionsListScaleCantripDamage": {
+    "name": "Show Scaled Cantrip Damage",
+    "hint": "Scales cantrip damage to match the actor's current level or challenge rating. This feature will only work for cantrips with one damage type (e.g., 1d8 Radiant) and no custom scaling formula."
+  },
   "T5EK.Settings.ColorPickerEnabled": {
     "name": "Use Custom Theme Colors",
     "hint": "Shows custom theme colors"

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -472,8 +472,8 @@
     "hint": "Includes consumables which have an activation cost (Action, Bonus Action, etc) in the Actions list by default."
   },
   "T5EK.Settings.ActionsListScaleCantripDamage": {
-    "name": "Show Scaled Cantrip Damage",
-    "hint": "Scales cantrip damage to match the actor's current level or challenge rating. This feature will only work for cantrips with one damage type (e.g., 1d8 Radiant) and no custom scaling formula."
+    "name": "Show Scaled Cantrip Damage (experimental)",
+    "hint": "Scales cantrip damage to match the PC's current level or the NPC's challenge rating."
   },
   "T5EK.Settings.ColorPickerEnabled": {
     "name": "Use Custom Theme Colors",

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -250,10 +250,10 @@ export function getScaledCantripDamageFormulaForSinglePart(
       [damageFormula],
       item.system.scaling.formula,
       item.actor.type === 'character'
-        ? item.actor.system.details.level
+        ? item.actor.system.details.level ?? 0
         : item.system.preparation.mode === 'innate'
-        ? Math.ceil(item.actor.system.details.cr)
-        : item.actor.system.details.spellLevel,
+        ? Math.ceil(item.actor.system.details.cr ?? 0)
+        : item.actor.system.details.spellLevel ?? 0,
       item.getRollData()
     );
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -233,3 +233,36 @@ export function toggleActionFilterOverride(item: Item5e) {
     !isItemInActionList(item)
   );
 }
+
+type derivedDamage = {
+  label: string;
+  formula: string;
+  damageType: string;
+};
+
+export function getScaledCantripDamageFormulaForSinglePart(
+  item: Item5e,
+  partIndex: number
+): derivedDamage {
+  try {
+    const damageFormula = item.system.damage.parts[partIndex]?.[0] ?? '';
+    const scaledFormula = item._scaleCantripDamage(
+      [damageFormula],
+      item.system.scaling.formula,
+      item.actor.type === 'character'
+        ? item.actor.system.details.level
+        : item.system.preparation.mode === 'innate'
+        ? Math.ceil(item.actor.system.details.cr)
+        : item.actor.system.details.spellLevel,
+      item.getRollData()
+    );
+
+    return {
+      ...item.labels.derivedDamage[partIndex],
+      formula: scaledFormula,
+    };
+  } catch (e) {
+    error('An error occurred while scaling cantrip damage', false, e);
+    return item.labels.derivedDamage[partIndex];
+  }
+}

--- a/src/applications/sheet-settings/SheetSettingsFormApplication.ts
+++ b/src/applications/sheet-settings/SheetSettingsFormApplication.ts
@@ -70,6 +70,8 @@ export class SheetSettingsFormApplication extends SvelteFormApplicationBase {
 
     this.cacheSettingsForChangeTracking(data.settings);
 
+    debug('Sheet Settings context data', data);
+
     return new SheetSettings({
       target: node,
       context: new Map<any, any>([

--- a/src/applications/sheet-settings/tabs/FeaturesSettingsTab.svelte
+++ b/src/applications/sheet-settings/tabs/FeaturesSettingsTab.svelte
@@ -4,11 +4,11 @@
   import type { Writable } from 'svelte/store';
   import {
     SettingsProvider,
-    type CurrentSettings,
   } from 'src/settings/settings';
   import CheckboxSetting from '../parts/CheckboxSetting.svelte';
+    import type { SettingsSheetContext } from '../SheetSettings.types';
 
-  let context = getContext<Writable<CurrentSettings>>('context');
+  let context = getContext<Writable<SettingsSheetContext>>('context');
 
   const localize = FoundryAdapter.localize;
 </script>
@@ -16,14 +16,14 @@
 <h2>{localize('T5EK.Settings.ActionsList.Header')}</h2>
 
 <CheckboxSetting
-  bind:value={$context.actionListLimitActionsToCantrips}
+  bind:value={$context.settings.actionListLimitActionsToCantrips}
   name={SettingsProvider.settings.actionListLimitActionsToCantrips.options.name}
   hint={SettingsProvider.settings.actionListLimitActionsToCantrips.options.hint}
   id="actionListLimitActionsToCantrips"
 />
 
 <CheckboxSetting
-  bind:value={$context.actionListIncludeMinuteLongSpellsAsActions}
+  bind:value={$context.settings.actionListIncludeMinuteLongSpellsAsActions}
   name={SettingsProvider.settings.actionListIncludeMinuteLongSpellsAsActions
     .options.name}
   hint={SettingsProvider.settings.actionListIncludeMinuteLongSpellsAsActions
@@ -32,7 +32,7 @@
 />
 
 <CheckboxSetting
-  bind:value={$context.actionListIncludeSpellsWithActiveEffects}
+  bind:value={$context.settings.actionListIncludeSpellsWithActiveEffects}
   name={SettingsProvider.settings.actionListIncludeSpellsWithActiveEffects
     .options.name}
   hint={SettingsProvider.settings.actionListIncludeSpellsWithActiveEffects
@@ -41,8 +41,15 @@
 />
 
 <CheckboxSetting
-  bind:value={$context.actionListIncludeConsumables}
+  bind:value={$context.settings.actionListIncludeConsumables}
   name={SettingsProvider.settings.actionListIncludeConsumables.options.name}
   hint={SettingsProvider.settings.actionListIncludeConsumables.options.hint}
   id="actionListIncludeConsumables"
+/>
+
+<CheckboxSetting
+  bind:value={$context.settings.actionListScaleCantripDamage}
+  name={SettingsProvider.settings.actionListScaleCantripDamage.options.name}
+  hint={SettingsProvider.settings.actionListScaleCantripDamage.options.hint}
+  id="actionListScaleCantripDamage"
 />

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1410,6 +1410,22 @@ export function createSettings() {
         },
       },
 
+      actionListScaleCantripDamage: {
+        options: {
+          name: 'T5EK.Settings.ActionsListScaleCantripDamage.name',
+          hint: 'T5EK.Settings.ActionsListScaleCantripDamage.hint',
+          scope: 'client',
+          config: false,
+          default: true,
+          type: Boolean,
+        },
+        get() {
+          return FoundryAdapter.getTidySetting<boolean>(
+            'actionListScaleCantripDamage'
+          );
+        },
+      },
+
       // Color customization
 
       colorPickerEnabled: {

--- a/src/sheets/actor/tabs/ActorActionsTab.svelte
+++ b/src/sheets/actor/tabs/ActorActionsTab.svelte
@@ -97,12 +97,12 @@
                   {:else if item.hasLimitedUses}
                     {#if item.system.uses?.value === item.system.uses?.max && item.system.uses?.autoDestroy}
                       <div title={item.system.quantity}>
-                        {item.system.quantity}
+                        {item.system.quantity ?? 0}
                       </div>
                       <small>{localize('DND5E.Quantity')}</small>
                     {:else}
                       <div>
-                        {item.system.uses.value} / {item.system.uses.max}
+                        {item.system.uses.value ?? 0} / {item.system.uses.max ?? 0}
                       </div>
                       <small>{localize('DND5E.Uses')}</small>
                     {/if}

--- a/src/sheets/actor/tabs/ActorActionsTab.svelte
+++ b/src/sheets/actor/tabs/ActorActionsTab.svelte
@@ -11,9 +11,13 @@
   import ItemName from 'src/components/item-list/ItemName.svelte';
   import { CONSTANTS } from 'src/constants';
   import ItemUseButton from 'src/components/item-list/ItemUseButton.svelte';
-  import { damageTypeIconMap } from 'src/actions/actions';
+  import {
+    damageTypeIconMap,
+    getScaledCantripDamageFormulaForSinglePart,
+  } from 'src/actions/actions';
   import RechargeControl from 'src/components/item-list/controls/RechargeControl.svelte';
   import ActionFilterOverrideControl from 'src/components/item-list/controls/ActionFilterOverrideControl.svelte';
+  import { settingStore } from 'src/settings/settings';
 
   let context = getContext<Readable<ActorSheetContext>>('context');
 
@@ -73,7 +77,7 @@
                       {item.labels.school ?? ''}
                       {#if spellClass}
                         • {localize(spellClass)}
-                    {/if}
+                      {/if}
                     {:else}
                       {item.labels.school ?? ''}
                       {item.labels.level ?? ''}
@@ -155,19 +159,36 @@
             </ItemTableCell>
             <ItemTableCell baseWidth="7.5rem" cssClass="flex-wrap">
               <!-- Damage -->
-              {#each item.labels.derivedDamage ?? [] as entry}
+              {#each item.labels.derivedDamage ?? [] as entry, i}
                 {@const damageHealingTypeLabel =
                   FoundryAdapter.lookupDamageType(entry.damageType) ??
                   FoundryAdapter.lookupHealingType(entry.damageType)}
-                <p
+                {@const isScalableCantripDamage =
+                  item.type === 'spell' &&
+                  item.system.scaling?.mode === 'cantrip' &&
+                  $settingStore.actionListScaleCantripDamage}
+
+                {#if isScalableCantripDamage}
+                  {@const scaledEntry =
+                    getScaledCantripDamageFormulaForSinglePart(item, i)}
+                  <p title={scaledEntry.formula + damageHealingTypeLabel}>
+                    {scaledEntry.formula}
+                    <span
+                      >{@html damageTypeIconMap[scaledEntry.damageType] ??
+                        ''}</span
+                    >
+                  </p>
+                {:else}
+                  <p
                     title={entry.label ??
                       entry.formula + damageHealingTypeLabel}
-                >
-                  {entry.formula}
+                  >
+                    {entry.formula}
                     <span
                       >{@html damageTypeIconMap[entry.damageType] ?? ''}</span
                     >
-                </p>
+                  </p>
+                {/if}
               {/each}
             </ItemTableCell>
             {#if $context.owner && $context.useClassicControls}


### PR DESCRIPTION
#82 

Adds optional cantrip scaling to the damage column (default: On).

Resolves some minor issues.