### PR TITLE
CCSS Migration wording update

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -686,7 +686,6 @@
       "ccss": "CCSS",
       "section": "Section",
       "explanation1": "Tidy 5e now natively supports custom sections and provides additional features around custom sections. This migration will copy Custom Character Sheet Sections (CCSS) section names into Tidy's section setup.",
-      "explanation2": "{boldStart}Note{boldEnd}: CCSS takes priority with custom sectioning. To disable CCSS for an item, be sure to use the option to delete affected flags, or manually clear the CCSS custom section value.",
       "overwrite": "Overwrite",
       "overwriteTooltip": "Enable to overwrite existing Tidy section flag. If unchecked, only empty Tidy flags will receive migrated CCSS data.",
       "deleteFlags": "Delete Affected CCSS Flags",

--- a/src/applications/migrations/v3/CcssToTidyMigration.svelte
+++ b/src/applications/migrations/v3/CcssToTidyMigration.svelte
@@ -153,12 +153,6 @@
   </h2>
   <div class="callout-banner">
     <p>{localize('TIDY5E.Settings.Migrations.CcssToTidy.explanation1')}</p>
-    <p>
-      {@html localize('TIDY5E.Settings.Migrations.CcssToTidy.explanation2', {
-        boldStart: '<strong>',
-        boldEnd: '</strong>',
-      })}
-    </p>
   </div>
   <p>{localize('TIDY5E.Settings.Migrations.UnlinkedExplanation')}</p>
   <h3>{localize('TIDY5E.Settings.Migrations.OptionsHeader')}</h3>


### PR DESCRIPTION
CCSS and Tidy are now coordinating so that CCSS works with other sheets while Tidy does its own thing. For this reason, the migration wording needed to be updated to remove verbiage about CCSS taking precedence.