### PR TITLE
[#143] Updated editors' editable area to span the full height of their containers

### DIFF
--- a/src/components/item-list/ItemTableRow.svelte
+++ b/src/components/item-list/ItemTableRow.svelte
@@ -107,21 +107,28 @@
 
   onMount(() => {
     let first = true;
-    return context?.subscribe(async (c: any) => {
+
+    const subscription = context?.subscribe(async (c: any) => {
       if (first) {
         first = false;
         restoreItemSummaryIfExpanded();
         return;
       }
 
-      if (item && chatData) {
+      if (item && showSummary) {
         item
           .getChatData({ secrets: item.actor.isOwner })
           .then((data: ItemChatData) => {
             chatData = data;
           });
+      } else if (item && !showSummary && chatData) {
+        // Reset chat data for non-expanded, hydrated chatData 
+        // so it rehydrates on next open
+        chatData = undefined;
       }
     });
+
+    return subscription;
   });
 </script>
 

--- a/src/scss/partials/_actor.scss
+++ b/src/scss/partials/_actor.scss
@@ -62,6 +62,10 @@
     }
   }
 
+  .editor {
+    flex: 1;
+  }
+
   .editor,
   .editor .editor-content {
     padding: 0;

--- a/src/scss/partials/_items.scss
+++ b/src/scss/partials/_items.scss
@@ -307,8 +307,13 @@ input[type='checkbox'] {
       border: none;
     }
 
+    [contenteditable='true']:hover,
+    [contenteditable='true']:focus {
+      box-shadow: 0 0 0 0.0625rem var(--t5ek-primary-accent-color) inset;
+    }
+
     .editor {
-      height: 100%;
+      flex: 1;
       font-size: 0.8125rem;
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
#143 

(Also, did some misc perf work on expanded item chat data refresh; unexpanded, hydrated chat data will clear on a change detection cycle now, so that they fetch fresh info on next open)