### PR TITLE
fixed: Nonstandard attunement values on items mistakenly mark item as attune-able

### DIFF
--- a/src/context-menu/tidy5e-context-menu.ts
+++ b/src/context-menu/tidy5e-context-menu.ts
@@ -209,7 +209,10 @@ function getItemContextOptions(item: Item5e) {
   }
 
   // Toggle Attunement State
-  if (!!item.system.attunement && !FoundryAdapter.concealDetails(item)) {
+  if (
+    !!CONFIG.DND5E.attunementTypes[item.system.attunement] &&
+    !FoundryAdapter.concealDetails(item)
+  ) {
     options.push({
       name: item.system.attuned
         ? 'TIDY5E.ContextMenuActionUnattune'

--- a/src/foundry/foundry-adapter.ts
+++ b/src/foundry/foundry-adapter.ts
@@ -1164,7 +1164,8 @@ export const FoundryAdapter = {
     title: 'DND5E.AttunementAttuned',
   },
   getAttunementContext(item: Item5e): AttunementContext | undefined {
-    return !!item.system.attunement && !item.system.attuned
+    return !!CONFIG.DND5E.attunementTypes[item.system.attunement] &&
+      !item.system.attuned
       ? {
           ...FoundryAdapter.attunementContextApplicable,
           title: CONFIG.DND5E.attunementTypes[item.system.attunement],

--- a/src/runtime/item/default-item-filters.ts
+++ b/src/runtime/item/default-item-filters.ts
@@ -193,7 +193,7 @@ export function getAttunementFilters(): ItemFilter[] {
       name: 'attuned',
       predicate: (item) =>
         !FoundryAdapter.concealDetails(item) &&
-        !!item.system.attunement &&
+        !!CONFIG.DND5E.attunementTypes[item.system.attunement] &&
         item.system.attuned,
       text: 'DND5E.AttunementAttuned',
     },

--- a/src/sheets/item/tabs/ItemConsumableDetailsTab.svelte
+++ b/src/sheets/item/tabs/ItemConsumableDetailsTab.svelte
@@ -72,7 +72,8 @@
       document={$context.item}
       field="system.attuned"
       checked={$context.system.attuned}
-      disabled={!$context.editable || !$context.system.attunement}
+      disabled={!$context.editable ||
+        !$context.config.attunementTypes[$context.system.attunement]}
       title={localize('DND5E.AttunementAttuned')}
     ></Checkbox>
     <Select

--- a/src/sheets/item/tabs/ItemContainerDetailsTab.svelte
+++ b/src/sheets/item/tabs/ItemContainerDetailsTab.svelte
@@ -67,7 +67,8 @@
       document={$context.item}
       field="system.attuned"
       checked={$context.system.attuned}
-      disabled={!$context.editable || !$context.system.attunement}
+      disabled={!$context.editable ||
+        !$context.config.attunementTypes[$context.system.attunement]}
       title={localize('DND5E.AttunementAttuned')}
     ></Checkbox>
     <Select

--- a/src/sheets/item/tabs/ItemEquipmentDetailsTab.svelte
+++ b/src/sheets/item/tabs/ItemEquipmentDetailsTab.svelte
@@ -80,7 +80,8 @@
         document={$context.item}
         field="system.attuned"
         checked={$context.system.attuned}
-        disabled={!$context.editable || !$context.system.attunement}
+        disabled={!$context.editable ||
+          !$context.config.attunementTypes[$context.system.attunement]}
         title={localize('DND5E.AttunementAttuned')}
       ></Checkbox>
       <Select

--- a/src/sheets/item/tabs/ItemToolDetailsTab.svelte
+++ b/src/sheets/item/tabs/ItemToolDetailsTab.svelte
@@ -70,7 +70,8 @@
       document={$context.item}
       field="system.attuned"
       checked={$context.system.attuned}
-      disabled={!$context.editable || !$context.system.attunement}
+      disabled={!$context.editable ||
+        !$context.config.attunementTypes[$context.system.attunement]}
       title={localize('DND5E.AttunementAttuned')}
     ></Checkbox>
     <Select

--- a/src/sheets/item/tabs/ItemWeaponDetailsTab.svelte
+++ b/src/sheets/item/tabs/ItemWeaponDetailsTab.svelte
@@ -68,7 +68,8 @@
         document={$context.item}
         field="system.attuned"
         checked={$context.system.attuned}
-        disabled={!$context.editable || !$context.system.attunement}
+        disabled={!$context.editable ||
+          !$context.config.attunementTypes[$context.system.attunement]}
         title={localize('DND5E.AttunementAttuned')}
       ></Checkbox>
       <Select


### PR DESCRIPTION
Updated attunement eligibility logic to specifically check the configured attunementTypes, rather than just looking for a truthy value.