### PR TITLE
Fix for NPC death saves

### DIFF
--- a/src/foundry/foundry-adapter.ts
+++ b/src/foundry/foundry-adapter.ts
@@ -640,7 +640,7 @@ export const FoundryAdapter = {
     actor: Actor5e,
     options: any
   ): Promise<unknown | null> {
-    const death = actor.flags[CONSTANTS.MODULE_ID].death ?? {};
+    const death = actor.flags[CONSTANTS.MODULE_ID]?.death ?? {};
 
     // Display a warning if we are not at zero HP or if we already have reached 3
     if (


### PR DESCRIPTION
Was getting an undefined error when rolling NPC death saves on dnd5e 3.0. Fixed it with a quick bit of optional chaining.