### PR TITLE
ui: last-minute Sheet Lock fine-tuning

### DIFF
--- a/src/components/toggle/_toggles.scss
+++ b/src/components/toggle/_toggles.scss
@@ -89,7 +89,7 @@
         0,
         0,
         0,
-        0.75
+        0.9
       ); // TODO: Theme color? Or at least top-level variable that can be customized?
       display: flex;
       justify-content: center;

--- a/src/sheets/actor/SheetEditModeToggle.svelte
+++ b/src/sheets/actor/SheetEditModeToggle.svelte
@@ -43,7 +43,7 @@
 
 <div class="sheet-edit-mode-toggle {$$restProps.class ?? ''}">
   <TidySwitch
-    --tidy-switch-scale=".875"
+    --tidy-switch-scale="1"
     --tidy-switch-thumb-transform-duration="0.15s"
     title={allowEdit ? unlockTitle : lockTitle}
     value={allowEdit}


### PR DESCRIPTION
Increased darkness of thumb icon on switch toggles.

Increased the switch scale to 1, to make it more satisfyingly centered and accessible.