### PR TITLE
Dnd5e 3.3.x the unbuttoning

### DIFF
--- a/src/applications/theme/ThemeSettingSheetMenu.svelte
+++ b/src/applications/theme/ThemeSettingSheetMenu.svelte
@@ -47,7 +47,7 @@
   openerPadding="0.125rem 0.5rem"
   buttonText={localize('TIDY5E.ThemeSettings.Sheet.menuLabel')}
 >
-  <ThemeSelectorButtonMenuCommand />
+  <ThemeSelectorButtonMenuCommand colorScheme={$context.colorScheme} />
   <ButtonMenuDivider />
   <ButtonMenuCommand
     on:click={() => fileImportInput.click()}

--- a/src/components/accordion/AccordionItem.svelte
+++ b/src/components/accordion/AccordionItem.svelte
@@ -2,13 +2,14 @@
   import { getContext, onMount } from 'svelte';
   import type { AccordionCtxType } from './Accordion.svelte';
   import { writable } from 'svelte/store';
-  import { settingStore } from 'src/settings/settings';
   import ExpandableContainer from 'src/components/expandable/ExpandableContainer.svelte';
   import { CONSTANTS } from 'src/constants';
 
   export let open: boolean = false;
 
-  const ctx = getContext<AccordionCtxType>(CONSTANTS.SVELTE_CONTEXT.ACCORDION_CONTEXT) ?? {};
+  const ctx =
+    getContext<AccordionCtxType>(CONSTANTS.SVELTE_CONTEXT.ACCORDION_CONTEXT) ??
+    {};
 
   const self = {};
   const selected = ctx.selected ?? writable();
@@ -27,18 +28,18 @@
 
 <section class="accordion-item {$$props.class ?? ''}">
   <h2 class="accordion-item-header" class:open>
-    <button
-      class="accordion-item-toggle transparent-button"
-      type="button"
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <span
+      class="accordion-item-toggle"
       on:click={() => toggle()}
       data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.EXPANSION_TOGGLE}
-      tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
     >
       <span class="accordion-arrow" class:open
         ><i class="fas fa-chevron-right" /></span
       >
       <slot name="header" />
-    </button>
+    </span>
   </h2>
 
   <ExpandableContainer expanded={open}>
@@ -65,6 +66,8 @@
     display: flex;
     gap: 0.5rem;
     align-items: center;
+    font-size: var(--font-size-14);
+    cursor: pointer;
 
     .accordion-arrow {
       font-size: 0.75rem;

--- a/src/components/button-menu/ButtonMenu.svelte
+++ b/src/components/button-menu/ButtonMenu.svelte
@@ -7,7 +7,6 @@
     ButtonMenuPosition,
   } from './button-menu-types';
   import { getPositionStyles } from './button-menu-position';
-  import { settingStore } from 'src/settings/settings';
   import { CONSTANTS } from 'src/constants';
 
   type StatefulIconClass = {
@@ -68,7 +67,6 @@
     {title}
     class="button-menu-opener {buttonClass ?? ''} {buttonStyle}"
     style:padding={openerPadding}
-    tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
   >
     {#if iconClass}
       <i class={actualIconClass} />

--- a/src/components/button-menu/ButtonMenu.svelte
+++ b/src/components/button-menu/ButtonMenu.svelte
@@ -27,7 +27,10 @@
   export let position: ButtonMenuPosition = 'bottom';
   export let anchor: ButtonMenuAnchor = 'center';
   export let menuElement: keyof HTMLElementTagNameMap = 'ul';
-  export let buttonStyle: 'solid' | 'transparent-inline' | 'transparent-inline-icon' = 'solid';
+  export let buttonStyle:
+    | 'solid'
+    | 'transparent-inline'
+    | 'transparent-inline-icon' = 'solid';
 
   let openerEl: HTMLElement;
   let menuStyles: string = '';
@@ -59,8 +62,10 @@
 </script>
 
 <div class="button-menu-wrapper {wrapperClass ?? ''}">
-  <button
-    type="button"
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <!-- svelte-ignore a11y-missing-attribute -->
+  <a
     on:click={() => (open = !open)}
     aria-label={ariaLabel}
     bind:this={openerEl}
@@ -72,7 +77,7 @@
       <i class={actualIconClass} />
     {/if}
     {buttonText}
-  </button>
+  </a>
 
   {#if open}
     <svelte:element

--- a/src/components/button-menu/ButtonMenuCommand.svelte
+++ b/src/components/button-menu/ButtonMenuCommand.svelte
@@ -2,7 +2,6 @@
   import { createEventDispatcher, getContext } from 'svelte';
   import ButtonMenuItem from './ButtonMenuItem.svelte';
   import type { ButtonMenuContext } from './button-menu-types';
-  import { settingStore } from 'src/settings/settings';
   import { CONSTANTS } from 'src/constants';
 
   export let iconClass: string = '';
@@ -35,7 +34,6 @@
     on:click={handleClick}
     {title}
     {disabled}
-    tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
   >
     {#if useIconColumn}
       <span class="icon-container">

--- a/src/components/button-menu/ButtonMenuCommand.svelte
+++ b/src/components/button-menu/ButtonMenuCommand.svelte
@@ -15,25 +15,25 @@
   );
   const dispatch = createEventDispatcher<{
     click: {
-      event: MouseEvent & { currentTarget: HTMLButtonElement };
+      event: MouseEvent & { currentTarget: HTMLElement };
     };
   }>();
 
-  function handleClick(
-    event: MouseEvent & { currentTarget: HTMLButtonElement },
-  ) {
+  function handleClick(event: MouseEvent & { currentTarget: HTMLElement }) {
     buttonMenuContext.close();
     dispatch('click', { event });
   }
 </script>
 
 <ButtonMenuItem cssClass="button-menu-command-li">
-  <button
-    type="button"
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <!-- svelte-ignore a11y-missing-attribute -->
+  <a
     class="button-menu-command {size}"
+    class:disabled
     on:click={handleClick}
     {title}
-    {disabled}
   >
     {#if useIconColumn}
       <span class="icon-container">
@@ -45,5 +45,5 @@
     <span class="command-text">
       <slot />
     </span>
-  </button>
+  </a>
 </ButtonMenuItem>

--- a/src/components/button-menu/button-menu.scss
+++ b/src/components/button-menu/button-menu.scss
@@ -11,6 +11,15 @@
     border: none;
     text-align: center;
     transition: background-color, 0.3s;
+    display: inline-flex;
+    flex-direction: row;
+    gap: 0.25rem;
+    align-items: center;
+    justify-content: center;
+
+    &.justify-content-start {
+      justify-content: flex-start;
+    }
 
     &.primary {
       color: var(--t5e-primary-color);

--- a/src/components/filter/FilterToggleButton.svelte
+++ b/src/components/filter/FilterToggleButton.svelte
@@ -2,7 +2,6 @@
   import type { ItemFilterService } from 'src/features/filtering/ItemFilterService';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
   import type { ConfiguredItemFilter } from 'src/runtime/item/item.types';
-  import { settingStore } from 'src/settings/settings';
   import {
     cycleNullTrueFalseForward,
     cycleNullTrueFalseBackward,
@@ -24,15 +23,16 @@
   const localize = FoundryAdapter.localize;
 </script>
 
-<button
-  type="button"
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y-missing-attribute -->
+<a
   class="filter-toggle-button pill-button truncate"
   class:include={filter.value === true}
   class:exclude={filter.value === false}
   on:click={() => cycleFilterForward(filter.name, filter.value)}
   on:contextmenu={() => cycleFilterBackward(filter.name, filter.value)}
-  tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
   title={localize(filter.text)}
 >
   <slot />
-</button>
+</a>

--- a/src/components/filter/PinnedFilterToggle.svelte
+++ b/src/components/filter/PinnedFilterToggle.svelte
@@ -2,7 +2,6 @@
   import type { ItemFilterService } from 'src/features/filtering/ItemFilterService';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
   import type { ConfiguredItemFilter } from 'src/runtime/item/item.types';
-  import { settingStore } from 'src/settings/settings';
   import {
     cycleNullTrueFalseForward,
     cycleNullTrueFalseBackward,
@@ -24,15 +23,16 @@
   const localize = FoundryAdapter.localize;
 </script>
 
-<button
-  type="button"
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-missing-attribute -->
+<a
   class="pinned-filter-toggle truncate"
   class:include={filter.value === true}
   class:exclude={filter.value === false}
   on:click={() => cycleFilterForward(filter.name, filter.value)}
   on:contextmenu={() => cycleFilterBackward(filter.name, filter.value)}
-  tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
   title={localize(filter.text)}
 >
   <slot />
-</button>
+</a>

--- a/src/components/inputs/InlineTextDropdownList.svelte
+++ b/src/components/inputs/InlineTextDropdownList.svelte
@@ -25,7 +25,7 @@
   ariaLabel={title}
   {title}
   buttonText={selected.text}
-  buttonClass="primary {buttonClass}"
+  buttonClass="primary justify-content-start {buttonClass}"
   buttonStyle="transparent-inline"
 >
   {#each options as option}

--- a/src/components/item-info-card/ItemInfoCard.svelte
+++ b/src/components/item-info-card/ItemInfoCard.svelte
@@ -10,15 +10,15 @@
   import type { Writable } from 'svelte/store';
   import HorizontalLineSeparator from '../layout/HorizontalLineSeparator.svelte';
   import { warn } from 'src/utils/logging';
-  import { settingStore } from 'src/settings/settings';
   import { getItemCardContentTemplate } from './item-info-card';
   import { ItemSummaryRuntime } from 'src/runtime/ItemSummaryRuntime';
   import ItemSummaryCommandButtonList from '../item-summary/ItemSummaryCommandButtonList.svelte';
   import { CONSTANTS } from 'src/constants';
+  import { SettingsProvider } from 'src/settings/settings';
 
   // Fix Key
   let frozen: boolean = false;
-  $: fixKey = $settingStore.itemCardsFixKey?.toUpperCase();
+  $: fixKey = SettingsProvider.settings.itemCardsFixKey.get()?.toUpperCase();
   $: concealDetails = FoundryAdapter.concealDetails(item);
 
   function detectFixStart(ev: KeyboardEvent) {
@@ -47,7 +47,11 @@
   function onMouseMove(args: { clientX: number; clientY: number }) {
     lastMouseEvent = args;
 
-    if (!$settingStore.itemCardsAreFloating || !open || frozen) {
+    if (
+      !SettingsProvider.settings.itemCardsAreFloating.get() ||
+      !open ||
+      frozen
+    ) {
       return;
     }
 
@@ -104,7 +108,7 @@
   let debug = false;
   let timer: any;
   let infoContentTemplate: ItemCardContentComponent | null;
-  $: delayMs = $settingStore.itemCardsDelay ?? 0;
+  $: delayMs = SettingsProvider.settings.itemCardsDelay.get() ?? 0;
 
   async function showCard() {
     if (!$card.item) {
@@ -124,7 +128,7 @@
       infoContentTemplate = $card.itemCardContentTemplate;
       item = $card.item;
 
-      if ($settingStore.itemCardsAreFloating) {
+      if (SettingsProvider.settings.itemCardsAreFloating.get()) {
         rootFontSizePx = getRootFontSizePx();
 
         const boundingClientRect = sheet?.getBoundingClientRect();
@@ -141,7 +145,9 @@
   }
 
   // Content
-  const card = getContext<Writable<ItemCardStore>>(CONSTANTS.SVELTE_CONTEXT.CARD);
+  const card = getContext<Writable<ItemCardStore>>(
+    CONSTANTS.SVELTE_CONTEXT.CARD,
+  );
   const cardWidthRem: number = 17.5;
   const cardHeightRem: number = 28.75;
   const mouseCursorCardGapRem = 1.5;
@@ -223,9 +229,13 @@
   bind:this={itemCardNode}
   class="item-info-container"
   class:open={debug || open}
-  class:floating={$settingStore.itemCardsAreFloating}
-  style:top={$settingStore.itemCardsAreFloating ? floatingTop : undefined}
-  style:left={$settingStore.itemCardsAreFloating ? floatingLeft : undefined}
+  class:floating={SettingsProvider.settings.itemCardsAreFloating.get()}
+  style:top={SettingsProvider.settings.itemCardsAreFloating.get()
+    ? floatingTop
+    : undefined}
+  style:left={SettingsProvider.settings.itemCardsAreFloating.get()
+    ? floatingLeft
+    : undefined}
   style:--card-width="{cardWidthRem}rem"
   style:--card-height="{cardHeightRem}rem"
 >

--- a/src/components/item-info-card/ItemInfoCard.svelte
+++ b/src/components/item-info-card/ItemInfoCard.svelte
@@ -7,18 +7,21 @@
   } from 'src/types/item.types';
   import type { ItemCardStore } from 'src/types/types';
   import { getContext, onDestroy, onMount } from 'svelte';
-  import type { Writable } from 'svelte/store';
+  import { type Readable, type Writable } from 'svelte/store';
   import HorizontalLineSeparator from '../layout/HorizontalLineSeparator.svelte';
   import { warn } from 'src/utils/logging';
   import { getItemCardContentTemplate } from './item-info-card';
   import { ItemSummaryRuntime } from 'src/runtime/ItemSummaryRuntime';
   import ItemSummaryCommandButtonList from '../item-summary/ItemSummaryCommandButtonList.svelte';
   import { CONSTANTS } from 'src/constants';
-  import { SettingsProvider } from 'src/settings/settings';
+  import type { CurrentSettings } from 'src/settings/settings';
 
+  let context = getContext<Readable<{ settings: CurrentSettings }>>(
+    CONSTANTS.SVELTE_CONTEXT.CONTEXT,
+  );
   // Fix Key
   let frozen: boolean = false;
-  $: fixKey = SettingsProvider.settings.itemCardsFixKey.get()?.toUpperCase();
+  $: fixKey = $context.settings.itemCardsFixKey?.toUpperCase();
   $: concealDetails = FoundryAdapter.concealDetails(item);
 
   function detectFixStart(ev: KeyboardEvent) {
@@ -47,11 +50,7 @@
   function onMouseMove(args: { clientX: number; clientY: number }) {
     lastMouseEvent = args;
 
-    if (
-      !SettingsProvider.settings.itemCardsAreFloating.get() ||
-      !open ||
-      frozen
-    ) {
+    if (!$context.settings.itemCardsAreFloating || !open || frozen) {
       return;
     }
 
@@ -108,7 +107,7 @@
   let debug = false;
   let timer: any;
   let infoContentTemplate: ItemCardContentComponent | null;
-  $: delayMs = SettingsProvider.settings.itemCardsDelay.get() ?? 0;
+  $: delayMs = $context.settings.itemCardsDelay ?? 0;
 
   async function showCard() {
     if (!$card.item) {
@@ -128,7 +127,7 @@
       infoContentTemplate = $card.itemCardContentTemplate;
       item = $card.item;
 
-      if (SettingsProvider.settings.itemCardsAreFloating.get()) {
+      if ($context.settings.itemCardsAreFloating) {
         rootFontSizePx = getRootFontSizePx();
 
         const boundingClientRect = sheet?.getBoundingClientRect();
@@ -229,13 +228,9 @@
   bind:this={itemCardNode}
   class="item-info-container"
   class:open={debug || open}
-  class:floating={SettingsProvider.settings.itemCardsAreFloating.get()}
-  style:top={SettingsProvider.settings.itemCardsAreFloating.get()
-    ? floatingTop
-    : undefined}
-  style:left={SettingsProvider.settings.itemCardsAreFloating.get()
-    ? floatingLeft
-    : undefined}
+  class:floating={$context.settings.itemCardsAreFloating}
+  style:top={$context.settings.itemCardsAreFloating ? floatingTop : undefined}
+  style:left={$context.settings.itemCardsAreFloating ? floatingLeft : undefined}
   style:--card-width="{cardWidthRem}rem"
   style:--card-height="{cardHeightRem}rem"
 >

--- a/src/components/item-list/ItemAddUses.svelte
+++ b/src/components/item-list/ItemAddUses.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { CONSTANTS } from 'src/constants';
-  import { settingStore } from 'src/settings/settings';
 
   export let item: any;
 

--- a/src/components/item-list/ItemAddUses.svelte
+++ b/src/components/item-list/ItemAddUses.svelte
@@ -18,15 +18,16 @@
   }
 </script>
 
-<button
-  type="button"
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y-missing-attribute -->
+<a
   class="item-add-uses item-list-button"
-  on:click={() => onAddUses()}
-  disabled={!item.isOwner}
-  tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
+  class:disabled={!item.isOwner}
+  on:click={() => item.isOwner && onAddUses()}
 >
   Add
-</button>
+</a>
 
 <style lang="scss">
   .item-add-uses {

--- a/src/components/item-list/ItemCreateButton.svelte
+++ b/src/components/item-list/ItemCreateButton.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import { type Actor5e } from 'src/types/types';
 
   export let dataset: any;
@@ -15,14 +14,15 @@
   }
 </script>
 
-<button
-  type="button"
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y-missing-attribute -->
+<a
   class="item-list-footer-button"
   on:click={create}
   title={localize('DND5E.FeatureAdd')}
   data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.ITEM_CREATE_COMMAND}
-  tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
 >
   <i class="fas fa-plus-circle" />
   {localize('DND5E.Add')}
-</button>
+</a>

--- a/src/components/item-list/ItemFilterLayoutToggle.svelte
+++ b/src/components/item-list/ItemFilterLayoutToggle.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import type { ItemLayoutMode } from 'src/types/types';
   import { createEventDispatcher } from 'svelte';
 
@@ -26,15 +25,16 @@
 
 <svelte:element this={element} class="toggle-layout">
   {#if mode === 'grid' || mode === 'list'}
-    <button
-      type="button"
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
       class="icon-button"
       title={toggleButtonPresentation?.title}
       on:click={() => dispatcher('toggle')}
-      tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
     >
       <i class={toggleButtonPresentation?.iconClass} />
-    </button>
+    </a>
   {:else}
     <span title={localize('TIDY5E.LayoutNotSupported')}>😞</span>
   {/if}

--- a/src/components/item-list/ItemName.svelte
+++ b/src/components/item-list/ItemName.svelte
@@ -2,8 +2,7 @@
   import type { Item5e } from 'src/types/item.types';
   import { createEventDispatcher } from 'svelte';
   import ActiveEffectsMarker from './ActiveEffectsMarker.svelte';
-  import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-    import { settingStore } from 'src/settings/settings';
+  import { SettingsProvider } from 'src/settings/settings';
 
   export let cssClass: string = '';
   export let hasChildren = true;
@@ -26,7 +25,7 @@
 >
   <slot />
 </span>
-{#if useActiveEffectsMarker && $settingStore.showActiveEffectsMarker && hasActiveEffects}
+{#if useActiveEffectsMarker && SettingsProvider.settings.showActiveEffectsMarker.get() && hasActiveEffects}
   <ActiveEffectsMarker />
 {/if}
 

--- a/src/components/item-list/ItemName.svelte
+++ b/src/components/item-list/ItemName.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import { settingStore } from 'src/settings/settings';
   import type { Item5e } from 'src/types/item.types';
   import { createEventDispatcher } from 'svelte';
   import ActiveEffectsMarker from './ActiveEffectsMarker.svelte';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
+    import { settingStore } from 'src/settings/settings';
 
   export let cssClass: string = '';
   export let hasChildren = true;
@@ -15,10 +15,9 @@
   const dispatcher = createEventDispatcher<{ toggle: Event }>();
 </script>
 
-<!-- TODO: Make this a button -->
+<!-- svelte-ignore a11y-interactive-supports-focus -->
 <span
   role="button"
-  tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
   on:click={(ev) => dispatcher('toggle', ev)}
   class="item-name truncate {cssClass}"
   class:has-children={hasChildren}

--- a/src/components/item-list/ItemName.svelte
+++ b/src/components/item-list/ItemName.svelte
@@ -1,13 +1,19 @@
 <script lang="ts">
   import type { Item5e } from 'src/types/item.types';
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher, getContext } from 'svelte';
   import ActiveEffectsMarker from './ActiveEffectsMarker.svelte';
-  import { SettingsProvider } from 'src/settings/settings';
+  import type { Readable } from 'svelte/store';
+  import type { CurrentSettings } from 'src/settings/settings';
+  import { CONSTANTS } from 'src/constants';
 
   export let cssClass: string = '';
   export let hasChildren = true;
   export let item: Item5e;
   export let useActiveEffectsMarker: boolean = true;
+
+  let context = getContext<Readable<{ settings: CurrentSettings }>>(
+    CONSTANTS.SVELTE_CONTEXT.CONTEXT,
+  );
 
   $: hasActiveEffects = !!item.effects?.size;
 
@@ -25,7 +31,7 @@
 >
   <slot />
 </span>
-{#if useActiveEffectsMarker && SettingsProvider.settings.showActiveEffectsMarker.get() && hasActiveEffects}
+{#if useActiveEffectsMarker && $context.settings.showActiveEffectsMarker && hasActiveEffects}
   <ActiveEffectsMarker />
 {/if}
 

--- a/src/components/item-list/ItemTableFooter.svelte
+++ b/src/components/item-list/ItemTableFooter.svelte
@@ -68,18 +68,19 @@
     {/if}
   {/if}
   {#each customCommands as command}
-    <button
-      type="button"
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
       class="item-list-footer-button"
       on:click={(ev) => command.execute?.({ section, event: ev, actor: actor })}
       title={localize(command.tooltip ?? '')}
-      tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
     >
       {#if (command.iconClass ?? '') !== ''}
         <i class={command.iconClass} />
       {/if}
       {localize(command.label ?? '')}
-    </button>
+    </a>
   {/each}
 </footer>
 

--- a/src/components/item-list/ItemTableFooter.svelte
+++ b/src/components/item-list/ItemTableFooter.svelte
@@ -8,7 +8,6 @@
   import ItemCreateButton from '../item-list/ItemCreateButton.svelte';
   import { ActorItemRuntime } from 'src/runtime/ActorItemRuntime';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
 
   export let section: TSection;
   export let actor: Actor5e;

--- a/src/components/item-list/ItemUseButton.svelte
+++ b/src/components/item-list/ItemUseButton.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
 
@@ -34,8 +33,10 @@
     <i class="fas fa-question" />
   </div>
   {#if !disabled}
-    <button
-      type="button"
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
       class="item-use-button icon-button"
       on:click={(event) => FoundryAdapter.actorTryUseItem(item, {}, { event })}
       on:contextmenu={(event) =>
@@ -43,10 +44,9 @@
       on:focusin={() => (buttonIsFocused = true)}
       on:focusout={() => (buttonIsFocused = false)}
       data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.ITEM_USE_COMMAND}
-      tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
     >
       <i class="fa fa-dice-d20" class:invisible={!showDiceIconOnHover} />
-    </button>
+    </a>
   {/if}
   <slot name="after-roll-button" />
 </div>

--- a/src/components/item-list/controls/ItemControl.svelte
+++ b/src/components/item-list/controls/ItemControl.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import Dnd5eIcon from 'src/components/icon/Dnd5eIcon.svelte';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
-  
+
   export let iconCssClass: string | undefined = undefined;
   export let iconSrc: string | undefined = undefined;
   export let title: string | undefined = undefined;
@@ -10,7 +9,7 @@
   export let onclick:
     | ((
         ev: MouseEvent & {
-          currentTarget: EventTarget & HTMLButtonElement;
+          currentTarget: EventTarget & HTMLElement;
         },
       ) => any)
     | undefined = undefined;
@@ -18,13 +17,14 @@
   const localize = FoundryAdapter.localize;
 </script>
 
-<button
-  type="button"
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y-missing-attribute -->
+<a
   class="item-list-button"
   class:inactive={!active}
   on:click={onclick}
   title={title !== undefined ? localize(title) : ''}
-  tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
 >
   {#if iconCssClass}
     <i class={iconCssClass} />
@@ -32,7 +32,7 @@
   {#if iconSrc}
     <Dnd5eIcon src={iconSrc} />
   {/if}
-</button>
+</a>
 
 <style lang="scss">
   .item-list-button {

--- a/src/components/item-list/controls/RechargeControl.svelte
+++ b/src/components/item-list/controls/RechargeControl.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import type { Item5e } from 'src/types/item.types';
   import type { ActorSheetContextV1 } from 'src/types/types';
   import { getContext } from 'svelte';
@@ -16,25 +15,24 @@
       ? localize('TIDY5E.RollRecharge.Hint', {
           rechargeLabel: item.labels?.recharge ?? '',
         })
-      : item.labels?.recharge ?? '';
+      : (item.labels?.recharge ?? '');
 
   let context = getContext<Readable<ActorSheetContextV1>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
   );
 </script>
 
-<button
-  type="button"
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y-missing-attribute -->
+<a
   class="item-list-button"
   title={rechargeLabel}
   on:click={(ev) =>
     ev.shiftKey
-      ? item.update({ 'system.recharge.charged': true })
-      : item.rollRecharge()}
-  disabled={!$context.owner}
-  tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
+      ? $context.owner && item.update({ 'system.recharge.charged': true })
+      : $context.owner && item.rollRecharge()}
 >
   <i class="fas fa-dice-six" />
-  {item.system.recharge
-    ?.value}{#if item.system.recharge?.value !== 6}+{/if}</button
->
+  {item.system.recharge?.value}{#if item.system.recharge?.value !== 6}+{/if}
+</a>

--- a/src/components/item-list/v1/ItemTableRow.svelte
+++ b/src/components/item-list/v1/ItemTableRow.svelte
@@ -19,7 +19,7 @@
   import { CONSTANTS } from 'src/constants';
   import { TidyHooks } from 'src/foundry/TidyHooks';
   import ExpandableContainer from 'src/components/expandable/ExpandableContainer.svelte';
-  import { SettingsProvider } from 'src/settings/settings';
+  import type { CurrentSettings } from 'src/settings/settings';
 
   export let item: Item5e | null = null;
   export let effect: ActiveEffect5e | ActiveEffectContext | null = null;
@@ -41,7 +41,7 @@
   const expandedItemData = getContext<ExpandedItemData>(
     CONSTANTS.SVELTE_CONTEXT.EXPANDED_ITEM_DATA,
   );
-  const context = getContext<Writable<unknown>>(
+  const context = getContext<Writable<{ settings: CurrentSettings }>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
   );
   const expandedItems = getContext<ExpandedItemIdToLocationsMap>(
@@ -74,10 +74,7 @@
   async function onMouseEnter(event: Event) {
     TidyHooks.tidy5eSheetsItemHoverOn(event, item);
 
-    if (
-      !item?.getChatData ||
-      !SettingsProvider.settings.itemCardsForAllItems.get()
-    ) {
+    if (!item?.getChatData || !$context.settings.itemCardsForAllItems) {
       return;
     }
 

--- a/src/components/item-list/v1/ItemTableRow.svelte
+++ b/src/components/item-list/v1/ItemTableRow.svelte
@@ -16,10 +16,10 @@
     ItemCardContentComponent,
     ItemChatData,
   } from 'src/types/item.types';
-  import { settingStore } from 'src/settings/settings';
   import { CONSTANTS } from 'src/constants';
   import { TidyHooks } from 'src/foundry/TidyHooks';
   import ExpandableContainer from 'src/components/expandable/ExpandableContainer.svelte';
+  import { SettingsProvider } from 'src/settings/settings';
 
   export let item: Item5e | null = null;
   export let effect: ActiveEffect5e | ActiveEffectContext | null = null;
@@ -74,7 +74,10 @@
   async function onMouseEnter(event: Event) {
     TidyHooks.tidy5eSheetsItemHoverOn(event, item);
 
-    if (!item?.getChatData || !$settingStore.itemCardsForAllItems) {
+    if (
+      !item?.getChatData ||
+      !SettingsProvider.settings.itemCardsForAllItems.get()
+    ) {
       return;
     }
 

--- a/src/components/item-list/v2/ItemTableRowV2.svelte
+++ b/src/components/item-list/v2/ItemTableRowV2.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import TidyTableRow from 'src/components/table/TidyTableRow.svelte';
   import { CONSTANTS } from 'src/constants';
-  import { settingStore } from 'src/settings/settings';
   import type {
     Item5e,
     ItemCardContentComponent,
@@ -14,12 +13,13 @@
     ItemCardStore,
   } from 'src/types/types';
   import { warn } from 'src/utils/logging';
-  import { getContext, createEventDispatcher, onMount } from 'svelte';
+  import { getContext, onMount } from 'svelte';
   import type { Writable } from 'svelte/store';
   import ItemSummary from '../ItemSummary.svelte';
   import ExpandableContainer from 'src/components/expandable/ExpandableContainer.svelte';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
   import { TidyHooks } from 'src/foundry/TidyHooks';
+    import { SettingsProvider } from 'src/settings/settings';
 
   export let item: Item5e | null = null;
   export let contextMenu: { type: string; uuid: string } | null = null;
@@ -70,7 +70,7 @@
   async function onMouseEnter(event: Event) {
     TidyHooks.tidy5eSheetsItemHoverOn(event, item);
 
-    if (!item?.getChatData || !$settingStore.itemCardsForAllItems) {
+    if (!item?.getChatData || !SettingsProvider.settings.itemCardsForAllItems.get()) {
       return;
     }
 

--- a/src/components/item-list/v2/ItemTableRowV2.svelte
+++ b/src/components/item-list/v2/ItemTableRowV2.svelte
@@ -19,7 +19,7 @@
   import ExpandableContainer from 'src/components/expandable/ExpandableContainer.svelte';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
   import { TidyHooks } from 'src/foundry/TidyHooks';
-    import { SettingsProvider } from 'src/settings/settings';
+  import type { CurrentSettings } from 'src/settings/settings';
 
   export let item: Item5e | null = null;
   export let contextMenu: { type: string; uuid: string } | null = null;
@@ -38,7 +38,7 @@
   const expandedItemData = getContext<ExpandedItemData>(
     CONSTANTS.SVELTE_CONTEXT.EXPANDED_ITEM_DATA,
   );
-  const context = getContext<Writable<unknown>>(
+  const context = getContext<Writable<{ settings: CurrentSettings }>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
   );
   const expandedItems = getContext<ExpandedItemIdToLocationsMap>(
@@ -70,7 +70,7 @@
   async function onMouseEnter(event: Event) {
     TidyHooks.tidy5eSheetsItemHoverOn(event, item);
 
-    if (!item?.getChatData || !SettingsProvider.settings.itemCardsForAllItems.get()) {
+    if (!item?.getChatData || !$context.settings.itemCardsForAllItems) {
       return;
     }
 

--- a/src/components/item-summary/ItemSummaryCommandButton.svelte
+++ b/src/components/item-summary/ItemSummaryCommandButton.svelte
@@ -1,25 +1,26 @@
 <script lang="ts">
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
   import type { RegisteredItemSummaryCommand } from 'src/runtime/types';
-  import { settingStore } from 'src/settings/settings';
   import type { Item5e } from 'src/types/item.types';
 
   export let command: RegisteredItemSummaryCommand;
   export let item: Item5e;
 </script>
 
-<button
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y-missing-attribute -->
+<a
   type="button"
   class="item-summary-command"
   title={command.tooltip ?? null}
   on:click={() => command.execute?.({ item: item })}
-  tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
 >
   {#if command.iconClass}
     <i class={command.iconClass}></i>
   {/if}
   {FoundryAdapter.localize(command.label ?? '')}
-</button>
+</a>
 
 <style lang="scss">
   .item-summary-command {

--- a/src/components/spellbook/SpellPip.svelte
+++ b/src/components/spellbook/SpellPip.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { settingStore } from 'src/settings/settings';
   import { onMount } from 'svelte';
 
   export let isEmpty: boolean;
@@ -33,27 +32,32 @@
   }
 </script>
 
-<button
-  bind:this={pipEl}
-  type="button"
-  class="pip"
-  class:empty={isEmpty}
-  class:change={willChange}
-  class:animate-expended={animateExpended}
-  class:animate-restored={animateRestored}
-  on:click
-  on:mouseenter
-  on:mouseleave
-  on:focusin
-  on:focusout
-  on:transitionend={() => {
-    // Prevent unwanted additional animations after the pip effect has ended.
-    animateExpended = false;
-    animateRestored = false;
-  }}
-  {disabled}
-  tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
-/>
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y-missing-attribute -->
+<!-- svelte-ignore a11y-missing-content -->
+{#if !disabled}
+  <a
+    bind:this={pipEl}
+    class="pip"
+    class:empty={isEmpty}
+    class:change={willChange}
+    class:animate-expended={animateExpended}
+    class:animate-restored={animateRestored}
+    on:click
+    on:mouseenter
+    on:mouseleave
+    on:focusin
+    on:focusout
+    on:transitionend={() => {
+      // Prevent unwanted additional animations after the pip effect has ended.
+      animateExpended = false;
+      animateRestored = false;
+    }}
+  ></a>
+{:else}
+  <a bind:this={pipEl} class="pip" class:empty={isEmpty}></a>
+{/if}
 
 <style lang="scss">
   .pip {

--- a/src/components/spellbook/SpellSlotConfigButton.svelte
+++ b/src/components/spellbook/SpellSlotConfigButton.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import type { CharacterSheetContext, NpcSheetContext } from 'src/types/types';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
@@ -13,13 +12,14 @@
   const localize = FoundryAdapter.localize;
 </script>
 
-<button
-  type="button"
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y-missing-attribute -->
+<a
   class="spell-slot-config inline-icon-button"
   title={localize('DND5E.SpellSlotsConfig')}
   aria-label={localize('DND5E.SpellSlotsConfig')}
   on:click={() => FoundryAdapter.openSpellSlotsConfig($context.actor)}
-  tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
 >
   <i class="fas fa-pencil" />
-</button>
+</a>

--- a/src/components/spellbook/SpellbookClassFilter.svelte
+++ b/src/components/spellbook/SpellbookClassFilter.svelte
@@ -45,7 +45,7 @@
   {#each allClasses as option}
     <option
       value={option.value}
-      selected={option.value === selectedClassFilter ?? undefined}
+      selected={option.value === (selectedClassFilter ?? undefined)}
       >{localize(option.text)}</option
     >
   {/each}

--- a/src/components/spellbook/SpellbookFooter.svelte
+++ b/src/components/spellbook/SpellbookFooter.svelte
@@ -8,11 +8,11 @@
   import TabFooter from 'src/sheets/actor/TabFooter.svelte';
   import { MaxPreparedSpellsConfigFormApplication } from 'src/applications/max-prepared-spells-config/MaxPreparedSpellsConfigFormApplication';
   import { CONSTANTS } from 'src/constants';
-  import { settingStore } from 'src/settings/settings';
   import { rollRawSpellAttack } from 'src/utils/formula';
 
-  let context =
-    getContext<Readable<CharacterSheetContext | NpcSheetContext>>(CONSTANTS.SVELTE_CONTEXT.CONTEXT);
+  let context = getContext<Readable<CharacterSheetContext | NpcSheetContext>>(
+    CONSTANTS.SVELTE_CONTEXT.CONTEXT,
+  );
   export let cssClass: string | null = null;
   export let includeAttackMod: boolean = true;
   export let includePreparedSpells: boolean = true;
@@ -42,10 +42,11 @@
         <span>{FoundryAdapter.localize('TIDY5E.AttackMod')}:</span>
 
         {#if $context.spellCalculations.rangedMod !== $context.spellCalculations.meleeMod}
-          <button
-            type="button"
+          <!-- svelte-ignore a11y-click-events-have-key-events -->
+          <!-- svelte-ignore a11y-no-static-element-interactions -->
+          <!-- svelte-ignore a11y-missing-attribute -->
+          <a
             on:click={(ev) => rollRawSpellAttack(ev, $context.actor, 'rsak')}
-            tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
             data-tooltip="{FoundryAdapter.localize(
               'TIDY5E.RangedSpellAttackMod',
             )}: {$context.spellCalculations.rangedTooltip}"
@@ -61,11 +62,13 @@
             >
               {$context.spellCalculations.rangedMod}
             </span>
-          </button>
-          <button
+          </a>
+          <!-- svelte-ignore a11y-click-events-have-key-events -->
+          <!-- svelte-ignore a11y-no-static-element-interactions -->
+          <!-- svelte-ignore a11y-missing-attribute -->
+          <a
             type="button"
             on:click={(ev) => rollRawSpellAttack(ev, $context.actor, 'msak')}
-            tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
             data-tooltip="{FoundryAdapter.localize(
               'TIDY5E.MeleeSpellAttackMod',
             )}: {$context.spellCalculations.meleeTooltip}"
@@ -80,12 +83,13 @@
             >
               {$context.spellCalculations.meleeMod}
             </span>
-          </button>
+          </a>
         {:else}
-          <button
-            type="button"
+          <!-- svelte-ignore a11y-click-events-have-key-events -->
+          <!-- svelte-ignore a11y-no-static-element-interactions -->
+          <!-- svelte-ignore a11y-missing-attribute -->
+          <a
             on:click={(ev) => rollRawSpellAttack(ev, $context.actor)}
-            tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
             data-tooltip="{FoundryAdapter.localize(
               'TIDY5E.SpellAttackMod',
             )}: {$context.spellCalculations.rangedTooltip}"
@@ -99,20 +103,22 @@
             >
               {$context.spellCalculations.rangedMod}
             </span>
-          </button>
+          </a>
         {/if}
       {/if}
     </div>
   </h3>
   {#if includePreparedSpells}
-    <button
-      type="button"
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
       class="transparent-button secondary-footer-field highlight-on-hover"
       on:click={() =>
+        $context.editable &&
+        !$context.lockSensitiveFields &&
         new MaxPreparedSpellsConfigFormApplication($context.actor).render(true)}
       title={localize('TIDY5E.MaxPreparedSpellsConfig.ButtonTooltip')}
-      disabled={!$context.editable || $context.lockSensitiveFields}
-      tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
     >
       <p>{localize('TIDY5E.PreparedSpells')}</p>
       <span class="spells-prepared">{$context.preparedSpells ?? 0}</span>
@@ -120,7 +126,7 @@
       <span class="spells-max-prepared"
         >{$context.maxPreparedSpellsTotal ?? 0}</span
       >
-    </button>
+    </a>
   {/if}
   <div class="spellcasting-attribute secondary-footer-field">
     <p>{localize('DND5E.SpellAbility')}</p>

--- a/src/components/spellbook/SpellbookGrid.svelte
+++ b/src/components/spellbook/SpellbookGrid.svelte
@@ -14,7 +14,6 @@
   import GridPaneFavoriteIcon from '../item-grid/GridPaneFavoriteIcon.svelte';
   import { getContext } from 'svelte';
   import type { Readable, Writable } from 'svelte/store';
-  import { settingStore } from 'src/settings/settings';
   import { ActorItemRuntime } from 'src/runtime/ActorItemRuntime';
   import { declareLocation } from 'src/types/location-awareness.types';
   import SpellSlotManagement from './SpellSlotManagement.svelte';
@@ -100,8 +99,8 @@
         {@const ctx = $context.itemContext[spell.id]}
         {@const spellImgUrl = FoundryAdapter.getSpellImageUrl($context, spell)}
         {@const hidden = !!$itemIdsToShow && !$itemIdsToShow.has(spell.id)}
-        <button
-          type="button"
+        <!-- svelte-ignore a11y-missing-attribute -->
+        <a
           class="spell {FoundryAdapter.getSpellRowClasses(
             spell,
           )} transparent-button"
@@ -119,10 +118,8 @@
           on:mouseleave={(ev) => onMouseLeave(ev, spell)}
           on:dragstart={(ev) => handleDragStart(ev, spell)}
           draggable={true}
-          disabled={!$context.editable}
           data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.ITEM_USE_COMMAND}
           data-item-id={spell.id}
-          tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
           data-tidy-grid-item
         >
           {#if 'favoriteId' in ctx && !!ctx.favoriteId}
@@ -139,26 +136,29 @@
               <ConcentrationOverlayIcon --tidy-icon-font-size="1.25rem" {ctx} />
             </div>
           </div>
-        </button>
+        </a>
       {/each}
       {#if $context.unlocked}
         <div class="spells-footer">
           {#if section.canCreate}
-            <button
-              type="button"
+            <!-- svelte-ignore a11y-click-events-have-key-events -->
+            <!-- svelte-ignore a11y-no-static-element-interactions -->
+            <!-- svelte-ignore a11y-missing-attribute -->
+            <a
               class="footer-command icon-button"
               title={localize('DND5E.SpellCreate')}
               on:click|stopPropagation|preventDefault={() =>
                 FoundryAdapter.createItem(section.dataset, $context.actor)}
               data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.ITEM_CREATE_COMMAND}
-              tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
             >
               <i class="fas fa-plus-circle" />
-            </button>
+            </a>
           {/if}
           {#each customCommands as command}
-            <button
-              type="button"
+            <!-- svelte-ignore a11y-click-events-have-key-events -->
+            <!-- svelte-ignore a11y-no-static-element-interactions -->
+            <!-- svelte-ignore a11y-missing-attribute -->
+            <a
               class="footer-command icon-button"
               on:click={(ev) =>
                 command.execute?.({
@@ -167,13 +167,12 @@
                   actor: $context.actor,
                 })}
               title={localize(command.tooltip ?? '')}
-              tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
             >
               {#if (command.iconClass ?? '') !== ''}
                 <i class={command.iconClass} />
               {/if}
               {localize(command.label ?? '')}
-            </button>
+            </a>
           {/each}
         </div>
       {/if}

--- a/src/components/spellbook/SpellbookList.svelte
+++ b/src/components/spellbook/SpellbookList.svelte
@@ -32,7 +32,6 @@
   import type { Item5e } from 'src/types/item.types';
   import ClassicControls from 'src/sheets/shared/ClassicControls.svelte';
   import ConcentrationOverlayIcon from './ConcentrationOverlayIcon.svelte';
-  import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<CharacterSheetContext | NpcSheetContext>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -205,7 +204,7 @@
               <ItemUses item={spell} />
             </ItemTableCell>
           {/if}
-          {#if allowFavorites && SettingsProvider.settings.showIconsNextToTheItemName.get() && 'favoriteId' in ctx && !!ctx.favoriteId}
+          {#if allowFavorites && $context.settings.showIconsNextToTheItemName && 'favoriteId' in ctx && !!ctx.favoriteId}
             <InlineFavoriteIcon />
           {/if}
           <ItemTableCell baseWidth={spellComponentsBaseWidth} cssClass="no-gap">

--- a/src/components/spellbook/SpellbookList.svelte
+++ b/src/components/spellbook/SpellbookList.svelte
@@ -24,7 +24,6 @@
   import ItemFavoriteControl from '../item-list/controls/ItemFavoriteControl.svelte';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
-  import { settingStore } from 'src/settings/settings';
   import ActionFilterOverrideControl from '../item-list/controls/ActionFilterOverrideControl.svelte';
   import { SpellSchool } from 'src/features/spell-school/SpellSchool';
   import { declareLocation } from 'src/types/location-awareness.types';
@@ -33,6 +32,7 @@
   import type { Item5e } from 'src/types/item.types';
   import ClassicControls from 'src/sheets/shared/ClassicControls.svelte';
   import ConcentrationOverlayIcon from './ConcentrationOverlayIcon.svelte';
+  import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<CharacterSheetContext | NpcSheetContext>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -205,7 +205,7 @@
               <ItemUses item={spell} />
             </ItemTableCell>
           {/if}
-          {#if allowFavorites && $settingStore.showIconsNextToTheItemName && 'favoriteId' in ctx && !!ctx.favoriteId}
+          {#if allowFavorites && SettingsProvider.settings.showIconsNextToTheItemName.get() && 'favoriteId' in ctx && !!ctx.favoriteId}
             <InlineFavoriteIcon />
           {/if}
           <ItemTableCell baseWidth={spellComponentsBaseWidth} cssClass="no-gap">

--- a/src/components/tabs/Tabs.svelte
+++ b/src/components/tabs/Tabs.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import type { Tab, OnTabSelectedFn } from 'src/types/types';
   import { createEventDispatcher, getContext, onMount } from 'svelte';
   import type { Readable } from 'svelte/store';
@@ -87,8 +86,10 @@
 >
   {#if tabs.length > 1}
     {#each tabs as tab, i (tab.id)}
-      <button
-        type="button"
+      <!-- svelte-ignore a11y-interactive-supports-focus -->
+      <!-- svelte-ignore a11y-interactive-supports-focus -->
+      <!-- svelte-ignore a11y-missing-attribute -->
+      <a
         class="{CONSTANTS.TAB_OPTION_CLASS} inline-transparent-button"
         class:active={tab.id === selectedTabId}
         class:first-tab={i === 0}
@@ -98,10 +99,9 @@
         role="tab"
         on:click={() => selectTab(tab)}
         on:keydown={(ev) => onKeyDown(ev, i)}
-        tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
       >
         {localize(tab.title)}
-      </button>
+      </a>
     {/each}
   {/if}
   <slot name="tab-end" />
@@ -124,6 +124,7 @@
       border-top-left-radius: 0.1875rem;
       border-top-right-radius: 0.1875rem;
       text-shadow: none;
+      line-height: normal;
 
       &:hover {
         background: var(--t5e-tab-background);

--- a/src/components/tabs/UnderlinedTabStrip.svelte
+++ b/src/components/tabs/UnderlinedTabStrip.svelte
@@ -7,14 +7,15 @@
 
 <div class="underlined-tab-strip flex-row no-gap {$$restProps.class ?? ''}">
   {#each tabs as tab (tab)}
-    <button
-      type="button"
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
       class="underlined-tab"
       class:active={selected === tab}
       on:click={() => (selected = tab)}
-      tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
     >
       {tab}
-    </button>
+    </a>
   {/each}
 </div>

--- a/src/components/tabs/UnderlinedTabStrip.svelte
+++ b/src/components/tabs/UnderlinedTabStrip.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { settingStore } from 'src/settings/settings';
-
   export let tabs: string[];
   export let selected: string;
 </script>

--- a/src/components/toggle/TidySwitch.svelte
+++ b/src/components/toggle/TidySwitch.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { settingStore } from 'src/settings/settings';
   import { createEventDispatcher } from 'svelte';
 
   export let value: boolean = false;
@@ -13,7 +12,7 @@
 
   function handleClick(
     _: MouseEvent & {
-      currentTarget: EventTarget & HTMLButtonElement;
+      currentTarget: EventTarget & HTMLElement;
     },
   ) {
     const originalValue = value;
@@ -24,22 +23,22 @@
 
 <label
   class="tidy-switch {$$props.class ?? ''}"
-  class:disabled={disabled}
+  class:disabled
   id={switchLabelId}
   title={$$props.title ?? null}
 >
   <slot />
-  <button
-    type="button"
+  <!-- svelte-ignore a11y-interactive-supports-focus -->
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <!-- svelte-ignore a11y-missing-attribute -->
+  <a
     role="switch"
-    on:click={(ev) => handleClick(ev)}
+    on:click={(ev) => !disabled && handleClick(ev)}
     aria-checked={value}
     aria-labelledby={switchLabelId}
-    tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
-    {disabled}
   >
     {#if thumbIconClass}
       <i class="thumb-icon {thumbIconClass}"></i>
     {/if}
-  </button>
+  </a>
 </label>

--- a/src/components/toggle/_toggles.scss
+++ b/src/components/toggle/_toggles.scss
@@ -61,7 +61,7 @@
     0.3s
   );
 
-  button {
+  [role="switch"] {
     width: calc(2.625rem * var(--tidy-switch-scale-internal));
     height: calc(1.375rem * var(--tidy-switch-scale-internal));
     position: relative;
@@ -104,7 +104,7 @@
     }
 
     &[aria-checked='true'] {
-      &:not([disabled]) {
+      &:not(.disabled) {
         background-color: var(--t5e-primary-accent-color);
       }
 

--- a/src/components/utility-bar/Search.svelte
+++ b/src/components/utility-bar/Search.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import type { LocationToSearchTextMap, OnSearchFn } from 'src/types/types';
   import { getContext, onMount } from 'svelte';
 
@@ -43,14 +42,16 @@
     on:blur|preventDefault|stopPropagation={() => rememberSearch()}
   />
   {#if value?.trim() !== ''}
-    <button
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
       class="inline-icon-button search-close-button"
       on:click={() => clearSearch()}
       data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.SEARCH_CLEAR}
-      tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
     >
       <i class="fas fa-times"></i>
-    </button>
+    </a>
   {/if}
 </div>
 

--- a/src/components/utility-bar/UtilityToolbarCommand.svelte
+++ b/src/components/utility-bar/UtilityToolbarCommand.svelte
@@ -2,7 +2,6 @@
   import { isNil } from 'src/utils/data';
   import { createEventDispatcher, getContext } from 'svelte';
   import type { UtilityToolbarCommandExecuteEvent } from './types';
-  import { settingStore } from 'src/settings/settings';
   import type { Readable } from 'svelte/store';
   import { CONSTANTS } from 'src/constants';
 
@@ -20,13 +19,14 @@
   }>();
 </script>
 
-<button
-  type="button"
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y-missing-attribute -->
+<a
   class="inline-icon-button"
   class:hidden={!visible}
   on:click={(ev) => dispatcher('execute', { event: ev, context: $context })}
   {title}
-  tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
   data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.UTILITY_TOOLBAR_COMMAND}
 >
   {#if !isNil(iconClass, '')}
@@ -35,4 +35,4 @@
   {#if !isNil(text, '')}
     {text}
   {/if}
-</button>
+</a>

--- a/src/foundry/TidyHooks.ts
+++ b/src/foundry/TidyHooks.ts
@@ -474,4 +474,18 @@ export class TidyHooks {
   ) {
     Hooks.callAll('tidy5e-sheet.selectTab', app, element, newTabId);
   }
+
+  /**
+   * Tidy 5e Settings have been updated.
+   *
+   * @example
+   * ```js
+   * Hooks.on('tidy5e-sheet.settingsUpdated', () => {
+   *   // Your code here
+   * });
+   * ```
+   */
+  static tidy5eSheetsSettingsUpdated() {
+    Hooks.callAll('tidy5e-sheet.settingsUpdated');
+  }
 }

--- a/src/mixins/SvelteApplicationMixin.ts
+++ b/src/mixins/SvelteApplicationMixin.ts
@@ -4,7 +4,7 @@ import { SettingsProvider, settingStore } from 'src/settings/settings';
 import {
   applySheetAttributesToWindow,
   applyThemeDataAttributeToWindow,
-  blurUntabbableButtonsOnClick,
+  blurButtonsOnClick,
 } from 'src/utils/applications';
 import { debug, error } from 'src/utils/logging';
 import type { SvelteComponent } from 'svelte';
@@ -278,6 +278,12 @@ export function SvelteApplicationMixin<
 
       this.#restoreScrollPositions(this.element);
       this.#restoreInputFocus(this.element);
+
+      if (!SettingsProvider.settings.useAccessibleKeyboardSupport.get()) {
+        this.element
+          .querySelectorAll('button')
+          .forEach((b: HTMLButtonElement) => (b.tabIndex = -1));
+      }
     }
 
     /* -------------------------------------------- */
@@ -288,8 +294,9 @@ export function SvelteApplicationMixin<
       super._attachFrameListeners();
 
       try {
-        // Support Foundry's hotkeys feature by blurring tabindex -1 clicked elements
-        blurUntabbableButtonsOnClick(this.element);
+        if (!SettingsProvider.settings.useAccessibleKeyboardSupport.get()) {
+          blurButtonsOnClick(this.element);
+        }
 
         // Manage application subscriptions
         this.#subscriptionsService.unsubscribeAll();

--- a/src/mixins/SvelteApplicationMixin.ts
+++ b/src/mixins/SvelteApplicationMixin.ts
@@ -1,6 +1,6 @@
 import { StoreSubscriptionsService } from 'src/features/store/StoreSubscriptionsService';
 import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-import { SettingsProvider, settingStore } from 'src/settings/settings';
+import { SettingsProvider } from 'src/settings/settings';
 import {
   applySheetAttributesToWindow,
   applyThemeDataAttributeToWindow,
@@ -303,9 +303,14 @@ export function SvelteApplicationMixin<
         const subscriptions = this._getSubscriptions();
         this.#subscriptionsService.registerSubscriptions(
           ...subscriptions,
-          settingStore.subscribe((settings) => {
-            applyThemeDataAttributeToWindow(settings.colorScheme, this.element);
-          })
+
+          SettingsProvider.getSettingsChangedSubscription(this, () => {
+            applyThemeDataAttributeToWindow(
+              SettingsProvider.settings.colorScheme.get(),
+              this.element
+            );
+            this.render();
+          }),
         );
 
         // If a controls dropdown button is clicked, close the controls dropdown.

--- a/src/scss/compatibility/_apps-active-effects.scss
+++ b/src/scss/compatibility/_apps-active-effects.scss
@@ -8,7 +8,6 @@
   .effect-controls {
     text-align: center;
     border-left: 0.0625rem solid var(--t5e-faint-color);
-    border-right: 0.0625rem solid var(--t5e-faint-color);
     font-size: 0.75rem;
   }
   .effect-controls {

--- a/src/scss/core-classic-appv2.scss
+++ b/src/scss/core-classic-appv2.scss
@@ -464,5 +464,11 @@
     padding: 1rem;
   }
 
+  a:hover {
+    outline: none;
+    box-shadow: none;
+    text-shadow: none;
+  }
+  
   @import './partials/floating-context-menu';
 }

--- a/src/scss/core.scss
+++ b/src/scss/core.scss
@@ -409,6 +409,12 @@
     -ms-user-select: text;
     user-select: text;
   }
+
+  a:hover {
+    outline: none;
+    box-shadow: none;
+    text-shadow: none;
+  }
 }
 
 @import './partials/floating-context-menu';

--- a/src/scss/partials/_buttons.scss
+++ b/src/scss/partials/_buttons.scss
@@ -129,6 +129,7 @@
   border-radius: 0.3125rem;
   font-size: 0.75rem;
   width: auto;
+  padding: 0.0625rem 0.375rem;
 
   &:hover {
     background: var(--t5e-light-color);

--- a/src/scss/partials/_items.scss
+++ b/src/scss/partials/_items.scss
@@ -272,6 +272,9 @@ input[type='checkbox'] {
       .hidden-config-button {
         visibility: hidden;
         font-size: 0.75rem;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
       }
 
       &:hover .hidden-config-button {

--- a/src/scss/partials/_items.scss
+++ b/src/scss/partials/_items.scss
@@ -601,7 +601,7 @@ input[type='checkbox'] {
   }
 }
 
-.tab.items-list-container {
+:is(.tab, .tidy-tab).items-list-container {
   .items-list {
     flex: 1;
     padding: 0 0.5625rem 0.5rem 0;
@@ -664,6 +664,7 @@ input[type='checkbox'] {
 
     .active-effect-controls {
       flex: 0 0 3.8125rem;
+      display: flex;
       text-align: center;
       justify-content: center;
     }
@@ -674,7 +675,7 @@ input[type='checkbox'] {
 
     .active-effect-control {
       flex: 0 0 1.25rem;
-      display: flex;
+      display: inline-flex;
       justify-content: center;
       align-items: center;
       color: var(--t5e-tertiary-color);

--- a/src/scss/partials/_layout.scss
+++ b/src/scss/partials/_layout.scss
@@ -4,6 +4,12 @@
   overflow-y: scroll;
 }
 
+.inline-flex-row {
+  display: inline-flex;
+  flex-direction: row;
+  gap: 0.25rem;
+}
+
 .flex-row {
   display: flex;
   flex-direction: row;

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -21,7 +21,7 @@ import { TabManager } from 'src/runtime/tab/TabManager';
 import { BulkMigrationsApplication } from 'src/migrations/BulkMigrationsApplication';
 import { AboutApplication } from 'src/applications/settings/about/AboutApplication';
 import { ApplyTidySheetPreferencesApplication } from 'src/applications/sheet-preferences/ApplyTidySheetPreferencesApplication';
-import { TidyHooks } from 'src/api';
+import { TidyHooks } from 'src/foundry/TidyHooks';
 
 export type Tidy5eSettings = {
   [settingKey: string]: Tidy5eSetting;

--- a/src/sheets/Tidy5eCharacterSheet.ts
+++ b/src/sheets/Tidy5eCharacterSheet.ts
@@ -33,7 +33,7 @@ import {
   applySheetAttributesToWindow,
   applyThemeDataAttributeToWindow,
   applyTitleToWindow,
-  blurUntabbableButtonsOnClick,
+  blurButtonsOnClick,
   maintainCustomContentInputFocus,
 } from 'src/utils/applications';
 import type { SvelteComponent } from 'svelte';
@@ -1409,7 +1409,16 @@ export class Tidy5eCharacterSheet
         super.activateListeners,
         this
       );
-      blurUntabbableButtonsOnClick(this.element.get(0));
+      if (!SettingsProvider.settings.useAccessibleKeyboardSupport.get()) {
+        blurButtonsOnClick(this.element.get(0));
+      }
+      if (!SettingsProvider.settings.useAccessibleKeyboardSupport.get()) {
+        this.element
+          .get(0)
+          .querySelectorAll('button')
+          .forEach((b: HTMLButtonElement) => (b.tabIndex = -1));
+      }
+
       return;
     }
 
@@ -1427,6 +1436,12 @@ export class Tidy5eCharacterSheet
         super.activateListeners,
         this
       );
+      if (!SettingsProvider.settings.useAccessibleKeyboardSupport.get()) {
+        this.element
+          .get(0)
+          .querySelectorAll('button')
+          .forEach((b: HTMLButtonElement) => (b.tabIndex = -1));
+      }
     });
   }
 

--- a/src/sheets/Tidy5eCharacterSheet.ts
+++ b/src/sheets/Tidy5eCharacterSheet.ts
@@ -1,10 +1,10 @@
 import { FoundryAdapter } from '../foundry/foundry-adapter';
 import CharacterSheet from './character/CharacterSheet.svelte';
 import { debug, error } from 'src/utils/logging';
-import { SettingsProvider, settingStore } from 'src/settings/settings';
+import { SettingsProvider } from 'src/settings/settings';
 import { initTidy5eContextMenu } from 'src/context-menu/tidy5e-context-menu';
 import { CONSTANTS } from 'src/constants';
-import { writable } from 'svelte/store';
+import { readable, writable } from 'svelte/store';
 import {
   type ItemCardStore,
   type CharacterSheetContext,
@@ -149,15 +149,18 @@ export class Tidy5eCharacterSheet
 
     // Subscriptions
     let first = true;
+
     this.subscriptionsService.unsubscribeAll();
     this.subscriptionsService.registerSubscriptions(
       this.itemFilterService.filterData$.subscribe(() => {
         if (first) return;
         this.render();
       }),
-      settingStore.subscribe((s) => {
-        if (first) return;
-        applyThemeDataAttributeToWindow(s.colorScheme, this.element.get(0));
+      SettingsProvider.getSettingsChangedSubscription(this, () => {
+        applyThemeDataAttributeToWindow(
+          SettingsProvider.settings.colorScheme.get(),
+          this.element.get(0)
+        );
         this.render();
       }),
       this.messageBus.subscribe((m) => {

--- a/src/sheets/Tidy5eCharacterSheet.ts
+++ b/src/sheets/Tidy5eCharacterSheet.ts
@@ -1,7 +1,7 @@
 import { FoundryAdapter } from '../foundry/foundry-adapter';
 import CharacterSheet from './character/CharacterSheet.svelte';
 import { debug, error } from 'src/utils/logging';
-import { SettingsProvider } from 'src/settings/settings';
+import { getCurrentSettings, SettingsProvider } from 'src/settings/settings';
 import { initTidy5eContextMenu } from 'src/context-menu/tidy5e-context-menu';
 import { CONSTANTS } from 'src/constants';
 import { readable, writable } from 'svelte/store';
@@ -855,6 +855,7 @@ export class Tidy5eCharacterSheet
       ),
       originalContext: defaultDocumentContext,
       owner: this.actor.isOwner,
+      settings: getCurrentSettings(),
       showContainerPanel:
         TidyFlags.showContainerPanel.get(this.actor) === true &&
         Array.from(defaultDocumentContext.items).some(

--- a/src/sheets/Tidy5eContainerSheet.ts
+++ b/src/sheets/Tidy5eContainerSheet.ts
@@ -27,7 +27,7 @@ import {
   applyTitleToWindow,
   maintainCustomContentInputFocus,
 } from 'src/utils/applications';
-import { SettingsProvider } from 'src/settings/settings';
+import { getCurrentSettings, SettingsProvider } from 'src/settings/settings';
 import { ItemSheetRuntime } from 'src/runtime/item/ItemSheetRuntime';
 import { TabManager } from 'src/runtime/tab/TabManager';
 import { isNil } from 'src/utils/data';
@@ -293,6 +293,7 @@ export class Tidy5eKgarContainerSheet
       itemOverrides: new Set<string>(this._getItemOverrides()),
       lockItemQuantity: FoundryAdapter.shouldLockItemQuantity(),
       originalContext: defaultDocumentContext,
+      settings: getCurrentSettings(),
       tabs: tabs,
       utilities: utilities,
       viewableWarnings:

--- a/src/sheets/Tidy5eContainerSheet.ts
+++ b/src/sheets/Tidy5eContainerSheet.ts
@@ -27,7 +27,7 @@ import {
   applyTitleToWindow,
   maintainCustomContentInputFocus,
 } from 'src/utils/applications';
-import { SettingsProvider, settingStore } from 'src/settings/settings';
+import { SettingsProvider } from 'src/settings/settings';
 import { ItemSheetRuntime } from 'src/runtime/item/ItemSheetRuntime';
 import { TabManager } from 'src/runtime/tab/TabManager';
 import { isNil } from 'src/utils/data';
@@ -105,9 +105,11 @@ export class Tidy5eKgarContainerSheet
         if (first) return;
         this.render();
       }),
-      settingStore.subscribe((s) => {
-        if (first) return;
-        applyThemeDataAttributeToWindow(s.colorScheme, this.element.get(0));
+      SettingsProvider.getSettingsChangedSubscription(this, () => {
+        applyThemeDataAttributeToWindow(
+          SettingsProvider.settings.colorScheme.get(),
+          this.element.get(0)
+        );
         this.render();
       }),
       this.messageBus.subscribe((m) => {

--- a/src/sheets/Tidy5eGroupSheetClassic.ts
+++ b/src/sheets/Tidy5eGroupSheetClassic.ts
@@ -27,7 +27,7 @@ import type {
   GroupSkill,
 } from 'src/types/group.types';
 import { Inventory } from 'src/features/sections/Inventory';
-import { SettingsProvider, settingStore } from 'src/settings/settings';
+import { SettingsProvider } from 'src/settings/settings';
 import { ActorPortraitRuntime } from 'src/runtime/ActorPortraitRuntime';
 import { getPercentage } from 'src/utils/numbers';
 import type { Item5e } from 'src/types/item.types';
@@ -766,10 +766,6 @@ export class Tidy5eGroupSheetClassic extends Tidy5eActorSheetBaseMixin(
     let first = true;
     const subscriptions = [
       this.#itemFilterService.filterData$.subscribe(() => {
-        if (first) return;
-        this.render();
-      }),
-      settingStore.subscribe((s) => {
         if (first) return;
         this.render();
       }),

--- a/src/sheets/Tidy5eGroupSheetClassic.ts
+++ b/src/sheets/Tidy5eGroupSheetClassic.ts
@@ -27,7 +27,7 @@ import type {
   GroupSkill,
 } from 'src/types/group.types';
 import { Inventory } from 'src/features/sections/Inventory';
-import { SettingsProvider } from 'src/settings/settings';
+import { getCurrentSettings, SettingsProvider } from 'src/settings/settings';
 import { ActorPortraitRuntime } from 'src/runtime/ActorPortraitRuntime';
 import { getPercentage } from 'src/utils/numbers';
 import type { Item5e } from 'src/types/item.types';
@@ -414,6 +414,7 @@ export class Tidy5eGroupSheetClassic extends Tidy5eActorSheetBaseMixin(
       memberSections: memberSections,
       movement: movement,
       owner: this.actor.isOwner,
+      settings: getCurrentSettings(),
       showContainerPanel:
         TidyFlags.showContainerPanel.get(this.actor) === true &&
         Array.from(uncontainedItems).some(

--- a/src/sheets/Tidy5eItemSheet.ts
+++ b/src/sheets/Tidy5eItemSheet.ts
@@ -20,7 +20,7 @@ import { isNil } from 'src/utils/data';
 import { ItemSheetRuntime } from 'src/runtime/item/ItemSheetRuntime';
 import { TabManager } from 'src/runtime/tab/TabManager';
 import { CustomContentRenderer } from './CustomContentRenderer';
-import { SettingsProvider } from 'src/settings/settings';
+import { getCurrentSettings, SettingsProvider } from 'src/settings/settings';
 import { SheetPreferencesService } from 'src/features/user-preferences/SheetPreferencesService';
 import { AsyncMutex } from 'src/utils/mutex';
 import { TidyHooks } from 'src/foundry/TidyHooks';
@@ -166,6 +166,7 @@ export class Tidy5eKgarItemSheet
       itemDescriptions,
       lockItemQuantity: FoundryAdapter.shouldLockItemQuantity(),
       originalContext: defaultDocumentContext,
+      settings: getCurrentSettings(),
       tabs: tabs,
       toggleAdvancementLock: this.toggleAdvancementLock.bind(this),
       viewableWarnings:

--- a/src/sheets/Tidy5eItemSheet.ts
+++ b/src/sheets/Tidy5eItemSheet.ts
@@ -20,7 +20,7 @@ import { isNil } from 'src/utils/data';
 import { ItemSheetRuntime } from 'src/runtime/item/ItemSheetRuntime';
 import { TabManager } from 'src/runtime/tab/TabManager';
 import { CustomContentRenderer } from './CustomContentRenderer';
-import { SettingsProvider, settingStore } from 'src/settings/settings';
+import { SettingsProvider } from 'src/settings/settings';
 import { SheetPreferencesService } from 'src/features/user-preferences/SheetPreferencesService';
 import { AsyncMutex } from 'src/utils/mutex';
 import { TidyHooks } from 'src/foundry/TidyHooks';
@@ -66,9 +66,11 @@ export class Tidy5eKgarItemSheet
     let first = true;
     this.subscriptionsService.unsubscribeAll();
     this.subscriptionsService.registerSubscriptions(
-      settingStore.subscribe((s) => {
-        if (first) return;
-        applyThemeDataAttributeToWindow(s.colorScheme, this.element.get(0));
+      SettingsProvider.getSettingsChangedSubscription(this, () => {
+        applyThemeDataAttributeToWindow(
+          SettingsProvider.settings.colorScheme.get(),
+          this.element.get(0)
+        );
         this.render();
       })
     );

--- a/src/sheets/Tidy5eKgarVehicleSheet.ts
+++ b/src/sheets/Tidy5eKgarVehicleSheet.ts
@@ -1,6 +1,6 @@
 import { CONSTANTS } from 'src/constants';
 import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-import { SettingsProvider, settingStore } from 'src/settings/settings';
+import { SettingsProvider } from 'src/settings/settings';
 import type {
   ItemCardStore,
   SheetExpandedItemsCacheable,
@@ -130,9 +130,11 @@ export class Tidy5eVehicleSheet
         if (first) return;
         this.render();
       }),
-      settingStore.subscribe((s) => {
-        if (first) return;
-        applyThemeDataAttributeToWindow(s.colorScheme, this.element.get(0));
+      SettingsProvider.getSettingsChangedSubscription(this, () => {
+        applyThemeDataAttributeToWindow(
+          SettingsProvider.settings.colorScheme.get(),
+          this.element.get(0)
+        );
         this.render();
       }),
       this.messageBus.subscribe((m) => {

--- a/src/sheets/Tidy5eKgarVehicleSheet.ts
+++ b/src/sheets/Tidy5eKgarVehicleSheet.ts
@@ -27,7 +27,7 @@ import {
   applySheetAttributesToWindow,
   applyThemeDataAttributeToWindow,
   applyTitleToWindow,
-  blurUntabbableButtonsOnClick,
+  blurButtonsOnClick,
   maintainCustomContentInputFocus,
 } from 'src/utils/applications';
 import type { SvelteComponent } from 'svelte';
@@ -696,7 +696,16 @@ export class Tidy5eVehicleSheet
         super.activateListeners,
         this
       );
-      blurUntabbableButtonsOnClick(this.element.get(0));
+      if (!SettingsProvider.settings.useAccessibleKeyboardSupport.get()) {
+        blurButtonsOnClick(this.element.get(0));
+      }
+      if (!SettingsProvider.settings.useAccessibleKeyboardSupport.get()) {
+        this.element
+          .get(0)
+          .querySelectorAll('button')
+          .forEach((b: HTMLButtonElement) => (b.tabIndex = -1));
+      }
+
       return;
     }
 
@@ -714,6 +723,12 @@ export class Tidy5eVehicleSheet
         super.activateListeners,
         this
       );
+      if (!SettingsProvider.settings.useAccessibleKeyboardSupport.get()) {
+        this.element
+          .get(0)
+          .querySelectorAll('button')
+          .forEach((b: HTMLButtonElement) => (b.tabIndex = -1));
+      }
     });
   }
 

--- a/src/sheets/Tidy5eKgarVehicleSheet.ts
+++ b/src/sheets/Tidy5eKgarVehicleSheet.ts
@@ -1,6 +1,6 @@
 import { CONSTANTS } from 'src/constants';
 import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-import { SettingsProvider } from 'src/settings/settings';
+import { getCurrentSettings, SettingsProvider } from 'src/settings/settings';
 import type {
   ItemCardStore,
   SheetExpandedItemsCacheable,
@@ -320,6 +320,7 @@ export class Tidy5eVehicleSheet
         (!unlocked && SettingsProvider.settings.useTotalSheetLock.get()) ||
         !defaultDocumentContext.editable,
       owner: this.actor.isOwner,
+      settings: getCurrentSettings(),
       showLimitedSheet: FoundryAdapter.showLimitedSheet(this.actor),
       tabs: [],
       unlocked: unlocked,

--- a/src/sheets/Tidy5eNpcSheet.ts
+++ b/src/sheets/Tidy5eNpcSheet.ts
@@ -27,7 +27,7 @@ import {
   maintainCustomContentInputFocus,
 } from 'src/utils/applications';
 import { debug, error } from 'src/utils/logging';
-import { SettingsProvider, settingStore } from 'src/settings/settings';
+import { SettingsProvider } from 'src/settings/settings';
 import { initTidy5eContextMenu } from 'src/context-menu/tidy5e-context-menu';
 import { getPercentage } from 'src/utils/numbers';
 import type { SvelteComponent } from 'svelte';
@@ -143,9 +143,11 @@ export class Tidy5eNpcSheet
         if (first) return;
         this.render();
       }),
-      settingStore.subscribe((s) => {
-        if (first) return;
-        applyThemeDataAttributeToWindow(s.colorScheme, this.element.get(0));
+      SettingsProvider.getSettingsChangedSubscription(this, () => {
+        applyThemeDataAttributeToWindow(
+          SettingsProvider.settings.colorScheme.get(),
+          this.element.get(0)
+        );
         this.render();
       }),
       this.messageBus.subscribe((m) => {

--- a/src/sheets/Tidy5eNpcSheet.ts
+++ b/src/sheets/Tidy5eNpcSheet.ts
@@ -23,7 +23,7 @@ import {
   applySheetAttributesToWindow,
   applyThemeDataAttributeToWindow,
   applyTitleToWindow,
-  blurUntabbableButtonsOnClick,
+  blurButtonsOnClick,
   maintainCustomContentInputFocus,
 } from 'src/utils/applications';
 import { debug, error } from 'src/utils/logging';
@@ -1183,7 +1183,16 @@ export class Tidy5eNpcSheet
         super.activateListeners,
         this
       );
-      blurUntabbableButtonsOnClick(this.element.get(0));
+      if (!SettingsProvider.settings.useAccessibleKeyboardSupport.get()) {
+        blurButtonsOnClick(this.element.get(0));
+      }
+      if (!SettingsProvider.settings.useAccessibleKeyboardSupport.get()) {
+        this.element
+          .get(0)
+          .querySelectorAll('button')
+          .forEach((b: HTMLButtonElement) => (b.tabIndex = -1));
+      }
+
       return;
     }
 
@@ -1201,6 +1210,12 @@ export class Tidy5eNpcSheet
         super.activateListeners,
         this
       );
+      if (!SettingsProvider.settings.useAccessibleKeyboardSupport.get()) {
+        this.element
+          .get(0)
+          .querySelectorAll('button')
+          .forEach((b: HTMLButtonElement) => (b.tabIndex = -1));
+      }
     });
   }
 

--- a/src/sheets/Tidy5eNpcSheet.ts
+++ b/src/sheets/Tidy5eNpcSheet.ts
@@ -27,7 +27,7 @@ import {
   maintainCustomContentInputFocus,
 } from 'src/utils/applications';
 import { debug, error } from 'src/utils/logging';
-import { SettingsProvider } from 'src/settings/settings';
+import { getCurrentSettings, SettingsProvider } from 'src/settings/settings';
 import { initTidy5eContextMenu } from 'src/context-menu/tidy5e-context-menu';
 import { getPercentage } from 'src/utils/numbers';
 import type { SvelteComponent } from 'svelte';
@@ -822,6 +822,7 @@ export class Tidy5eNpcSheet
       preparedSpells: FoundryAdapter.countPreparedSpells(
         defaultDocumentContext.items
       ),
+      settings: getCurrentSettings(),
       shortRest: this._onShortRest.bind(this),
       showLimitedSheet: FoundryAdapter.showLimitedSheet(this.actor),
       spellCalculations: calculateSpellAttackAndDc(this.actor),

--- a/src/sheets/actor/AcShield.svelte
+++ b/src/sheets/actor/AcShield.svelte
@@ -4,7 +4,6 @@
   import type { Readable } from 'svelte/store';
   import type { ActorSheetContextV1 } from 'src/types/types';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import { CONSTANTS } from 'src/constants';
 
   /**
@@ -29,20 +28,21 @@
 </script>
 
 <AcShieldBase {cssClass}>
-  <button
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <!-- svelte-ignore a11y-missing-attribute -->
+  <a
     bind:this={acShieldButton}
-    type="button"
-    on:click={() => FoundryAdapter.renderArmorConfig($context.actor)}
+    on:click={() =>
+      $context.editable && FoundryAdapter.renderArmorConfig($context.actor)}
     on:focus
     class="config-button attribute-value transparent-button"
     data-attribution="attributes.ac"
     data-attribution-caption="DND5E.ArmorClass"
     data-tooltip-direction="DOWN"
-    disabled={!$context.editable}
-    tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
   >
     {ac}
-  </button>
+  </a>
 </AcShieldBase>
 
 <style lang="scss">

--- a/src/sheets/actor/ActorMovement.svelte
+++ b/src/sheets/actor/ActorMovement.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import type { ActorSheetContextV1 } from 'src/types/types';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
@@ -31,13 +30,14 @@
     >
   {/if}
   {#if $context.unlocked}
-    <button
-      type="button"
-      class="configure inline-icon-button"
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <a
+      class="configure inline-icon-button inline-flex-row align-items-center"
       title={localize('DND5E.MovementConfig')}
       on:click={() => FoundryAdapter.renderActorMovementConfig($context.actor)}
-      tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
-      ><i class="fas fa-cog" /></button
-    >
+      ><i class="fas fa-cog" />
+    </a>
   {/if}
 </section>

--- a/src/sheets/actor/ActorWarnings.svelte
+++ b/src/sheets/actor/ActorWarnings.svelte
@@ -19,7 +19,7 @@
         <!-- svelte-ignore a11y-no-static-element-interactions -->
         <!-- svelte-ignore a11y-missing-attribute -->
         <a
-          class="inline-transparent-button"
+          class="warning-link inline-transparent-button"
           on:click={(ev) => $context.actor.sheet._onWarningLink(ev)}
           data-target={warning.link}
           >{warning.message}
@@ -43,7 +43,7 @@
       box-shadow: none;
     }
 
-    button {
+    .warning-link {
       color: inherit;
     }
   }

--- a/src/sheets/actor/ActorWarnings.svelte
+++ b/src/sheets/actor/ActorWarnings.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { CONSTANTS } from 'src/constants';
-  import { settingStore } from 'src/settings/settings';
   import type { ActorSheetContextV1 } from 'src/types/types';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
@@ -15,14 +14,16 @@
 <ol class="warnings">
   {#each warnings as warning}
     <li class="notification {warning.type}">
-      {#if warning.link}
-        <button
-          type="button"
+      {#if true}
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
+        <!-- svelte-ignore a11y-missing-attribute -->
+        <a
           class="inline-transparent-button"
           on:click={(ev) => $context.actor.sheet._onWarningLink(ev)}
-          tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
-          data-target={warning.link}>{warning.message}</button
-        >
+          data-target={warning.link}
+          >{warning.message}
+        </a>
       {:else}
         {warning.message}
       {/if}

--- a/src/sheets/actor/ActorWarnings.svelte
+++ b/src/sheets/actor/ActorWarnings.svelte
@@ -14,7 +14,7 @@
 <ol class="warnings">
   {#each warnings as warning}
     <li class="notification {warning.type}">
-      {#if true}
+      {#if warning.link}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <!-- svelte-ignore a11y-no-static-element-interactions -->
         <!-- svelte-ignore a11y-missing-attribute -->

--- a/src/sheets/actor/AmmoSelector.svelte
+++ b/src/sheets/actor/AmmoSelector.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { SettingsProvider } from 'src/settings/settings';
   import type { ContainerSheetContext, Item5e } from 'src/types/item.types';
   import type { ActorSheetContextV1 } from 'src/types/types';
   import { getContext } from 'svelte';
@@ -26,8 +25,7 @@
       .filter(
         (item: any) =>
           item.system.type?.value === 'ammo' &&
-          (!SettingsProvider.settings.showEquippedAmmoOnly.get() ||
-            item.system.equipped),
+          (!$context.settings.showEquippedAmmoOnly || item.system.equipped),
       )
       .map((item: any) => ({
         text: `${item.name} (${item.system.quantity})`,

--- a/src/sheets/actor/AmmoSelector.svelte
+++ b/src/sheets/actor/AmmoSelector.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
+  import { SettingsProvider } from 'src/settings/settings';
   import type { ContainerSheetContext, Item5e } from 'src/types/item.types';
   import type { ActorSheetContextV1 } from 'src/types/types';
   import { getContext } from 'svelte';
@@ -9,9 +9,9 @@
 
   export let item: Item5e;
 
-  let context = getContext<Readable<ActorSheetContextV1 | ContainerSheetContext>>(
-    CONSTANTS.SVELTE_CONTEXT.CONTEXT,
-  );
+  let context = getContext<
+    Readable<ActorSheetContextV1 | ContainerSheetContext>
+  >(CONSTANTS.SVELTE_CONTEXT.CONTEXT);
 
   $: actor = $context.actor ?? $context.item.actor;
 
@@ -26,7 +26,8 @@
       .filter(
         (item: any) =>
           item.system.type?.value === 'ammo' &&
-          (!$settingStore.showEquippedAmmoOnly || item.system.equipped),
+          (!SettingsProvider.settings.showEquippedAmmoOnly.get() ||
+            item.system.equipped),
       )
       .map((item: any) => ({
         text: `${item.name} (${item.system.quantity})`,

--- a/src/sheets/actor/AttributeBlock.svelte
+++ b/src/sheets/actor/AttributeBlock.svelte
@@ -7,7 +7,6 @@
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
   import type { ActorSheetContextV1 } from 'src/types/types';
-  import { settingStore } from 'src/settings/settings';
   import { CONSTANTS } from 'src/constants';
   import { ActiveEffectsHelper } from 'src/utils/active-effect';
 
@@ -39,8 +38,6 @@
     title={ability.label}
     text={abbreviation}
     on:roll={(event) => $context.actor.rollAbility(id, { event: event.detail })}
-    hideFromTabOrder={$settingStore.useDefaultSheetAttributeTabbing ||
-      !$settingStore.useAccessibleKeyboardSupport}
     attributes={{
       'data-tidy-sheet-part': CONSTANTS.SHEET_PARTS.ABILITY_ROLLER,
     }}
@@ -60,60 +57,54 @@
     />
   </BlockScore>
   <div class="ability-modifiers">
-    <button
-      type="button"
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
       class="ability-mod transparent-button"
       class:rollable={$context.editable}
       title={localize('DND5E.AbilityModifier')}
-      on:click={(event) => $context.actor.rollAbilityTest(id, { event })}
-      tabindex={!$settingStore.useDefaultSheetAttributeTabbing &&
-      $settingStore.useAccessibleKeyboardSupport
-        ? 0
-        : -1}
-      disabled={!$context.editable}
+      on:click={(event) =>
+        $context.editable && $context.actor.rollAbilityTest(id, { event })}
       data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.ABILITY_TEST_ROLLER}
     >
       {formatAsModifier(ability.mod)}
-    </button>
-    <button
-      type="button"
+    </a>
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
       class="ability-save transparent-button"
       class:rollable={$context.editable}
       title={localize('DND5E.ActionSave')}
-      on:click={(event) => $context.actor.rollAbilitySave(id, { event })}
-      tabindex={!$settingStore.useDefaultSheetAttributeTabbing &&
-      $settingStore.useAccessibleKeyboardSupport
-        ? 0
-        : -1}
-      disabled={!$context.editable}
+      on:click={(event) =>
+        $context.editable && $context.actor.rollAbilitySave(id, { event })}
       data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.ABILITY_SAVE_ROLLER}
     >
       {formatAsModifier(ability.save)}
-    </button>
+    </a>
     {#if useSavingThrowProficiency}
       {#if $context.unlocked}
-        <button
-          type="button"
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
+        <!-- svelte-ignore a11y-missing-attribute -->
+        <a
           title={ability.hover}
           class="proficiency-toggle inline-icon-button"
           on:click={() =>
+            !activeEffectApplied &&
             $context.actor.update({
               [`system.abilities.${id}.proficient`]:
                 1 - parseInt(ability.proficient),
             })}
-          tabindex={!$settingStore.useDefaultSheetAttributeTabbing &&
-          $settingStore.useAccessibleKeyboardSupport
-            ? 0
-            : -1}
           data-tidy-sheet-part={CONSTANTS.SHEET_PARTS
             .ABILITY_SAVE_PROFICIENCY_TOGGLE}
-          disabled={activeEffectApplied}
           data-tooltip={activeEffectApplied
             ? localize('DND5E.ActiveEffectOverrideWarning')
             : null}
         >
           {@html ability.icon}
-        </button>
+        </a>
       {:else}
         <span
           title={ability.hover}
@@ -125,21 +116,19 @@
       {/if}
     {/if}
     {#if useConfigurationOption && $context.editable && $context.unlocked}
-      <button
-        type="button"
+      <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <!-- svelte-ignore a11y-no-static-element-interactions -->
+      <!-- svelte-ignore a11y-missing-attribute -->
+      <a
         class="config-button inline-icon-button"
         title={localize('DND5E.AbilityConfigure')}
         on:click={() =>
           FoundryAdapter.renderActorAbilityConfig($context.actor, id)}
-        tabindex={!$settingStore.useDefaultSheetAttributeTabbing &&
-        $settingStore.useAccessibleKeyboardSupport
-          ? 0
-          : -1}
         data-tidy-sheet-part={CONSTANTS.SHEET_PARTS
           .ABILITY_CONFIGURATION_CONTROL}
       >
         <i class="fas fa-cog" />
-      </button>
+      </a>
     {/if}
   </div>
   <span class="mod-label ability-mod-label">{localize('TIDY5E.AbbrMod')}</span>

--- a/src/sheets/actor/Currency.svelte
+++ b/src/sheets/actor/Currency.svelte
@@ -2,7 +2,6 @@
   import TextInput from 'src/components/inputs/TextInput.svelte';
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import type { ContainerSheetContext, Item5e } from 'src/types/item.types';
   import type { Actor5e } from 'src/types/types';
   import type { ActorSheetContextV1 } from 'src/types/types';
@@ -11,9 +10,9 @@
 
   export let document: Actor5e | Item5e;
 
-  let context = getContext<Readable<ActorSheetContextV1 | ContainerSheetContext>>(
-    CONSTANTS.SVELTE_CONTEXT.CONTEXT,
-  );
+  let context = getContext<
+    Readable<ActorSheetContextV1 | ContainerSheetContext>
+  >(CONSTANTS.SVELTE_CONTEXT.CONTEXT);
 
   $: currencies = Object.entries(document.system.currency).map((e) => ({
     key: e[0],
@@ -55,16 +54,17 @@
       </li>
     {/each}
     <li class="currency-item convert">
-      <button
-        type="button"
+      <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <!-- svelte-ignore a11y-no-static-element-interactions -->
+      <!-- svelte-ignore a11y-missing-attribute -->
+      <a
         class="currency-convert"
         title={localize('DND5E.CurrencyManager.Title')}
-        on:click|stopPropagation|preventDefault={() => confirmConvertCurrency()}
-        disabled={!$context.editable}
-        tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
+        on:click|stopPropagation|preventDefault={() =>
+          $context.editable && confirmConvertCurrency()}
       >
         <i class="fas fa-coins" />
-      </button>
+      </a>
     </li>
   </ol>
 </div>

--- a/src/sheets/actor/DeathSaves.svelte
+++ b/src/sheets/actor/DeathSaves.svelte
@@ -5,7 +5,6 @@
   import type { Readable } from 'svelte/store';
   import TextInput from 'src/components/inputs/TextInput.svelte';
   import { CONSTANTS } from 'src/constants';
-  import { settingStore } from 'src/settings/settings';
 
   let context = getContext<Readable<CharacterSheetContext | NpcSheetContext>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,

--- a/src/sheets/actor/DeathSaves.svelte
+++ b/src/sheets/actor/DeathSaves.svelte
@@ -40,15 +40,16 @@
       disabled={!$context.editable}
       data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.DEATH_SAVE_SUCCESSES}
     />
-    <button
-      type="button"
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
       class="death-save rollable"
       on:click={(event) => dispatcher('rollDeathSave', { mouseEvent: event })}
       data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.DEATH_SAVE_ROLLER}
-      tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
     >
       <i class="fas fa-skull" />
-    </button>
+    </a>
     <TextInput
       document={$context.actor}
       field={failuresField}

--- a/src/sheets/actor/ExhaustionTracker.svelte
+++ b/src/sheets/actor/ExhaustionTracker.svelte
@@ -6,7 +6,6 @@
     IconWithSeverity,
   } from 'src/features/exhaustion/exhaustion.types';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import type {
     ActorSheetContextV1,
     PortraitCharmRadiusClass,
@@ -50,10 +49,12 @@
     levelSelected: { level: number };
   }>();
 
-  let exhaustionOptionWidthRems = 1.25;
+  let exhaustionOptionWidthRems = 1.5;
   $: exhaustionExpandedWidth = `${
     exhaustionOptionWidthRems * (exhaustionConfig.levels + 1) + 2.125
   }rem`;
+
+  $: disabled = !$context.editable || isActiveEffectApplied;
 </script>
 
 <div
@@ -73,20 +74,29 @@
     <ul class="exhaustion-levels">
       {#each iconsWithSeverities as _, i}
         <li>
-          <button
-            type="button"
-            class="exhaustion-level-option transparent-button"
-            class:colorized={i <= level}
-            title={localize(exhaustionConfig.hints[i] ?? '')}
-            on:click={() => dispatch('levelSelected', { level: i })}
-            disabled={!$context.editable || isActiveEffectApplied}
-            tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
-            data-tooltip={isActiveEffectApplied
-              ? localize('DND5E.ActiveEffectOverrideWarning')
-              : null}
-          >
-            {i}
-          </button>
+          {#if !disabled}
+            <!-- svelte-ignore a11y-missing-attribute -->
+            <!-- svelte-ignore a11y-click-events-have-key-events -->
+            <!-- svelte-ignore a11y-no-static-element-interactions -->
+            <a
+              class="exhaustion-level-option transparent-button"
+              class:colorized={i <= level}
+              title={localize(exhaustionConfig.hints[i] ?? '')}
+              on:click={() => dispatch('levelSelected', { level: i })}
+              data-tooltip={isActiveEffectApplied
+                ? localize('DND5E.ActiveEffectOverrideWarning')
+                : null}
+            >
+              {i}
+            </a>
+          {:else}
+            <span
+              class="exhaustion-level-option transparent-button"
+              class:colorized={i <= level}
+            >
+              {i}
+            </span>
+          {/if}
         </li>
       {/each}
     </ul>
@@ -124,7 +134,7 @@
     }
 
     &:hover .exhaustion-wrap,
-    .exhaustion-wrap:has(button:focus-visible) {
+    .exhaustion-wrap:has(.exhaustion-level-option:focus-visible) {
       width: var(--t5e-exhaustion-expanded-width);
     }
 
@@ -161,12 +171,16 @@
         flex: 1;
 
         li {
-          flex: 0 0 1.25rem;
+          flex: 0 0 1.5rem;
           text-align: center;
           line-height: 2.125rem;
           display: flex;
 
           .exhaustion-level-option {
+            flex: 1;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
             border-radius: 0;
 
             &:is(:hover, :focus-visible) {

--- a/src/sheets/actor/InitiativeBlock.svelte
+++ b/src/sheets/actor/InitiativeBlock.svelte
@@ -7,7 +7,6 @@
   import type { ActorSheetContextV1 } from 'src/types/types';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
-  import { settingStore } from 'src/settings/settings';
   import { CONSTANTS } from 'src/constants';
 
   export let initiative: { total: number; bonus: number };
@@ -45,16 +44,17 @@
   </label>
 
   {#if $context.editable && $context.unlocked}
-    <button
-      type="button"
-      class="config-button icon-button"
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
+      class="config-button icon-button inline-flex-row align-items-center"
       title={localize('DND5E.InitiativeConfig')}
       on:click={() =>
         FoundryAdapter.renderActorInitiativeConfig($context.actor)}
-      tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
     >
       <i class="fas fa-cog" />
-    </button>
+    </a>
   {:else}
     <span
       class="config-button invisible"

--- a/src/sheets/actor/InventoryGrid.svelte
+++ b/src/sheets/actor/InventoryGrid.svelte
@@ -15,7 +15,6 @@
   import { getContext } from 'svelte';
   import type { Readable, Writable } from 'svelte/store';
   import TextInput from '../../components/inputs/TextInput.svelte';
-  import { settingStore } from 'src/settings/settings';
   import { ActorItemRuntime } from 'src/runtime/ActorItemRuntime';
   import { declareLocation } from 'src/types/location-awareness.types';
   import { TidyHooks } from 'src/foundry/TidyHooks';
@@ -108,8 +107,8 @@
     {#each items as item (item.id)}
       {@const ctx = $context.itemContext[item.id]}
       {@const hidden = !!$itemIdsToShow && !$itemIdsToShow.has(item.id)}
-      <button
-        type="button"
+      <!-- svelte-ignore a11y-missing-attribute -->
+      <a
         class="item {getInventoryRowClasses(item)} transparent-button"
         class:hidden
         aria-hidden={hidden}
@@ -125,10 +124,8 @@
         on:mouseleave={(ev) => onMouseLeave(ev, item)}
         on:dragstart={(ev) => handleDragStart(ev, item)}
         draggable={true}
-        disabled={!$context.editable}
         data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.ITEM_USE_COMMAND}
         data-item-id={item.id}
-        tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
         data-tidy-grid-item
       >
         <div class="item-name">
@@ -168,7 +165,6 @@
             style="display:none"
             data-action="itemEdit"
             title={localize('DND5E.ItemEdit')}
-            tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
           >
             <i class="fas fa-edit fa-fw" />
           </button>
@@ -213,12 +209,14 @@
             />
           </span>
         </div>
-      </button>
+      </a>
     {/each}
     {#if $context.unlocked}
       <div class="items-footer">
-        <button
-          type="button"
+        <!-- svelte-ignore a11y-missing-attribute -->
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
+        <a
           class="footer-command icon-button"
           title={localize('DND5E.ItemCreate')}
           on:click|stopPropagation|preventDefault={() =>
@@ -231,24 +229,25 @@
               $context.actor,
             )}
           data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.ITEM_CREATE_COMMAND}
-          tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
         >
           <i class="fas fa-plus-circle" />
-        </button>
+        </a>
         {#each customCommands as command}
-          <button
+          <!-- svelte-ignore a11y-click-events-have-key-events -->
+          <!-- svelte-ignore a11y-no-static-element-interactions -->
+          <!-- svelte-ignore a11y-missing-attribute -->
+          <a
             type="button"
             class="footer-command icon-button"
             on:click={(ev) =>
               command.execute?.({ section, event: ev, actor: $context.actor })}
-            tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
             title={localize(command.tooltip ?? '')}
           >
             {#if (command.iconClass ?? '') !== ''}
               <i class={command.iconClass} />
             {/if}
             {localize(command.label ?? '')}
-          </button>
+          </a>
         {/each}
       </div>
     {/if}

--- a/src/sheets/actor/InventoryList.svelte
+++ b/src/sheets/actor/InventoryList.svelte
@@ -27,7 +27,6 @@
     RenderableClassicControl,
   } from 'src/types/types';
   import AmmoSelector from './AmmoSelector.svelte';
-  import { settingStore } from 'src/settings/settings';
   import ActionFilterOverrideControl from 'src/components/item-list/controls/ActionFilterOverrideControl.svelte';
   import { coalesce } from 'src/utils/formatting';
   import TextInput from 'src/components/inputs/TextInput.svelte';
@@ -35,6 +34,7 @@
   import InlineContainerToggle from '../container/InlineContainerToggle.svelte';
   import { InlineContainerToggleService } from 'src/features/containers/InlineContainerToggleService';
   import InlineContainerView from '../container/InlineContainerView.svelte';
+  import { SettingsProvider } from 'src/settings/settings';
 
   export let primaryColumnName: string;
   export let items: Item5e[];
@@ -222,7 +222,7 @@
               {/if}
             </ItemName>
           </ItemTableCell>
-          {#if $settingStore.showIconsNextToTheItemName}
+          {#if SettingsProvider.settings.showIconsNextToTheItemName.get()}
             <ItemTableCell cssClass="no-border">
               {#if ctx?.attunement && !FoundryAdapter.concealDetails(item)}
                 <div class="item-detail attunement">

--- a/src/sheets/actor/InventoryList.svelte
+++ b/src/sheets/actor/InventoryList.svelte
@@ -34,7 +34,6 @@
   import InlineContainerToggle from '../container/InlineContainerToggle.svelte';
   import { InlineContainerToggleService } from 'src/features/containers/InlineContainerToggleService';
   import InlineContainerView from '../container/InlineContainerView.svelte';
-  import { SettingsProvider } from 'src/settings/settings';
 
   export let primaryColumnName: string;
   export let items: Item5e[];
@@ -222,7 +221,7 @@
               {/if}
             </ItemName>
           </ItemTableCell>
-          {#if SettingsProvider.settings.showIconsNextToTheItemName.get()}
+          {#if $context.settings.showIconsNextToTheItemName}
             <ItemTableCell cssClass="no-border">
               {#if ctx?.attunement && !FoundryAdapter.concealDetails(item)}
                 <div class="item-detail attunement">

--- a/src/sheets/actor/NoSpells.svelte
+++ b/src/sheets/actor/NoSpells.svelte
@@ -2,7 +2,6 @@
   import Notice from 'src/components/notice/Notice.svelte';
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import type { CharacterSheetContext, NpcSheetContext } from 'src/types/types';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
@@ -20,16 +19,17 @@
 <div class="no-spells-container {cssClass}">
   <Notice>{localize('DND5E.NoSpellLevels')}</Notice>
   {#if $context.editable && editable}
-    <button
-      type="button"
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
       class="create-spell-btn flex-row align-items-center extra-small-gap"
       on:click={() =>
         FoundryAdapter.createItem({ type: 'spell', level: '' }, $context.actor)}
-      tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
     >
       <i class="fas fa-plus-circle" />
       {localize('DND5E.SpellCreate')}
-    </button>
+    </a>
   {/if}
 </div>
 

--- a/src/sheets/actor/RollableBlockTitle.svelte
+++ b/src/sheets/actor/RollableBlockTitle.svelte
@@ -6,7 +6,6 @@
 
   export let title: string | null = null;
   export let text: string;
-  export let hideFromTabOrder: boolean = false;
   export let attributes: Record<string, string> = {};
 
   const dispatcher = createEventDispatcher<{ roll: MouseEvent }>();
@@ -16,20 +15,19 @@
   );
 </script>
 
-<button
-  type="button"
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y-missing-attribute -->
+<a
   class:rollable={$context.editable}
   class="transparent-button"
   {title}
-  on:click={(ev) => dispatcher('roll', ev)}
-  disabled={!$context.editable}
-  tabindex={!hideFromTabOrder ? 0 : -1}
+  on:click={(ev) => $context.editable && dispatcher('roll', ev)}
   {...attributes}
 >
   <h4 class="block-title">
     {text}
   </h4>
-</button>
+</a>
 
 <style lang="scss">
   .block-title {

--- a/src/sheets/actor/SheetEditModeToggle.svelte
+++ b/src/sheets/actor/SheetEditModeToggle.svelte
@@ -3,10 +3,10 @@
   import { TidyFlags } from 'src/foundry/TidyFlags';
   import TidySwitch from 'src/components/toggle/TidySwitch.svelte';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import type { ActorSheetContextV1 } from 'src/types/types';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
+  import { SettingsProvider } from 'src/settings/settings';
 
   export let hint: string | null = null;
 
@@ -20,15 +20,17 @@
 
   $: allowEdit = TidyFlags.allowEdit.get($context.actor);
 
+  $: useTotalSheetLock = SettingsProvider.settings.useTotalSheetLock.get();
+
   $: descriptionVariable =
     hint ??
-    ($settingStore.useTotalSheetLock
+    (useTotalSheetLock
       ? localize('TIDY5E.SheetLock.Description')
       : localize('TIDY5E.SheetEdit.Description'));
-  $: lockHintVariable = $settingStore.useTotalSheetLock
+  $: lockHintVariable = useTotalSheetLock
     ? 'TIDY5E.SheetLock.Unlock.Hint'
     : 'TIDY5E.SheetEdit.Enable.Hint';
-  $: unlockHintVariable = $settingStore.useTotalSheetLock
+  $: unlockHintVariable = useTotalSheetLock
     ? 'TIDY5E.SheetLock.Lock.Hint'
     : 'TIDY5E.SheetEdit.Disable.Hint';
   $: unlockTitle = localize(unlockHintVariable, {

--- a/src/sheets/actor/SheetEditModeToggle.svelte
+++ b/src/sheets/actor/SheetEditModeToggle.svelte
@@ -6,7 +6,6 @@
   import type { ActorSheetContextV1 } from 'src/types/types';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
-  import { SettingsProvider } from 'src/settings/settings';
 
   export let hint: string | null = null;
 
@@ -20,7 +19,7 @@
 
   $: allowEdit = TidyFlags.allowEdit.get($context.actor);
 
-  $: useTotalSheetLock = SettingsProvider.settings.useTotalSheetLock.get();
+  $: useTotalSheetLock = $context.settings.useTotalSheetLock;
 
   $: descriptionVariable =
     hint ??

--- a/src/sheets/actor/SheetMenu.svelte
+++ b/src/sheets/actor/SheetMenu.svelte
@@ -26,7 +26,7 @@
   title={localize('TIDY5E.SheetMenu.label')}
   iconClass="fas fa-ellipsis-vertical"
 >
-  <ThemeSelectorButtonMenuCommand />
+  <ThemeSelectorButtonMenuCommand colorScheme={$context.settings.colorScheme} />
   <ButtonMenuDivider />
   <ButtonMenuCommand
     on:click={() => ApplicationsManager.openUserSettings(defaultSettingsTab)}

--- a/src/sheets/actor/SkillsList.svelte
+++ b/src/sheets/actor/SkillsList.svelte
@@ -2,7 +2,6 @@
   import InlineTextDropdownList from 'src/components/inputs/InlineTextDropdownList.svelte';
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import type { Actor5e, DropdownListOption } from 'src/types/types';
   import type { CharacterSheetContext, NpcSheetContext } from 'src/types/types';
   import { ActiveEffectsHelper } from 'src/utils/active-effect';
@@ -121,8 +120,10 @@
                 $context.actor,
                 `system.skills.${skillRef.key}.value`,
               )}
-            <button
-              type="button"
+            <!-- svelte-ignore a11y-click-events-have-key-events -->
+            <!-- svelte-ignore a11y-no-static-element-interactions -->
+            <!-- svelte-ignore a11y-missing-attribute -->
+            <a
               class="configure-proficiency inline-icon-button"
               on:click={() =>
                 FoundryAdapter.renderProficiencyConfig(
@@ -133,14 +134,16 @@
               title={localize('DND5E.SkillConfigure')}
               data-tidy-sheet-part={CONSTANTS.SHEET_PARTS
                 .SKILL_CONFIGURATION_CONTROL}
-              tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
             >
               <i class="fas fa-cog" />
-            </button>
-            <button
-              type="button"
+            </a>
+            <!-- svelte-ignore a11y-click-events-have-key-events -->
+            <!-- svelte-ignore a11y-no-static-element-interactions -->
+            <!-- svelte-ignore a11y-missing-attribute -->
+            <a
               class="skill-proficiency-toggle inline-icon-button"
               on:click={() =>
+                !activeEffectApplied &&
                 FoundryAdapter.cycleProficiency(
                   $context.actor,
                   skillRef.key,
@@ -148,6 +151,7 @@
                   'skills',
                 )}
               on:contextmenu={() =>
+                !activeEffectApplied &&
                 FoundryAdapter.cycleProficiency(
                   $context.actor,
                   skillRef.key,
@@ -158,11 +162,9 @@
               title={skillRef.skill.hover}
               data-tidy-sheet-part={CONSTANTS.SHEET_PARTS
                 .SKILL_PROFICIENCY_TOGGLE}
-              tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
-              disabled={activeEffectApplied}
               data-tooltip={activeEffectApplied
                 ? localize('DND5E.ActiveEffectOverrideWarning')
-                : null}>{@html skillRef.skill.icon}</button
+                : null}>{@html skillRef.skill.icon}</a
             >
           {:else}
             <span class="skill-proficiency" title={skillRef.skill.hover}
@@ -170,17 +172,18 @@
             >
           {/if}
           {#if $context.editable}
-            <button
-              type="button"
+            <!-- svelte-ignore a11y-click-events-have-key-events -->
+            <!-- svelte-ignore a11y-no-static-element-interactions -->
+            <!-- svelte-ignore a11y-missing-attribute -->
+            <a
               class="tidy5e-skill-name transparent-button rollable"
               on:click={(event) =>
                 $context.actor.rollSkill(skillRef.key, { event })}
               data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.SKILL_ROLLER}
-              tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
               title={skillRef.skill.label}
             >
               {skillRef.skill.label}
-            </button>
+            </a>
           {:else}
             <span class="tidy5e-skill-name" title={skillRef.skill.label}>
               {skillRef.skill.label}
@@ -214,20 +217,21 @@
   </ul>
   {#if toggleable}
     <div style="text-align:center;">
-      <button
-        type="button"
+      <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <!-- svelte-ignore a11y-no-static-element-interactions -->
+      <!-- svelte-ignore a11y-missing-attribute -->
+      <a
         class="toggle-proficient inline-transparent-button"
         on:click={toggleShowAllSkills}
         data-tidy-sheet-part={CONSTANTS.SHEET_PARTS
           .SKILLS_SHOW_PROFICIENT_TOGGLE}
-        tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
       >
         {#if showAllSkills}
           {localize('TIDY5E.HideNotProficientSkills')}
         {:else}
           {localize('TIDY5E.ShowNotProficientSkills')}
-        {/if}</button
-      >
+        {/if}
+      </a>
     </div>
   {/if}
 </div>

--- a/src/sheets/actor/SpecialSaves.svelte
+++ b/src/sheets/actor/SpecialSaves.svelte
@@ -14,23 +14,27 @@
 {#if $context.saves.concentration}
   {@const save = $context.saves.concentration}
   <span class="special-save">
-    <button
-      type="button"
-      class="inline-transparent-button flex-row extra-small-gap align-items-center highlight-on-hover"
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
+      class="concentration-roller inline-transparent-button flex-row extra-small-gap align-items-center highlight-on-hover"
       on:click={(ev) => $context.actor.rollConcentration({ event: ev })}
     >
       <Dnd5eIcon src="systems/dnd5e/icons/svg/statuses/concentrating.svg" />
       {save.label}:
       <span class="special-save-mod">{save.sign}{save.mod}</span>
-    </button>
+    </a>
     {#if $context.unlocked}
-      <button
-        type="button"
-        class="inline-icon-button"
+      <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <!-- svelte-ignore a11y-no-static-element-interactions -->
+      <!-- svelte-ignore a11y-missing-attribute -->
+      <a
+        class="configure-concentration inline-icon-button"
         on:click={() =>
           FoundryAdapter.openActorConcentrationConfig($context.actor)}
-        ><i class="fas fa-cog" style="font-size: var(--icon-size);"></i></button
-      >
+        ><i class="fas fa-cog" style="font-size: var(--icon-size);"></i>
+      </a>
     {/if}
   </span>
 {/if}
@@ -45,7 +49,7 @@
 
     --icon-fill: var(--t5e-icon-hover-color);
 
-    button {
+    * {
       font-weight: 700;
     }
   }

--- a/src/sheets/actor/TempHp.svelte
+++ b/src/sheets/actor/TempHp.svelte
@@ -4,7 +4,6 @@
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
   import TextInput from 'src/components/inputs/TextInput.svelte';
-  import { settingStore } from 'src/settings/settings';
   import { CONSTANTS } from 'src/constants';
 
   let context = getContext<Readable<CharacterSheetContext | NpcSheetContext>>(
@@ -38,16 +37,17 @@
     disabled={!$context.editable}
   />
   {#if $context.editable && $context.unlocked}
-    <button
-      type="button"
-      class="inline-icon-button"
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
+      class="inline-icon-button inline-flex-row align-items-center"
       title={localize('DND5E.HitPointsConfig')}
       on:click|stopPropagation|preventDefault={() =>
         FoundryAdapter.renderActorHitPointsDialog($context.actor)}
-      tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
     >
       <i class="fas fa-cog" />
-    </button>
+    </a>
   {/if}
 </div>
 

--- a/src/sheets/actor/tabs/ActorInventoryTab.svelte
+++ b/src/sheets/actor/tabs/ActorInventoryTab.svelte
@@ -14,7 +14,6 @@
   import Notice from '../../../components/notice/Notice.svelte';
   import EncumbranceBar from 'src/sheets/actor/EncumbranceBar.svelte';
   import TabFooter from 'src/sheets/actor/TabFooter.svelte';
-  import { settingStore } from 'src/settings/settings';
   import { CONSTANTS } from 'src/constants';
   import UtilityToolbar from 'src/components/utility-bar/UtilityToolbar.svelte';
   import Search from 'src/components/utility-bar/Search.svelte';
@@ -29,6 +28,7 @@
   import { SheetPreferencesService } from 'src/features/user-preferences/SheetPreferencesService';
   import { ItemVisibility } from 'src/features/sections/ItemVisibility';
   import AttunementTracker from '../AttunementTracker.svelte';
+    import { SettingsProvider } from 'src/settings/settings';
 
   export let tabId: string;
 
@@ -140,7 +140,7 @@
     <Currency document={$context.actor} />
   </div>
 
-  {#if $settingStore.useCharacterEncumbranceBar}
+  {#if SettingsProvider.settings.useCharacterEncumbranceBar.get()}
     <EncumbranceBar />
   {/if}
 </TabFooter>

--- a/src/sheets/actor/tabs/ActorInventoryTab.svelte
+++ b/src/sheets/actor/tabs/ActorInventoryTab.svelte
@@ -28,7 +28,6 @@
   import { SheetPreferencesService } from 'src/features/user-preferences/SheetPreferencesService';
   import { ItemVisibility } from 'src/features/sections/ItemVisibility';
   import AttunementTracker from '../AttunementTracker.svelte';
-    import { SettingsProvider } from 'src/settings/settings';
 
   export let tabId: string;
 
@@ -140,7 +139,7 @@
     <Currency document={$context.actor} />
   </div>
 
-  {#if SettingsProvider.settings.useCharacterEncumbranceBar.get()}
+  {#if $context.settings.useCharacterEncumbranceBar}
     <EncumbranceBar />
   {/if}
 </TabFooter>

--- a/src/sheets/actor/traits/TraitSection.svelte
+++ b/src/sheets/actor/traits/TraitSection.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { CONSTANTS } from 'src/constants';
-  import { SettingsProvider } from 'src/settings/settings';
   import type { ActorSheetContextV1 } from 'src/types/types';
   import { createEventDispatcher, getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
@@ -34,7 +33,7 @@
       class="trait-label-and-list"
       data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.ACTOR_TRAIT_DETAILS}
     >
-      {#if SettingsProvider.settings.showTraitLabels.get()}
+      {#if $context.settings.showTraitLabels}
         <span class="trait-label">{title}</span>
       {/if}
       <slot />

--- a/src/sheets/actor/traits/TraitSection.svelte
+++ b/src/sheets/actor/traits/TraitSection.svelte
@@ -40,16 +40,17 @@
       <slot />
     </div>
     {#if $context.unlocked}
-      <button
-        type="button"
+      <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <!-- svelte-ignore a11y-no-static-element-interactions -->
+      <!-- svelte-ignore a11y-missing-attribute -->
+      <a
         class="trait-editor inline-icon-button flex-row align-items-flex-start justify-content-center"
         title={configureButtonTitle}
         on:click|stopPropagation|preventDefault={(event) =>
           dispatcher('onConfigureClicked', event)}
-        tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
       >
         <i class="fas fa-pencil-alt" />
-      </button>
+      </a>
     {/if}
   </div>
 {/if}

--- a/src/sheets/actor/traits/TraitSection.svelte
+++ b/src/sheets/actor/traits/TraitSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { CONSTANTS } from 'src/constants';
-  import { settingStore } from 'src/settings/settings';
+  import { SettingsProvider } from 'src/settings/settings';
   import type { ActorSheetContextV1 } from 'src/types/types';
   import { createEventDispatcher, getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
@@ -34,7 +34,7 @@
       class="trait-label-and-list"
       data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.ACTOR_TRAIT_DETAILS}
     >
-      {#if $settingStore.showTraitLabels}
+      {#if SettingsProvider.settings.showTraitLabels.get()}
         <span class="trait-label">{title}</span>
       {/if}
       <slot />

--- a/src/sheets/actor/traits/TraitSectionTools.svelte
+++ b/src/sheets/actor/traits/TraitSectionTools.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import type { ActorSheetContextV1 } from 'src/types/types';
   import { ActiveEffectsHelper } from 'src/utils/active-effect';
   import { getContext } from 'svelte';
@@ -32,11 +31,14 @@
             $context.actor,
             `system.tools.${key}.value`,
           )}
-        <button
-          type="button"
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
+        <!-- svelte-ignore a11y-missing-attribute -->
+        <a
           class="tool-proficiency-toggle inline-transparent-button"
           title={tool.hover}
           on:click|stopPropagation|preventDefault={(event) =>
+            !activeEffectApplied &&
             FoundryAdapter.cycleProficiency(
               $context.actor,
               key,
@@ -44,6 +46,7 @@
               'tools',
             )}
           on:contextmenu|stopPropagation|preventDefault={(event) =>
+            !activeEffectApplied &&
             FoundryAdapter.cycleProficiency(
               $context.actor,
               key,
@@ -52,14 +55,12 @@
               true,
             )}
           data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.TOOL_PROFICIENCY_TOGGLE}
-          tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
-          disabled={activeEffectApplied}
           data-tooltip={activeEffectApplied
             ? localize('DND5E.ActiveEffectOverrideWarning')
             : null}
         >
           {@html tool.icon}
-        </button>
+        </a>
       {:else}
         <span title={tool.hover} class="tool-proficiency-readonly"
           >{@html tool.icon}</span
@@ -67,15 +68,16 @@
       {/if}
 
       {#if $context.editable}
-        <button
-          type="button"
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
+        <!-- svelte-ignore a11y-missing-attribute -->
+        <a
           class="tool-check-roller inline-transparent-button rollable"
           on:click={(event) => $context.actor.rollToolCheck(key, { event })}
           data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.TOOL_ROLLER}
-          tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
         >
           {tool.label}
-        </button>
+        </a>
       {:else}
         <span class="tool-check-roller">
           {tool.label}
@@ -83,8 +85,10 @@
       {/if}
 
       {#if $context.unlocked}
-        <button
-          type="button"
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
+        <!-- svelte-ignore a11y-missing-attribute -->
+        <a
           class="tool-proficiency-editor inline-icon-button"
           title={localize('DND5E.ToolConfigure')}
           on:click|stopPropagation|preventDefault={() =>
@@ -95,10 +99,9 @@
             )}
           data-tidy-sheet-part={CONSTANTS.SHEET_PARTS
             .TOOL_CONFIGURATION_CONTROL}
-          tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
         >
           <i class="fas fa-cog" />
-        </button>
+        </a>
       {/if}
     </li>
   {/each}

--- a/src/sheets/actor/traits/Traits.svelte
+++ b/src/sheets/actor/traits/Traits.svelte
@@ -5,7 +5,6 @@
   import TraitSectionTools from './TraitSectionTools.svelte';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
-  import { settingStore } from 'src/settings/settings';
   import { error } from 'src/utils/logging';
   import TraitSectionTags from './TraitSectionTags.svelte';
   import TraitSectionModifications from './TraitSectionModifications.svelte';
@@ -270,32 +269,34 @@
   {/if}
 
   {#if toggleable}
-    <button
-      type="button"
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
       class="toggle-traits inline-transparent-button"
       on:click|stopPropagation|preventDefault={() => toggleTraitsExpanded()}
-      tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
     >
       {#if traitsExpanded}
         {localize('TIDY5E.HideEmptyTraits')}
       {:else}
         {localize('TIDY5E.ShowEmptyTraits')}
       {/if}
-    </button>
+    </a>
   {/if}
   {#if enableSpecialTraitsConfiguration && !$context.lockSensitiveFields}
-    <button
-      type="button"
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
       class="configure-special-traits inline-icon-button"
       title={localize('DND5E.TraitConfig', {
         trait: localize('DND5E.SpecialTraits'),
       })}
       on:click|stopPropagation|preventDefault={() =>
         FoundryAdapter.renderActorSheetFlags($context.actor)}
-      tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
     >
       <i class="fas fa-star" />
-    </button>
+    </a>
   {/if}
 </div>
 

--- a/src/sheets/character/CharacterSheetFull.svelte
+++ b/src/sheets/character/CharacterSheetFull.svelte
@@ -26,7 +26,6 @@
   import ActorOriginSummaryConfigFormApplication from 'src/applications/actor-origin-summary/ActorOriginSummaryConfigFormApplication';
   import ActorName from '../actor/ActorName.svelte';
   import { TidyFlags } from 'src/foundry/TidyFlags';
-  import { SettingsProvider } from 'src/settings/settings';
 
   let selectedTabId: string;
   let context = getContext<Readable<CharacterSheetContext>>(
@@ -134,7 +133,7 @@
 
     <section class="class-list">
       <!-- Player Name -->
-      {#if SettingsProvider.settings.showPlayerName.get()}
+      {#if $context.settings.showPlayerName}
         <ContentEditableFormField
           element="span"
           document={$context.actor}
@@ -149,7 +148,7 @@
       {/if}
 
       <!-- Class / Subclass -->
-      {#if $context.owner && SettingsProvider.settings.showClassList.get()}
+      {#if $context.owner && $context.settings.showClassList}
         <span class="flex-row extra-small-gap">
           {#each classAndSubclassSummaries as summary, i}
             {#if i > 0}
@@ -241,7 +240,7 @@
   <svelte:fragment slot="tab-end">
     {#if $context.editable}
       <SheetEditModeToggle
-        hint={SettingsProvider.settings.permanentlyUnlockCharacterSheetForGm.get() &&
+        hint={$context.settings.permanentlyUnlockCharacterSheetForGm &&
         FoundryAdapter.userIsGm()
           ? localize(
               'TIDY5E.Settings.PermanentlyUnlockCharacterSheetForGM.title',

--- a/src/sheets/character/CharacterSheetFull.svelte
+++ b/src/sheets/character/CharacterSheetFull.svelte
@@ -22,11 +22,11 @@
   import TextInput from 'src/components/inputs/TextInput.svelte';
   import ItemInfoCard from 'src/components/item-info-card/ItemInfoCard.svelte';
   import SheetMenu from '../actor/SheetMenu.svelte';
-  import { settingStore } from 'src/settings/settings';
   import InlineCreatureType from '../shared/InlineCreatureType.svelte';
   import ActorOriginSummaryConfigFormApplication from 'src/applications/actor-origin-summary/ActorOriginSummaryConfigFormApplication';
   import ActorName from '../actor/ActorName.svelte';
   import { TidyFlags } from 'src/foundry/TidyFlags';
+  import { SettingsProvider } from 'src/settings/settings';
 
   let selectedTabId: string;
   let context = getContext<Readable<CharacterSheetContext>>(
@@ -134,7 +134,7 @@
 
     <section class="class-list">
       <!-- Player Name -->
-      {#if $settingStore.showPlayerName}
+      {#if SettingsProvider.settings.showPlayerName.get()}
         <ContentEditableFormField
           element="span"
           document={$context.actor}
@@ -149,7 +149,7 @@
       {/if}
 
       <!-- Class / Subclass -->
-      {#if $context.owner && $settingStore.showClassList}
+      {#if $context.owner && SettingsProvider.settings.showClassList.get()}
         <span class="flex-row extra-small-gap">
           {#each classAndSubclassSummaries as summary, i}
             {#if i > 0}
@@ -199,18 +199,19 @@
           {localize('DND5E.Proficiency')}: {$context.labels.proficiency}
         </b>
         {#if $context.unlocked}
-          <button
-            type="button"
+          <!-- svelte-ignore a11y-click-events-have-key-events -->
+          <!-- svelte-ignore a11y-no-static-element-interactions -->
+          <!-- svelte-ignore a11y-missing-attribute -->
+          <a
             class="inline-icon-button"
             title={localize('TIDY5E.OriginSummaryConfig')}
             on:click={() =>
               new ActorOriginSummaryConfigFormApplication(
                 $context.actor,
               ).render(true)}
-            tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
           >
             <i class="fas fa-cog" />
-          </button>
+          </a>
         {/if}
       </span>
     </section>
@@ -240,7 +241,7 @@
   <svelte:fragment slot="tab-end">
     {#if $context.editable}
       <SheetEditModeToggle
-        hint={$settingStore.permanentlyUnlockCharacterSheetForGm &&
+        hint={SettingsProvider.settings.permanentlyUnlockCharacterSheetForGm.get() &&
         FoundryAdapter.userIsGm()
           ? localize(
               'TIDY5E.Settings.PermanentlyUnlockCharacterSheetForGM.title',

--- a/src/sheets/character/parts/CharacterHitPoints.svelte
+++ b/src/sheets/character/parts/CharacterHitPoints.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
   import { type Actor5e } from 'src/types/types';
-  import { settingStore } from 'src/settings/settings';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
   import type { CharacterSheetContext } from 'src/types/types';
   import HpBar from 'src/components/bar/HpBar.svelte';
   import ResourceWithBar from 'src/components/bar/ResourceWithBar.svelte';
   import { CONSTANTS } from 'src/constants';
+  import { SettingsProvider } from 'src/settings/settings';
 
   export let value: number;
   export let max: number;
@@ -41,7 +41,7 @@
       $context.lockHpMaxChanges ||
       $context.lockSensitiveFields}
     percentage={$context.healthPercentage}
-    Bar={$settingStore.useHpBar ? HpBar : null}
+    Bar={SettingsProvider.settings.useHpBar.get() ? HpBar : null}
   />
 </div>
 

--- a/src/sheets/character/parts/CharacterHitPoints.svelte
+++ b/src/sheets/character/parts/CharacterHitPoints.svelte
@@ -7,7 +7,6 @@
   import HpBar from 'src/components/bar/HpBar.svelte';
   import ResourceWithBar from 'src/components/bar/ResourceWithBar.svelte';
   import { CONSTANTS } from 'src/constants';
-  import { SettingsProvider } from 'src/settings/settings';
 
   export let value: number;
   export let max: number;
@@ -41,7 +40,7 @@
       $context.lockHpMaxChanges ||
       $context.lockSensitiveFields}
     percentage={$context.healthPercentage}
-    Bar={SettingsProvider.settings.useHpBar.get() ? HpBar : null}
+    Bar={$context.settings.useHpBar ? HpBar : null}
   />
 </div>
 

--- a/src/sheets/character/parts/CharacterProfile.svelte
+++ b/src/sheets/character/parts/CharacterProfile.svelte
@@ -11,10 +11,10 @@
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
   import ActorProfile from 'src/sheets/actor/ActorProfile.svelte';
-  import { settingStore } from 'src/settings/settings';
   import ExhaustionInput from 'src/sheets/actor/ExhaustionInput.svelte';
   import { ActiveEffectsHelper } from 'src/utils/active-effect';
   import { CONSTANTS } from 'src/constants';
+  import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<CharacterSheetContext>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -29,10 +29,14 @@
       'system.attributes.exhaustion': event.detail.level,
     });
   }
+
+  $: exhaustionConfig = SettingsProvider.settings.exhaustionConfig.get();
+  $: specificExhaustionConfig =
+    exhaustionConfig?.type === 'specific' ? exhaustionConfig : null;
 </script>
 
-<ActorProfile useHpOverlay={$settingStore.useHpOverlay}>
-  {#if incapacitated && (!$settingStore.hideDeathSavesFromPlayers || FoundryAdapter.userIsGm())}
+<ActorProfile useHpOverlay={SettingsProvider.settings.useHpOverlay.get()}>
+  {#if incapacitated && (!SettingsProvider.settings.hideDeathSavesFromPlayers.get() || FoundryAdapter.userIsGm())}
     <DeathSaves
       successes={$context.system.attributes.death.success}
       failures={$context.system.attributes.death.failure}
@@ -40,31 +44,31 @@
       failuresField="system.attributes.death.failure"
       on:rollDeathSave={(event) =>
         $context.actor.rollDeathSave({ event: event.detail.mouseEvent })}
-      hasHpOverlay={$settingStore.useHpOverlay}
+      hasHpOverlay={SettingsProvider.settings.useHpOverlay.get()}
     />
   {/if}
 
-  {#if $settingStore.useExhaustion && $settingStore.exhaustionConfig.type === 'specific'}
+  {#if SettingsProvider.settings.useExhaustion.get() && specificExhaustionConfig}
     <ExhaustionTracker
       level={$context.system.attributes.exhaustion}
       radiusClass={$context.useRoundedPortraitStyle ? 'rounded' : 'top-left'}
       on:levelSelected={onLevelSelected}
-      onlyShowOnHover={$settingStore.showExhaustionOnHover ||
-        ($settingStore.hideIfZero &&
+      onlyShowOnHover={SettingsProvider.settings.showExhaustionOnHover.get() ||
+        (SettingsProvider.settings.hideIfZero.get() &&
           $context.system.attributes.exhaustion === 0)}
-      exhaustionConfig={$settingStore.exhaustionConfig}
+      exhaustionConfig={specificExhaustionConfig}
       isActiveEffectApplied={ActiveEffectsHelper.isActiveEffectAppliedToField(
         $context.actor,
         'system.attributes.exhaustion',
       )}
     />
-  {:else if $settingStore.useExhaustion && $settingStore.exhaustionConfig.type === 'open'}
+  {:else if SettingsProvider.settings.useExhaustion.get() && SettingsProvider.settings.exhaustionConfig.get()?.type === 'open'}
     <ExhaustionInput
       level={$context.system.attributes.exhaustion}
       radiusClass={$context.useRoundedPortraitStyle ? 'rounded' : 'top-left'}
       on:levelSelected={onLevelSelected}
-      onlyShowOnHover={$settingStore.showExhaustionOnHover ||
-        ($settingStore.hideIfZero &&
+      onlyShowOnHover={SettingsProvider.settings.showExhaustionOnHover.get() ||
+        (SettingsProvider.settings.hideIfZero.get() &&
           $context.system.attributes.exhaustion === 0)}
       isActiveEffectApplied={ActiveEffectsHelper.isActiveEffectAppliedToField(
         $context.actor,
@@ -73,14 +77,14 @@
     />
   {/if}
 
-  {#if $settingStore.useCharacterInspiration}
+  {#if SettingsProvider.settings.useCharacterInspiration.get()}
     <Inspiration
       inspired={$context.actor.system.attributes.inspiration}
       radiusClass={$context.useRoundedPortraitStyle ? 'rounded' : 'top-right'}
-      onlyShowOnHover={$settingStore.showInspirationOnHover ||
-        ($settingStore.hideIfZero &&
+      onlyShowOnHover={SettingsProvider.settings.showInspirationOnHover.get() ||
+        (SettingsProvider.settings.hideIfZero.get() &&
           !$context.actor.system.attributes.inspiration)}
-      animate={$settingStore.animateInspiration}
+      animate={SettingsProvider.settings.animateInspiration.get()}
     />
   {/if}
 

--- a/src/sheets/character/parts/CharacterProfile.svelte
+++ b/src/sheets/character/parts/CharacterProfile.svelte
@@ -14,7 +14,6 @@
   import ExhaustionInput from 'src/sheets/actor/ExhaustionInput.svelte';
   import { ActiveEffectsHelper } from 'src/utils/active-effect';
   import { CONSTANTS } from 'src/constants';
-  import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<CharacterSheetContext>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -30,13 +29,13 @@
     });
   }
 
-  $: exhaustionConfig = SettingsProvider.settings.exhaustionConfig.get();
+  $: exhaustionConfig = $context.settings.exhaustionConfig;
   $: specificExhaustionConfig =
     exhaustionConfig?.type === 'specific' ? exhaustionConfig : null;
 </script>
 
-<ActorProfile useHpOverlay={SettingsProvider.settings.useHpOverlay.get()}>
-  {#if incapacitated && (!SettingsProvider.settings.hideDeathSavesFromPlayers.get() || FoundryAdapter.userIsGm())}
+<ActorProfile useHpOverlay={$context.settings.useHpOverlay}>
+  {#if incapacitated && (!$context.settings.hideDeathSavesFromPlayers || FoundryAdapter.userIsGm())}
     <DeathSaves
       successes={$context.system.attributes.death.success}
       failures={$context.system.attributes.death.failure}
@@ -44,17 +43,17 @@
       failuresField="system.attributes.death.failure"
       on:rollDeathSave={(event) =>
         $context.actor.rollDeathSave({ event: event.detail.mouseEvent })}
-      hasHpOverlay={SettingsProvider.settings.useHpOverlay.get()}
+      hasHpOverlay={$context.settings.useHpOverlay}
     />
   {/if}
 
-  {#if SettingsProvider.settings.useExhaustion.get() && specificExhaustionConfig}
+  {#if $context.settings.useExhaustion && specificExhaustionConfig}
     <ExhaustionTracker
       level={$context.system.attributes.exhaustion}
       radiusClass={$context.useRoundedPortraitStyle ? 'rounded' : 'top-left'}
       on:levelSelected={onLevelSelected}
-      onlyShowOnHover={SettingsProvider.settings.showExhaustionOnHover.get() ||
-        (SettingsProvider.settings.hideIfZero.get() &&
+      onlyShowOnHover={$context.settings.showExhaustionOnHover ||
+        ($context.settings.hideIfZero &&
           $context.system.attributes.exhaustion === 0)}
       exhaustionConfig={specificExhaustionConfig}
       isActiveEffectApplied={ActiveEffectsHelper.isActiveEffectAppliedToField(
@@ -62,13 +61,13 @@
         'system.attributes.exhaustion',
       )}
     />
-  {:else if SettingsProvider.settings.useExhaustion.get() && SettingsProvider.settings.exhaustionConfig.get()?.type === 'open'}
+  {:else if $context.settings.useExhaustion && $context.settings.exhaustionConfig?.type === 'open'}
     <ExhaustionInput
       level={$context.system.attributes.exhaustion}
       radiusClass={$context.useRoundedPortraitStyle ? 'rounded' : 'top-left'}
       on:levelSelected={onLevelSelected}
-      onlyShowOnHover={SettingsProvider.settings.showExhaustionOnHover.get() ||
-        (SettingsProvider.settings.hideIfZero.get() &&
+      onlyShowOnHover={$context.settings.showExhaustionOnHover ||
+        ($context.settings.hideIfZero &&
           $context.system.attributes.exhaustion === 0)}
       isActiveEffectApplied={ActiveEffectsHelper.isActiveEffectAppliedToField(
         $context.actor,
@@ -77,14 +76,14 @@
     />
   {/if}
 
-  {#if SettingsProvider.settings.useCharacterInspiration.get()}
+  {#if $context.settings.useCharacterInspiration}
     <Inspiration
       inspired={$context.actor.system.attributes.inspiration}
       radiusClass={$context.useRoundedPortraitStyle ? 'rounded' : 'top-right'}
-      onlyShowOnHover={SettingsProvider.settings.showInspirationOnHover.get() ||
-        (SettingsProvider.settings.hideIfZero.get() &&
+      onlyShowOnHover={$context.settings.showInspirationOnHover ||
+        ($context.settings.hideIfZero &&
           !$context.actor.system.attributes.inspiration)}
-      animate={SettingsProvider.settings.animateInspiration.get()}
+      animate={$context.settings.animateInspiration}
     />
   {/if}
 

--- a/src/sheets/character/parts/HitDice.svelte
+++ b/src/sheets/character/parts/HitDice.svelte
@@ -3,7 +3,6 @@
   import type { CharacterSheetContext } from 'src/types/types';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
-  import { settingStore } from 'src/settings/settings';
   import { CONSTANTS } from 'src/constants';
 
   let context = getContext<Readable<CharacterSheetContext>>(
@@ -29,10 +28,6 @@
     on:click={$context.editable &&
       FoundryAdapter.renderActorHitDiceConfig($context.actor)}
     disabled={!$context.editable}
-    tabindex={!$settingStore.useDefaultSheetHpTabbing &&
-    $settingStore.useAccessibleKeyboardSupport
-      ? 0
-      : -1}
   >
     {hitDice}
   </button>

--- a/src/sheets/character/parts/Resource.svelte
+++ b/src/sheets/character/parts/Resource.svelte
@@ -5,7 +5,6 @@
   import type { Readable } from 'svelte/store';
   import TextInput from '../../../components/inputs/TextInput.svelte';
   import { CONSTANTS } from 'src/constants';
-  import { settingStore } from 'src/settings/settings';
 
   export let resource: TidyResource;
   let context = getContext<Readable<CharacterSheetContext>>(
@@ -108,17 +107,17 @@
       </label>
     </div>
     {#if $context.editable && !$context.lockSensitiveFields}
-      <button
-        type="button"
+      <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <!-- svelte-ignore a11y-missing-attribute -->
+      <a
         class="inline-icon-button resource-options"
         class:active={configActive}
         on:click={() => {
           configActive = !configActive;
         }}
-        tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
       >
         <i class="fas fa-cog" />
-      </button>
+      </a>
     {/if}
   </header>
 </li>

--- a/src/sheets/character/parts/Rest.svelte
+++ b/src/sheets/character/parts/Rest.svelte
@@ -3,7 +3,6 @@
   import type { CharacterSheetContext } from 'src/types/types';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
-  import { settingStore } from 'src/settings/settings';
   import { CONSTANTS } from 'src/constants';
 
   let context = getContext<Readable<CharacterSheetContext>>(
@@ -18,32 +17,28 @@
     <span class="resting-icon" title={localize('TIDY5E.RestHint')}
       ><i class="rest-icon fas fa-bed" /></span
     >
-    <button
-      type="button"
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
       class="rest icon-button"
       title={localize('TIDY5E.ShortRest')}
-      on:click={(event) => $context.actor.sheet.onShortRest(event)}
-      disabled={!$context.editable}
-      tabindex={!$settingStore.useDefaultSheetHpTabbing &&
-      $settingStore.useAccessibleKeyboardSupport
-        ? 0
-        : -1}
+      on:click={(event) =>
+        $context.editable && $context.actor.sheet.onShortRest(event)}
     >
       <i class="fas fa-hourglass-half" />
-    </button>
-    <button
-      type="button"
+    </a>
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
       class="rest icon-button"
       title={localize('TIDY5E.LongRest')}
-      on:click={(event) => $context.actor.sheet.onLongRest(event)}
-      disabled={!$context.editable}
-      tabindex={!$settingStore.useDefaultSheetHpTabbing &&
-      $settingStore.useAccessibleKeyboardSupport
-        ? 0
-        : -1}
+      on:click={(event) =>
+        $context.editable && $context.actor.sheet.onLongRest(event)}
     >
       <i class="fas fa-hourglass-end" />
-    </button>
+    </a>
   </div>
 </div>
 

--- a/src/sheets/character/tabs/CharacterAttributesTab.svelte
+++ b/src/sheets/character/tabs/CharacterAttributesTab.svelte
@@ -7,7 +7,6 @@
   import { isNil } from 'src/utils/data';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
-  import { settingStore } from 'src/settings/settings';
   import { CONSTANTS } from 'src/constants';
   import UtilityToolbar from 'src/components/utility-bar/UtilityToolbar.svelte';
   import UtilityToolbarCommand from 'src/components/utility-bar/UtilityToolbarCommand.svelte';
@@ -16,6 +15,7 @@
   import { ItemFilterRuntime } from 'src/runtime/item/ItemFilterRuntime';
   import FilterMenu from 'src/components/filter/FilterMenu.svelte';
   import { TidyFlags } from 'src/foundry/TidyFlags';
+  import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<CharacterSheetContext>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -61,20 +61,24 @@
     <section class="side-panel">
       <SkillsList
         actor={$context.actor}
-        toggleable={$settingStore.toggleEmptyCharacterSkills}
+        toggleable={SettingsProvider.settings.toggleEmptyCharacterSkills.get()}
         expanded={!!TidyFlags.skillsExpanded.get($context.actor)}
         toggleField={TidyFlags.skillsExpanded.prop}
       />
-      {#if !$settingStore.moveTraitsBelowCharacterResources}
-        <Traits toggleable={$settingStore.toggleEmptyCharacterTraits} />
+      {#if !SettingsProvider.settings.moveTraitsBelowCharacterResources.get()}
+        <Traits
+          toggleable={SettingsProvider.settings.toggleEmptyCharacterTraits.get()}
+        />
       {/if}
     </section>
     <section class="main-panel">
       {#if showResources}
         <Resources />
       {/if}
-      {#if $settingStore.moveTraitsBelowCharacterResources}
-        <Traits toggleable={$settingStore.toggleEmptyCharacterTraits} />
+      {#if SettingsProvider.settings.moveTraitsBelowCharacterResources.get()}
+        <Traits
+          toggleable={SettingsProvider.settings.toggleEmptyCharacterTraits.get()}
+        />
       {/if}
       <Favorites {searchCriteria} />
     </section>

--- a/src/sheets/character/tabs/CharacterAttributesTab.svelte
+++ b/src/sheets/character/tabs/CharacterAttributesTab.svelte
@@ -15,7 +15,6 @@
   import { ItemFilterRuntime } from 'src/runtime/item/ItemFilterRuntime';
   import FilterMenu from 'src/components/filter/FilterMenu.svelte';
   import { TidyFlags } from 'src/foundry/TidyFlags';
-  import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<CharacterSheetContext>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -61,13 +60,13 @@
     <section class="side-panel">
       <SkillsList
         actor={$context.actor}
-        toggleable={SettingsProvider.settings.toggleEmptyCharacterSkills.get()}
+        toggleable={$context.settings.toggleEmptyCharacterSkills}
         expanded={!!TidyFlags.skillsExpanded.get($context.actor)}
         toggleField={TidyFlags.skillsExpanded.prop}
       />
-      {#if !SettingsProvider.settings.moveTraitsBelowCharacterResources.get()}
+      {#if !$context.settings.moveTraitsBelowCharacterResources}
         <Traits
-          toggleable={SettingsProvider.settings.toggleEmptyCharacterTraits.get()}
+          toggleable={$context.settings.toggleEmptyCharacterTraits}
         />
       {/if}
     </section>
@@ -75,9 +74,9 @@
       {#if showResources}
         <Resources />
       {/if}
-      {#if SettingsProvider.settings.moveTraitsBelowCharacterResources.get()}
+      {#if $context.settings.moveTraitsBelowCharacterResources}
         <Traits
-          toggleable={SettingsProvider.settings.toggleEmptyCharacterTraits.get()}
+          toggleable={$context.settings.toggleEmptyCharacterTraits}
         />
       {/if}
       <Favorites {searchCriteria} />

--- a/src/sheets/character/tabs/CharacterEffectsTab.svelte
+++ b/src/sheets/character/tabs/CharacterEffectsTab.svelte
@@ -22,7 +22,6 @@
   import ActorEffectToggleControl from 'src/components/item-list/controls/ActorEffectToggleControl.svelte';
   import EffectFavoriteControl from 'src/components/item-list/controls/EffectFavoriteControl.svelte';
   import InlineFavoriteIcon from 'src/components/item-list/InlineFavoriteIcon.svelte';
-  import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<ActorSheetContextV1>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -158,7 +157,7 @@
                       >{effectContext.name}</span
                     >
                   </ItemTableCell>
-                  {#if FoundryAdapter.isActiveEffectContextFavorited(effectContext, $context.actor) && SettingsProvider.settings.showIconsNextToTheItemName.get()}
+                  {#if FoundryAdapter.isActiveEffectContextFavorited(effectContext, $context.actor) && $context.settings.showIconsNextToTheItemName}
                     <InlineFavoriteIcon />
                   {/if}
                   <ItemTableCell baseWidth="12.5rem">

--- a/src/sheets/character/tabs/CharacterEffectsTab.svelte
+++ b/src/sheets/character/tabs/CharacterEffectsTab.svelte
@@ -22,7 +22,7 @@
   import ActorEffectToggleControl from 'src/components/item-list/controls/ActorEffectToggleControl.svelte';
   import EffectFavoriteControl from 'src/components/item-list/controls/EffectFavoriteControl.svelte';
   import InlineFavoriteIcon from 'src/components/item-list/InlineFavoriteIcon.svelte';
-  import { settingStore } from 'src/settings/settings';
+  import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<ActorSheetContextV1>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -158,7 +158,7 @@
                       >{effectContext.name}</span
                     >
                   </ItemTableCell>
-                  {#if FoundryAdapter.isActiveEffectContextFavorited(effectContext, $context.actor) && $settingStore.showIconsNextToTheItemName}
+                  {#if FoundryAdapter.isActiveEffectContextFavorited(effectContext, $context.actor) && SettingsProvider.settings.showIconsNextToTheItemName.get()}
                     <InlineFavoriteIcon />
                   {/if}
                   <ItemTableCell baseWidth="12.5rem">

--- a/src/sheets/character/tabs/CharacterFeaturesTab.svelte
+++ b/src/sheets/character/tabs/CharacterFeaturesTab.svelte
@@ -220,7 +220,7 @@
                     </ItemName>
                   </ItemTableCell>
                   <!-- TODO: Handle more gracefully; it is sitting outside of any table cell -->
-                  {#if SettingsProvider.settings.showIconsNextToTheItemName.get() && 'favoriteId' in ctx && !!ctx.favoriteId}
+                  {#if $context.settings.showIconsNextToTheItemName && 'favoriteId' in ctx && !!ctx.favoriteId}
                     <InlineFavoriteIcon />
                   {/if}
                   {#if section.showUsesColumn}

--- a/src/sheets/character/tabs/CharacterFeaturesTab.svelte
+++ b/src/sheets/character/tabs/CharacterFeaturesTab.svelte
@@ -23,7 +23,6 @@
   import { getContext, setContext } from 'svelte';
   import { writable, type Readable } from 'svelte/store';
   import Notice from '../../../components/notice/Notice.svelte';
-  import { settingStore } from 'src/settings/settings';
   import RechargeControl from 'src/components/item-list/controls/RechargeControl.svelte';
   import ActionFilterOverrideControl from 'src/components/item-list/controls/ActionFilterOverrideControl.svelte';
   import { declareLocation } from 'src/types/location-awareness.types';
@@ -40,6 +39,7 @@
   import { SheetSections } from 'src/features/sections/SheetSections';
   import { SheetPreferencesService } from 'src/features/user-preferences/SheetPreferencesService';
   import { ItemVisibility } from 'src/features/sections/ItemVisibility';
+    import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<CharacterSheetContext>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -220,7 +220,7 @@
                     </ItemName>
                   </ItemTableCell>
                   <!-- TODO: Handle more gracefully; it is sitting outside of any table cell -->
-                  {#if $settingStore.showIconsNextToTheItemName && 'favoriteId' in ctx && !!ctx.favoriteId}
+                  {#if SettingsProvider.settings.showIconsNextToTheItemName.get() && 'favoriteId' in ctx && !!ctx.favoriteId}
                     <InlineFavoriteIcon />
                   {/if}
                   {#if section.showUsesColumn}

--- a/src/sheets/character/tabs/CharacterSpellbookTab.svelte
+++ b/src/sheets/character/tabs/CharacterSpellbookTab.svelte
@@ -26,7 +26,6 @@
   import ButtonMenu from 'src/components/button-menu/ButtonMenu.svelte';
   import ButtonMenuCommand from 'src/components/button-menu/ButtonMenuCommand.svelte';
   import SpellSourceClassAssignmentsFormApplication from 'src/applications/spell-source-class-assignments/SpellSourceClassAssignmentsFormApplication';
-  import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<CharacterSheetContext>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -62,7 +61,7 @@
 
   function tryFilterByClass(spells: any[]) {
     if (
-      !SettingsProvider.settings.useMulticlassSpellbookFilter.get() ||
+      !$context.settings.useMulticlassSpellbookFilter ||
       selectedClassFilter === ''
     ) {
       return spells;
@@ -89,7 +88,7 @@
 
 <UtilityToolbar>
   <Search bind:value={searchCriteria} />
-  {#if SettingsProvider.settings.useMulticlassSpellbookFilter.get()}
+  {#if $context.settings.useMulticlassSpellbookFilter}
     <div class="spellbook-class-filter">
       <SpellbookClassFilter />
     </div>

--- a/src/sheets/character/tabs/CharacterSpellbookTab.svelte
+++ b/src/sheets/character/tabs/CharacterSpellbookTab.svelte
@@ -13,7 +13,6 @@
   import { writable, type Readable } from 'svelte/store';
   import NoSpells from 'src/sheets/actor/NoSpells.svelte';
   import Notice from '../../../components/notice/Notice.svelte';
-  import { settingStore } from 'src/settings/settings';
   import { CONSTANTS } from 'src/constants';
   import UtilityToolbar from 'src/components/utility-bar/UtilityToolbar.svelte';
   import Search from 'src/components/utility-bar/Search.svelte';
@@ -27,6 +26,7 @@
   import ButtonMenu from 'src/components/button-menu/ButtonMenu.svelte';
   import ButtonMenuCommand from 'src/components/button-menu/ButtonMenuCommand.svelte';
   import SpellSourceClassAssignmentsFormApplication from 'src/applications/spell-source-class-assignments/SpellSourceClassAssignmentsFormApplication';
+  import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<CharacterSheetContext>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -62,7 +62,7 @@
 
   function tryFilterByClass(spells: any[]) {
     if (
-      !$settingStore.useMulticlassSpellbookFilter ||
+      !SettingsProvider.settings.useMulticlassSpellbookFilter.get() ||
       selectedClassFilter === ''
     ) {
       return spells;
@@ -89,7 +89,7 @@
 
 <UtilityToolbar>
   <Search bind:value={searchCriteria} />
-  {#if $settingStore.useMulticlassSpellbookFilter}
+  {#if SettingsProvider.settings.useMulticlassSpellbookFilter.get()}
     <div class="spellbook-class-filter">
       <SpellbookClassFilter />
     </div>

--- a/src/sheets/container/InlineContainerToggle.svelte
+++ b/src/sheets/container/InlineContainerToggle.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { CONSTANTS } from 'src/constants';
   import type { InlineContainerToggleService } from 'src/features/containers/InlineContainerToggleService';
-  import { settingStore } from 'src/settings/settings';
   import type { Item5e } from 'src/types/item.types';
   import { getContext } from 'svelte';
 
@@ -14,11 +13,12 @@
   $: inlineContainerToggleServiceStore = inlineContainerToggleService.store;
 </script>
 
-<button
-  type="button"
-  class="inline-container-toggle inline-transparent-button"
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y-missing-attribute -->
+<a
+  class="inline-container-toggle inline-transparent-button inline-flex-row align-items-center"
   on:click={() => inlineContainerToggleService.toggle(tabId, item.id)}
-  tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
   data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.INLINE_CONTAINER_TOGGLE}
 >
   {#if $inlineContainerToggleServiceStore.get(tabId)?.has(item.id)}
@@ -26,4 +26,4 @@
   {:else}
     <i class="fa-solid fa-box fa-fw {iconClass}" />
   {/if}
-</button>
+</a>

--- a/src/sheets/group/GroupSheet.scss
+++ b/src/sheets/group/GroupSheet.scss
@@ -17,10 +17,16 @@
   gap: 0.25rem;
   margin: 0;
 
-  button {
+  .group-action-button {
     padding: 0.25rem;
     line-height: 1;
     border: 1px solid var(--t5e-faint-color);
+    border-radius: 0.25rem;
+    background: var(--t5e-faint-color);
+
+    &:hover {
+      background: var(--t5e-light-color);
+    }
   }
 }
 

--- a/src/sheets/group/GroupSheet.svelte
+++ b/src/sheets/group/GroupSheet.svelte
@@ -9,7 +9,6 @@
   import Select from 'src/components/inputs/Select.svelte';
   import SelectOptions from 'src/components/inputs/SelectOptions.svelte';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import ActorProfile from '../actor/ActorProfile.svelte';
   import ActorMovement from '../actor/ActorMovement.svelte';
   import HorizontalLineSeparator from 'src/components/layout/HorizontalLineSeparator.svelte';
@@ -121,42 +120,46 @@
     <HorizontalLineSeparator class="header-line-margin-left" />
     {#if $context.isGM}
       <div class="group-commands">
-        <button
-          type="button"
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
+        <!-- svelte-ignore a11y-missing-attribute -->
+        <a
           class="group-action-button flex-row small-gap flex-grow-0 flex-basis-max-content"
           on:click={() => $context.actor.sheet.award()}
-          tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
         >
           <i class="fa-solid fa-trophy"></i>
           {localize('DND5E.Award.Action')}
-        </button>
-        <button
-          type="button"
+        </a>
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
+        <!-- svelte-ignore a11y-missing-attribute -->
+        <a
           class="group-action-button flex-row small-gap flex-grow-0 flex-basis-max-content"
           on:click={() => $context.actor.system.placeMembers()}
-          tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
         >
           <i class="fa-solid fa-location-dot"></i>
           {localize('DND5E.Group.PlaceMembers')}
-        </button>
-        <button
-          type="button"
+        </a>
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
+        <!-- svelte-ignore a11y-missing-attribute -->
+        <a
           class="group-action-button flex-row small-gap rest-button flex-grow-0 flex-basis-max-content"
           on:click={() => $context.actor.shortRest({ advanceTime: true })}
-          tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
         >
           <i class="fa-solid fa-utensils"></i>
           {localize('DND5E.ShortRest')}
-        </button>
-        <button
-          type="button"
+        </a>
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
+        <!-- svelte-ignore a11y-missing-attribute -->
+        <a
           class="group-action-button flex-row small-gap rest-button flex-grow-0 flex-basis-max-content"
           on:click={() => $context.actor.longRest({ advanceTime: true })}
-          tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
         >
           <i class="fa-solid fa-campground"></i>
           {localize('DND5E.LongRest')}
-        </button>
+        </a>
       </div>
     {/if}
   </div>

--- a/src/sheets/group/parts/EncounterMemberList.svelte
+++ b/src/sheets/group/parts/EncounterMemberList.svelte
@@ -15,7 +15,6 @@
   import TidyTableCell from 'src/components/table/TidyTableCell.svelte';
   import TidyTableRow from 'src/components/table/TidyTableRow.svelte';
   import TextInput from 'src/components/inputs/TextInput.svelte';
-  import { settingStore } from 'src/settings/settings';
 
   export let section: GroupMemberSection;
 
@@ -86,15 +85,16 @@
         </TidyTableHeaderCell>
         <TidyTableHeaderCell>
           <span>{localize('DND5E.QuantityAbbr')}</span>&nbsp;
-          <button
-            type="button"
+          <!-- svelte-ignore a11y-click-events-have-key-events -->
+          <!-- svelte-ignore a11y-no-static-element-interactions -->
+          <!-- svelte-ignore a11y-missing-attribute -->
+          <a
             class="inline-icon-button"
             title={localize('DND5E.QuantityRoll')}
             on:click={() => $context.actor.system.rollQuantities()}
-            tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
           >
             <i class="fas fa-dice"></i>
-          </button>
+          </a>
         </TidyTableHeaderCell>
         <TidyTableHeaderCell>
           <!-- Formula -->
@@ -123,19 +123,20 @@
               }}
             >
               <TidyTableCell class="flex-row small-gap" primary={true}>
-                <button
-                  type="button"
+                <!-- svelte-ignore a11y-click-events-have-key-events -->
+                <!-- svelte-ignore a11y-no-static-element-interactions -->
+                <!-- svelte-ignore a11y-missing-attribute -->
+
+                <a
                   class="inline-transparent-button"
-                  disabled={!ctx.canObserve}
                   on:click={() =>
-                    FoundryAdapter.renderImagePopout(member.img, {
+                    ctx.canObserve && FoundryAdapter.renderImagePopout(member.img, {
                       title: FoundryAdapter.localize('TIDY5E.PortraitTitle', {
                         subject: member.name,
                       }),
                       shareable: true,
                       uuid: member.uuid,
                     })}
-                  tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
                 >
                   <img
                     class="encounter-member-list-item-image"
@@ -144,15 +145,17 @@
                     data-tidy-sheet-part={CONSTANTS.SHEET_PARTS
                       .GROUP_MEMBER_PORTRAIT}
                   />
-                </button>
-                <button
-                  type="button"
+                </a>
+                <!-- svelte-ignore a11y-click-events-have-key-events -->
+                <!-- svelte-ignore a11y-no-static-element-interactions -->
+                <!-- svelte-ignore a11y-missing-attribute -->
+
+                <a
                   class="encounter-member-name transparent-button highlight-on-hover"
                   on:click={() => member.sheet.render(true)}
-                  tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
                 >
                   {member.name}
-                </button>
+                </a>
               </TidyTableCell>
               <TidyTableCell>
                 <TextInput

--- a/src/sheets/group/parts/GroupHitPoints.svelte
+++ b/src/sheets/group/parts/GroupHitPoints.svelte
@@ -7,7 +7,6 @@
   import HpBar from 'src/components/bar/HpBar.svelte';
   import ResourceWithBar from 'src/components/bar/ResourceWithBar.svelte';
   import { CONSTANTS } from 'src/constants';
-  import { SettingsProvider } from 'src/settings/settings';
 
   export let value: number;
   export let max: number;
@@ -38,6 +37,6 @@
     maxTitle={null}
     maxDisabled={true}
     percentage={$context.healthPercentage}
-    Bar={SettingsProvider.settings.useHpBar.get() ? HpBar : null}
+    Bar={$context.settings.useHpBar ? HpBar : null}
   />
 </div>

--- a/src/sheets/group/parts/GroupHitPoints.svelte
+++ b/src/sheets/group/parts/GroupHitPoints.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
   import { type Actor5e } from 'src/types/types';
-  import { settingStore } from 'src/settings/settings';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
   import type { CharacterSheetContext } from 'src/types/types';
   import HpBar from 'src/components/bar/HpBar.svelte';
   import ResourceWithBar from 'src/components/bar/ResourceWithBar.svelte';
   import { CONSTANTS } from 'src/constants';
+  import { SettingsProvider } from 'src/settings/settings';
 
   export let value: number;
   export let max: number;
@@ -38,6 +38,6 @@
     maxTitle={null}
     maxDisabled={true}
     percentage={$context.healthPercentage}
-    Bar={$settingStore.useHpBar ? HpBar : null}
+    Bar={SettingsProvider.settings.useHpBar.get() ? HpBar : null}
   />
 </div>

--- a/src/sheets/group/parts/GroupMemberListItem.svelte
+++ b/src/sheets/group/parts/GroupMemberListItem.svelte
@@ -11,8 +11,6 @@
   import { CONSTANTS } from 'src/constants';
   import GroupMemberListItemProfile from './GroupMemberListItemProfile.svelte';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
-  import { formatAsModifier } from 'src/utils/formatting';
 
   const context = getContext<Readable<GroupSheetClassicContext>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -25,7 +23,7 @@
 
   function onPerceptionClicked(
     event: MouseEvent & {
-      currentTarget: EventTarget & HTMLButtonElement;
+      currentTarget: EventTarget & HTMLElement;
     },
   ) {
     if (ctx.perception) {
@@ -49,15 +47,15 @@
     <div
       class="flex-row small-gap align-items-center justify-content-space-between"
     >
-      <button
-        type="button"
+      <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <!-- svelte-ignore a11y-no-static-element-interactions -->
+      <!-- svelte-ignore a11y-missing-attribute -->
+      <a
         class="inline-transparent-button highlight-on-hover ff-title fs-lg"
-        on:click={() => member.sheet.render(true)}
-        disabled={!ctx.canObserve}
-        tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
+        on:click={() => ctx.canObserve && member.sheet.render(true)}
       >
         {member.name}
-      </button>
+      </a>
       {#if $context.unlocked}
         <RemoveMemberControl {member} />
       {/if}
@@ -102,16 +100,16 @@
 
       <div class="flex-row flex-wrap skills">
         {#if ctx.perception}
-          <button
-            type="button"
+          <!-- svelte-ignore a11y-click-events-have-key-events -->
+          <!-- svelte-ignore a11y-no-static-element-interactions -->
+          <!-- svelte-ignore a11y-missing-attribute -->
+          <a
             class="skill"
-            disabled={!$context.isGM}
-            on:click={(event) => onPerceptionClicked(event)}
-            tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
+            on:click={(event) => $context.isGM && onPerceptionClicked(event)}
           >
             {localize(ctx.perception?.label ?? '')}
             {ctx.perception?.formattedTotal} ({ctx.perception?.passive})
-          </button>
+          </a>
         {/if}
         {#each ctx.topSkills as skill (skill.key)}
           <span class="skill">

--- a/src/sheets/group/parts/GroupMemberListItemProfile.svelte
+++ b/src/sheets/group/parts/GroupMemberListItemProfile.svelte
@@ -3,7 +3,6 @@
   import ResourceWithBar from 'src/components/bar/ResourceWithBar.svelte';
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import type { Actor5e } from 'src/types/types';
   import { getPercentage } from 'src/utils/numbers';
 
@@ -14,9 +13,11 @@
 </script>
 
 <div role="presentation" class="member-list-item-image-wrapper">
-  <button
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <!-- svelte-ignore a11y-missing-attribute -->
+  <a
     class="transparent-button"
-    type="button"
     on:click={() =>
       FoundryAdapter.renderImagePopout(member.img, {
         title: FoundryAdapter.localize('TIDY5E.PortraitTitle', {
@@ -25,7 +26,6 @@
         shareable: true,
         uuid: member.uuid,
       })}
-    tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
   >
     <img
       class="member-list-item-image"
@@ -33,7 +33,7 @@
       alt={member.name}
       data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.GROUP_MEMBER_PORTRAIT}
     />
-  </button>
+  </a>
 
   {#if showHp}
     <div class="member-list-item-hp-bar">

--- a/src/sheets/group/parts/RemoveMemberControl.svelte
+++ b/src/sheets/group/parts/RemoveMemberControl.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import type { GroupSheetClassicContext } from 'src/types/group.types';
   import type { Actor5e } from 'src/types/types';
   import { getContext } from 'svelte';
@@ -16,12 +15,13 @@
   const localize = FoundryAdapter.localize;
 </script>
 
-<button
-  type="button"
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y-missing-attribute -->
+<a
   class="inline-icon-button"
   on:click={() => $context.actor.system.removeMember(member.id)}
   title={localize('TIDY5E.Group.RemoveMemberFromGroup')}
-  tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
 >
   <i class="fas fa-xmark"></i>
-</button>
+</a>

--- a/src/sheets/item/parts/ItemAction.svelte
+++ b/src/sheets/item/parts/ItemAction.svelte
@@ -9,7 +9,6 @@
   import ItemFormGroup from '../form/ItemFormGroup.svelte';
   import TextInput from 'src/components/inputs/TextInput.svelte';
   import { CONSTANTS } from 'src/constants';
-  import { settingStore } from 'src/settings/settings';
   import Checkbox from 'src/components/inputs/Checkbox.svelte';
 
   let context = getContext<Readable<ItemSheetContext>>(
@@ -162,16 +161,17 @@
       {localize('DND5E.Damage')}
     {/if}
     {localize('DND5E.Formula')}
-    <button
-      type="button"
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
       class="damage-formula-control add-damage"
-      on:click={() => addDamageFormula()}
-      disabled={!$context.editable || damageIsEnchanted}
-      tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
+      on:click={() =>
+        $context.editable && !damageIsEnchanted && addDamageFormula()}
       data-tooltip={enchantedTooltip}
     >
       <i class="fas fa-plus" />
-    </button>
+    </a>
   </h4>
   {#if damageParts?.length}
     <ol class="damage-parts form-group">
@@ -216,18 +216,19 @@
               />
             </optgroup>
           </select>
-          <button
-            type="button"
+          <!-- svelte-ignore a11y-click-events-have-key-events -->
+          <!-- svelte-ignore a11y-no-static-element-interactions -->
+          <!-- svelte-ignore a11y-missing-attribute -->
+          <a
             class="damage-formula-control delete-damage"
-            on:click={() => deleteDamageFormula(i)}
-            disabled={!$context.editable || damageIsEnchanted}
+            on:click={() =>
+              $context.editable && !damageIsEnchanted && deleteDamageFormula(i)}
             data-tidy-sheet-part={CONSTANTS.SHEET_PARTS
               .DAMAGE_PART_DELETE_COMMAND}
-            tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
             data-tooltip={enchantedTooltip}
           >
             <i class="fas fa-minus" />
-          </button>
+          </a>
         </li>
       {/each}
     </ol>
@@ -398,16 +399,16 @@
           role="presentation"
           class="summon-controls flex-row justify-content-space-between flex-wrap extra-small-row-gap"
         >
-          <button
+          <!-- svelte-ignore a11y-click-events-have-key-events -->
+          <!-- svelte-ignore a11y-no-static-element-interactions -->
+          <a
             id={inputId}
-            type="button"
-            class="inline-transparent-button no-wrap highlight-on-hover"
-            tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
+            class="inline-transparent-button no-wrap highlight-on-hover inline-flex-row align-items-center"
             on:click={() => FoundryAdapter.openSummonConfig($context.item)}
           >
             <i class="fa-solid fa-gear" aria-hidden="true"></i>
             {localize('DND5E.Summoning.Action.Configure')}
-          </button>
+          </a>
 
           <Checkbox
             document={$context.item}

--- a/src/sheets/item/parts/ItemDescriptions.svelte
+++ b/src/sheets/item/parts/ItemDescriptions.svelte
@@ -4,7 +4,6 @@
   import type { Readable } from 'svelte/store';
   import Accordion from 'src/components/accordion/Accordion.svelte';
   import AccordionItem from 'src/components/accordion/AccordionItem.svelte';
-  import { settingStore } from 'src/settings/settings';
   import { CONSTANTS } from 'src/constants';
 
   /**
@@ -55,18 +54,18 @@
                 {itemDescription.label}
 
                 {#if $context.editable}
-                  <button
-                    type="button"
+                  <!-- svelte-ignore a11y-click-events-have-key-events -->
+                  <!-- svelte-ignore a11y-no-static-element-interactions -->
+                  <!-- svelte-ignore a11y-missing-attribute -->
+                  <a
                     class="inline-icon-button edit-item-description"
                     on:click|stopPropagation={() =>
                       dispatcher('edit', {
                         valueToEdit: itemDescription.content,
                         fieldToEdit: itemDescription.field,
                       })}
-                    tabindex={$settingStore.useAccessibleKeyboardSupport
-                      ? 0
-                      : -1}><i class="fas fa-edit" /></button
-                  >
+                    ><i class="fas fa-edit" />
+                  </a>
                 {/if}
               </span>
               <div

--- a/src/sheets/item/tabs/ItemActiveEffectsTab.svelte
+++ b/src/sheets/item/tabs/ItemActiveEffectsTab.svelte
@@ -2,7 +2,6 @@
   import ContentConcealer from 'src/components/content-concealment/ContentConcealer.svelte';
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import type { ItemSheetContext } from 'src/types/item.types';
   import type { CharacterSheetContext } from 'src/types/types';
   import { getContext } from 'svelte';
@@ -52,16 +51,17 @@
           <div class="effect-source">{localize('DND5E.Duration')}</div>
           <div class="item-controls active-effect-controls flexrow">
             {#if $context.editable}
-              <button
-                type="button"
+              <!-- svelte-ignore a11y-click-events-have-key-events -->
+              <!-- svelte-ignore a11y-no-static-element-interactions -->
+              <!-- svelte-ignore a11y-missing-attribute -->
+              <a
                 class="active-effect-control inline-icon-button"
                 title={localize('DND5E.EffectCreate')}
                 on:click={(event) => onAddClicked(section)}
-                tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
               >
                 <i class="fas fa-plus" />
                 {localize('DND5E.Add')}
-              </button>
+              </a>
             {/if}
           </div>
         </li>
@@ -110,47 +110,44 @@
               <div class="item-controls active-effect-controls flexrow">
                 {#if $context.editable}
                   {#if section.type !== 'enchantment'}
-                    <button
-                      type="button"
+                    <!-- svelte-ignore a11y-click-events-have-key-events -->
+                    <!-- svelte-ignore a11y-no-static-element-interactions -->
+                    <!-- svelte-ignore a11y-missing-attribute -->
+                    <a
                       class="active-effect-control inline-transparent-button"
                       title={effect.disabled
-                        ? 'DND5E.EffectEnable'
-                        : 'DND5E.EffectDisable'}
+                        ? localize('DND5E.EffectEnable')
+                        : localize('DND5E.EffectDisable')}
                       on:click={() =>
                         effect.update({ disabled: !effect.disabled })}
-                      tabindex={$settingStore.useAccessibleKeyboardSupport
-                        ? 0
-                        : -1}
                     >
                       <i
                         class="fas"
                         class:fa-check={effect.disabled}
                         class:fa-times={!effect.disabled}
                       />
-                    </button>
+                    </a>
                   {/if}
-                  <button
-                    type="button"
+                  <!-- svelte-ignore a11y-click-events-have-key-events -->
+                  <!-- svelte-ignore a11y-no-static-element-interactions -->
+                  <!-- svelte-ignore a11y-missing-attribute -->
+                  <a
                     class="active-effect-control inline-transparent-button"
                     title={localize('DND5E.EffectEdit')}
                     on:click={() => effect.sheet.render(true)}
-                    tabindex={$settingStore.useAccessibleKeyboardSupport
-                      ? 0
-                      : -1}
                   >
                     <i class="fas fa-edit" />
-                  </button>
-                  <button
-                    type="button"
+                  </a>
+                  <!-- svelte-ignore a11y-click-events-have-key-events -->
+                  <!-- svelte-ignore a11y-no-static-element-interactions -->
+                  <!-- svelte-ignore a11y-missing-attribute -->
+                  <a
                     class="active-effect-control inline-transparent-button"
                     title={localize('DND5E.EffectDelete')}
                     on:click={() => effect.deleteDialog()}
-                    tabindex={$settingStore.useAccessibleKeyboardSupport
-                      ? 0
-                      : -1}
                   >
                     <i class="fas fa-trash" />
-                  </button>
+                  </a>
                 {/if}
               </div>
             </li>

--- a/src/sheets/item/tabs/ItemAdvancementTab.svelte
+++ b/src/sheets/item/tabs/ItemAdvancementTab.svelte
@@ -2,7 +2,6 @@
   import InlineSvg from 'src/components/utility/InlineSvg.svelte';
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import type { Item5e, ItemSheetContext } from 'src/types/item.types';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
@@ -48,11 +47,13 @@
     >
       <div class="item-controls configuration-mode-control">
         {#if $context.editable && $context.isEmbedded}
-          <button
+          <!-- svelte-ignore a11y-click-events-have-key-events -->
+          <!-- svelte-ignore a11y-no-static-element-interactions -->
+          <!-- svelte-ignore a11y-missing-attribute -->
+          <a
             class="inline-icon-button"
             on:click={() => toggleAdvancementLock($context.item)}
             title={localize('DND5E.AdvancementConfigurationActionDisable')}
-            tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
           >
             {#if $context.advancementEditable}
               <i class="fas fa-lock-open" />
@@ -61,23 +62,24 @@
               <i class="fas fa-lock" />
               {localize('DND5E.AdvancementConfigurationModeDisabled')}
             {/if}
-          </button>
+          </a>
         {/if}
       </div>
       {#if $context.editable && $context.advancementEditable}
         <div class="item-controls add-button">
-          <button
-            type="button"
+          <!-- svelte-ignore a11y-click-events-have-key-events -->
+          <!-- svelte-ignore a11y-no-static-element-interactions -->
+          <!-- svelte-ignore a11y-missing-attribute -->
+          <a
             class="inline-icon-button"
             title={localize('DND5E.AdvancementControlCreate')}
             aria-label={localize('DND5E.AdvancementControlCreate')}
             on:click={() =>
               FoundryAdapter.createAdvancementSelectionDialog($context.item)}
-            tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
           >
             <i class="fas fa-plus" />
             {localize('DND5E.Add')}
-          </button>
+          </a>
         </div>
       {:else}
         <div role="presentation" />
@@ -99,15 +101,16 @@
 
       {#if $context.editable && data.configured && level !== 'unconfigured'}
         <div>
-          <button
-            type="button"
+          <!-- svelte-ignore a11y-click-events-have-key-events -->
+          <!-- svelte-ignore a11y-no-static-element-interactions -->
+          <!-- svelte-ignore a11y-missing-attribute -->
+          <a
             class="inline-transparent-button"
             on:click={() =>
               FoundryAdapter.modifyAdvancementChoices(level, $context.item)}
-            tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
           >
             {localize('DND5E.AdvancementModifyChoices')}
-          </button>
+          </a>
         </div>
       {/if}
 
@@ -157,19 +160,22 @@
           {/if}
           {#if $context.editable && $context.advancementEditable}
             <div class="item-controls flexrow">
-              <button
-                type="button"
+              <!-- svelte-ignore a11y-click-events-have-key-events -->
+              <!-- svelte-ignore a11y-no-static-element-interactions -->
+              <!-- svelte-ignore a11y-missing-attribute -->
+              <a
                 class="inline-icon-button"
                 title={localize('DND5E.AdvancementControlEdit')}
                 aria-label={localize('DND5E.AdvancementControlEdit')}
                 on:click={() =>
                   FoundryAdapter.editAdvancement(advancement.id, $context.item)}
-                tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
               >
                 <i class="fas fa-edit" />
-              </button>
-              <button
-                type="button"
+              </a>
+              <!-- svelte-ignore a11y-click-events-have-key-events -->
+              <!-- svelte-ignore a11y-no-static-element-interactions -->
+              <!-- svelte-ignore a11y-missing-attribute -->
+              <a
                 class="inline-icon-button"
                 title={localize('DND5E.AdvancementControlDelete')}
                 aria-label={localize('DND5E.AdvancementControlDelete')}
@@ -178,10 +184,9 @@
                     advancement.id,
                     $context.item,
                   )}
-                tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
               >
                 <i class="fas fa-trash" />
-              </button>
+              </a>
             </div>
           {/if}
           {#if advancement.summary}

--- a/src/sheets/item/tabs/ItemRaceDescriptionTab.svelte
+++ b/src/sheets/item/tabs/ItemRaceDescriptionTab.svelte
@@ -5,7 +5,6 @@
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
   import ItemDescription from './ItemDescriptionTab.svelte';
-  import { settingStore } from 'src/settings/settings';
   import { CONSTANTS } from 'src/constants';
 
   let context = getContext<Readable<ItemSheetContext>>(
@@ -27,14 +26,15 @@
     <h4 class="properties-header flex-row justify-content-space-between">
       {localize('DND5E.Type')}
       {#if $context.editable}
-        <button
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
+        <!-- svelte-ignore a11y-missing-attribute -->
+        <a
           class="inline-icon-button hidden-config-button"
-          type="button"
           on:click={() => FoundryAdapter.renderItemTypeConfig($context.item)}
-          tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
         >
           <i class="fas fa-cog" />
-        </button>
+        </a>
       {/if}
     </h4>
     <ol class="properties-list">
@@ -43,16 +43,17 @@
     <h4 class="properties-header flex-row justify-content-space-between">
       {localize('DND5E.Movement')}
       {#if $context.editable}
-        <button
-          type="button"
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
+        <!-- svelte-ignore a11y-missing-attribute -->
+        <a
           class="inline-icon-button hidden-config-button"
           data-action="movement"
           on:click={() =>
             FoundryAdapter.renderItemMovementConfig($context.item)}
-          tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
         >
           <i class="fas fa-cog" />
-        </button>
+        </a>
       {/if}
     </h4>
     <ol class="properties-list">
@@ -65,15 +66,16 @@
     <h4 class="properties-header flex-row justify-content-space-between">
       {localize('DND5E.Senses')}
       {#if $context.editable}
-        <button
-          type="button"
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
+        <!-- svelte-ignore a11y-missing-attribute -->
+        <a
           class="inline-icon-button hidden-config-button"
           data-action="senses"
           on:click={() => FoundryAdapter.renderItemSensesConfig($context.item)}
-          tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
         >
           <i class="fas fa-cog" />
-        </button>
+        </a>
       {/if}
     </h4>
     <ol class="properties-list">

--- a/src/sheets/npc/NpcSheetFull.svelte
+++ b/src/sheets/npc/NpcSheetFull.svelte
@@ -23,7 +23,6 @@
   import ActorOriginSummaryConfigFormApplication from 'src/applications/actor-origin-summary/ActorOriginSummaryConfigFormApplication';
   import ActorName from '../actor/ActorName.svelte';
   import SpecialSaves from '../actor/SpecialSaves.svelte';
-  import { SettingsProvider } from 'src/settings/settings';
 
   let selectedTabId: string;
 
@@ -48,7 +47,7 @@
   const localize = FoundryAdapter.localize;
 </script>
 
-{#if SettingsProvider.settings.itemCardsForNpcs.get()}
+{#if $context.settings.itemCardsForNpcs}
   <ItemInfoCard />
 {/if}
 
@@ -206,7 +205,7 @@
     <svelte:fragment slot="tab-end">
       {#if $context.editable}
         <SheetEditModeToggle
-          hint={SettingsProvider.settings.permanentlyUnlockNpcSheetForGm.get() &&
+          hint={$context.settings.permanentlyUnlockNpcSheetForGm &&
           FoundryAdapter.userIsGm()
             ? localize('TIDY5E.Settings.PermanentlyUnlockNPCSheetForGM.title')
             : null}

--- a/src/sheets/npc/NpcSheetFull.svelte
+++ b/src/sheets/npc/NpcSheetFull.svelte
@@ -17,13 +17,13 @@
   import ActorHeaderStats from '../actor/ActorHeaderStats.svelte';
   import ItemInfoCard from 'src/components/item-info-card/ItemInfoCard.svelte';
   import SheetMenu from '../actor/SheetMenu.svelte';
-  import { settingStore } from 'src/settings/settings';
   import ActorWarnings from '../actor/ActorWarnings.svelte';
   import InlineSource from '../shared/InlineSource.svelte';
   import InlineCreatureType from '../shared/InlineCreatureType.svelte';
   import ActorOriginSummaryConfigFormApplication from 'src/applications/actor-origin-summary/ActorOriginSummaryConfigFormApplication';
   import ActorName from '../actor/ActorName.svelte';
   import SpecialSaves from '../actor/SpecialSaves.svelte';
+  import { SettingsProvider } from 'src/settings/settings';
 
   let selectedTabId: string;
 
@@ -48,7 +48,7 @@
   const localize = FoundryAdapter.localize;
 </script>
 
-{#if $settingStore.itemCardsForNpcs}
+{#if SettingsProvider.settings.itemCardsForNpcs.get()}
   <ItemInfoCard />
 {/if}
 
@@ -163,18 +163,19 @@
             )}
           </b>
           {#if $context.unlocked}
-            <button
-              type="button"
+            <!-- svelte-ignore a11y-click-events-have-key-events -->
+            <!-- svelte-ignore a11y-no-static-element-interactions -->
+            <!-- svelte-ignore a11y-missing-attribute -->
+            <a
               class="origin-summary-tidy inline-icon-button"
               on:click={() =>
                 new ActorOriginSummaryConfigFormApplication(
                   $context.actor,
                 ).render(true)}
               title={localize('TIDY5E.OriginSummaryConfig')}
-              tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
             >
               <i class="fas fa-cog" />
-            </button>
+            </a>
           {/if}
         </div>
       </div>
@@ -205,7 +206,7 @@
     <svelte:fragment slot="tab-end">
       {#if $context.editable}
         <SheetEditModeToggle
-          hint={$settingStore.permanentlyUnlockNpcSheetForGm &&
+          hint={SettingsProvider.settings.permanentlyUnlockNpcSheetForGm.get() &&
           FoundryAdapter.userIsGm()
             ? localize('TIDY5E.Settings.PermanentlyUnlockNPCSheetForGM.title')
             : null}

--- a/src/sheets/npc/parts/NpcHealthFormulaRoller.svelte
+++ b/src/sheets/npc/parts/NpcHealthFormulaRoller.svelte
@@ -4,7 +4,6 @@
   import { debug } from 'src/utils/logging';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
-  import { settingStore } from 'src/settings/settings';
   import { CONSTANTS } from 'src/constants';
 
   let context = getContext<Readable<NpcSheetContext>>(
@@ -44,21 +43,19 @@
 </script>
 
 <div class="portrait-hp-formula health" title={localize('DND5E.HPFormula')}>
-  <button
-    type="button"
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <!-- svelte-ignore a11y-missing-attribute -->
+  <a
     title="{localize('DND5E.HitDiceRoll')}/{localize(
       'TIDY5E.HitDiceRollAverage',
     )}"
     on:click={rollNpcHp}
     on:contextmenu={calcAverageHitDie}
     class="roll-hp-formula highlight-on-hover"
-    tabindex={!$settingStore.useDefaultSheetHpTabbing &&
-    $settingStore.useAccessibleKeyboardSupport
-      ? 0
-      : -1}
   >
     <i class="fas fa-dice-six" />
-  </button>
+  </a>
 </div>
 
 <style lang="scss">

--- a/src/sheets/npc/parts/NpcHitPoints.svelte
+++ b/src/sheets/npc/parts/NpcHitPoints.svelte
@@ -3,7 +3,6 @@
   import ResourceWithBar from 'src/components/bar/ResourceWithBar.svelte';
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { SettingsProvider } from 'src/settings/settings';
   import type { NpcSheetContext } from 'src/types/types';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
@@ -30,7 +29,7 @@
       $context.lockHpMaxChanges ||
       $context.lockSensitiveFields}
     percentage={$context.healthPercentage}
-    Bar={SettingsProvider.settings.useHpBarNpc.get() ? HpBar : null}
+    Bar={$context.settings.useHpBarNpc ? HpBar : null}
   />
 </div>
 

--- a/src/sheets/npc/parts/NpcHitPoints.svelte
+++ b/src/sheets/npc/parts/NpcHitPoints.svelte
@@ -3,7 +3,7 @@
   import ResourceWithBar from 'src/components/bar/ResourceWithBar.svelte';
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
+  import { SettingsProvider } from 'src/settings/settings';
   import type { NpcSheetContext } from 'src/types/types';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
@@ -30,7 +30,7 @@
       $context.lockHpMaxChanges ||
       $context.lockSensitiveFields}
     percentage={$context.healthPercentage}
-    Bar={$settingStore.useHpBarNpc ? HpBar : null}
+    Bar={SettingsProvider.settings.useHpBarNpc.get() ? HpBar : null}
   />
 </div>
 

--- a/src/sheets/npc/parts/NpcProfile.svelte
+++ b/src/sheets/npc/parts/NpcProfile.svelte
@@ -10,10 +10,10 @@
   import NpcRest from './NpcRest.svelte';
   import NpcHealthFormulaRoller from './NpcHealthFormulaRoller.svelte';
   import ActorProfile from 'src/sheets/actor/ActorProfile.svelte';
-  import { settingStore } from 'src/settings/settings';
   import ExhaustionInput from 'src/sheets/actor/ExhaustionInput.svelte';
   import { ActiveEffectsHelper } from 'src/utils/active-effect';
   import { CONSTANTS } from 'src/constants';
+  import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<NpcSheetContext>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -28,10 +28,15 @@
       'system.attributes.exhaustion': event.detail.level,
     });
   }
+
+  $: exhaustionConfig = SettingsProvider.settings.exhaustionConfig.get();
+
+  $: specificExhaustionConfig =
+    exhaustionConfig?.type === 'specific' ? exhaustionConfig : null;
 </script>
 
-<ActorProfile useHpOverlay={$settingStore.useHpOverlayNpc}>
-  {#if incapacitated && (!$settingStore.hideDeathSavesFromPlayers || FoundryAdapter.userIsGm())}
+<ActorProfile useHpOverlay={SettingsProvider.settings.useHpOverlayNpc.get()}>
+  {#if incapacitated && (!SettingsProvider.settings.hideDeathSavesFromPlayers.get() || FoundryAdapter.userIsGm())}
     <DeathSaves
       successes={$context.system.attributes.death.success}
       failures={$context.system.attributes.death.failure}
@@ -39,21 +44,21 @@
       failuresField="system.attributes.death.failure"
       on:rollDeathSave={(event) =>
         $context.actor.rollDeathSave({ event: event.detail.mouseEvent })}
-      hasHpOverlay={$settingStore.useHpOverlayNpc}
+      hasHpOverlay={SettingsProvider.settings.useHpOverlayNpc.get()}
     />
   {/if}
-  {#if $settingStore.useExhaustion && $settingStore.exhaustionConfig.type === 'specific'}
+  {#if SettingsProvider.settings.useExhaustion.get() && specificExhaustionConfig}
     <ExhaustionTracker
       level={$context.system.attributes.exhaustion}
       radiusClass={$context.useRoundedPortraitStyle ? 'rounded' : 'top-left'}
       on:levelSelected={onLevelSelected}
-      exhaustionConfig={$settingStore.exhaustionConfig}
+      exhaustionConfig={specificExhaustionConfig}
       isActiveEffectApplied={ActiveEffectsHelper.isActiveEffectAppliedToField(
         $context.actor,
         'system.attributes.exhaustion',
       )}
     />
-  {:else if $settingStore.useExhaustion && $settingStore.exhaustionConfig.type === 'open'}
+  {:else if SettingsProvider.settings.useExhaustion.get() && SettingsProvider.settings.exhaustionConfig.get()?.type === 'open'}
     <ExhaustionInput
       level={$context.system.attributes.exhaustion}
       radiusClass={$context.useRoundedPortraitStyle ? 'rounded' : 'top-left'}

--- a/src/sheets/npc/parts/NpcProfile.svelte
+++ b/src/sheets/npc/parts/NpcProfile.svelte
@@ -13,7 +13,6 @@
   import ExhaustionInput from 'src/sheets/actor/ExhaustionInput.svelte';
   import { ActiveEffectsHelper } from 'src/utils/active-effect';
   import { CONSTANTS } from 'src/constants';
-  import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<NpcSheetContext>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -29,14 +28,14 @@
     });
   }
 
-  $: exhaustionConfig = SettingsProvider.settings.exhaustionConfig.get();
+  $: exhaustionConfig = $context.settings.exhaustionConfig;
 
   $: specificExhaustionConfig =
     exhaustionConfig?.type === 'specific' ? exhaustionConfig : null;
 </script>
 
-<ActorProfile useHpOverlay={SettingsProvider.settings.useHpOverlayNpc.get()}>
-  {#if incapacitated && (!SettingsProvider.settings.hideDeathSavesFromPlayers.get() || FoundryAdapter.userIsGm())}
+<ActorProfile useHpOverlay={$context.settings.useHpOverlayNpc}>
+  {#if incapacitated && (!$context.settings.hideDeathSavesFromPlayers || FoundryAdapter.userIsGm())}
     <DeathSaves
       successes={$context.system.attributes.death.success}
       failures={$context.system.attributes.death.failure}
@@ -44,10 +43,10 @@
       failuresField="system.attributes.death.failure"
       on:rollDeathSave={(event) =>
         $context.actor.rollDeathSave({ event: event.detail.mouseEvent })}
-      hasHpOverlay={SettingsProvider.settings.useHpOverlayNpc.get()}
+      hasHpOverlay={$context.settings.useHpOverlayNpc}
     />
   {/if}
-  {#if SettingsProvider.settings.useExhaustion.get() && specificExhaustionConfig}
+  {#if $context.settings.useExhaustion && specificExhaustionConfig}
     <ExhaustionTracker
       level={$context.system.attributes.exhaustion}
       radiusClass={$context.useRoundedPortraitStyle ? 'rounded' : 'top-left'}
@@ -58,7 +57,7 @@
         'system.attributes.exhaustion',
       )}
     />
-  {:else if SettingsProvider.settings.useExhaustion.get() && SettingsProvider.settings.exhaustionConfig.get()?.type === 'open'}
+  {:else if $context.settings.useExhaustion && $context.settings.exhaustionConfig?.type === 'open'}
     <ExhaustionInput
       level={$context.system.attributes.exhaustion}
       radiusClass={$context.useRoundedPortraitStyle ? 'rounded' : 'top-left'}

--- a/src/sheets/npc/parts/NpcRest.svelte
+++ b/src/sheets/npc/parts/NpcRest.svelte
@@ -3,7 +3,6 @@
   import type { NpcSheetContext } from 'src/types/types';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
-  import { settingStore } from 'src/settings/settings';
   import { CONSTANTS } from 'src/constants';
 
   let context = getContext<Readable<NpcSheetContext>>(
@@ -22,32 +21,26 @@
     <span class="resting-icon">
       <i class="rest-icon fas fa-bed" />
     </span>
-    <button
-      type="button"
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
       class="rest short-rest inline-icon-button"
       title={localize('TIDY5E.ShortRest')}
-      on:click={(ev) => $context.shortRest(ev)}
-      disabled={!$context.editable}
-      tabindex={!$settingStore.useDefaultSheetHpTabbing &&
-      $settingStore.useAccessibleKeyboardSupport
-        ? 0
-        : -1}
+      on:click={(ev) => $context.editable && $context.shortRest(ev)}
     >
       <i class="fas fa-hourglass-half" />
-    </button>
-    <button
-      type="button"
+    </a>
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
       class="rest long-rest inline-icon-button"
       title={localize('TIDY5E.LongRest')}
-      on:click={(ev) => $context.longRest(ev)}
-      disabled={!$context.editable}
-      tabindex={!$settingStore.useDefaultSheetHpTabbing &&
-      $settingStore.useAccessibleKeyboardSupport
-        ? 0
-        : -1}
+      on:click={(ev) => $context.editable && $context.longRest(ev)}
     >
       <i class="fas fa-hourglass-end" />
-    </button>
+    </a>
   </div>
 </div>
 

--- a/src/sheets/npc/tabs/NpcAbilitiesTab.svelte
+++ b/src/sheets/npc/tabs/NpcAbilitiesTab.svelte
@@ -56,7 +56,6 @@
   import { SheetPreferencesService } from 'src/features/user-preferences/SheetPreferencesService';
   import { ItemVisibility } from 'src/features/sections/ItemVisibility';
   import InlineContainerView from 'src/sheets/container/InlineContainerView.svelte';
-  import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<NpcSheetContext>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -85,7 +84,7 @@
   const itemIdsToShow = writable<Set<string> | undefined>(undefined);
   setContext(CONSTANTS.SVELTE_CONTEXT.ITEM_IDS_TO_SHOW, itemIdsToShow);
 
-  $: spellbook = !SettingsProvider.settings.showSpellbookTabNpc.get()
+  $: spellbook = !$context.settings.showSpellbookTabNpc
     ? SheetSections.configureSpellbook(
         $context.actor,
         tabId,
@@ -173,13 +172,13 @@
   <div class="side-panel">
     <SkillsList
       actor={$context.actor}
-      toggleable={!SettingsProvider.settings.alwaysShowNpcSkills.get()}
+      toggleable={!$context.settings.alwaysShowNpcSkills}
       expanded={!!TidyFlags.skillsExpanded.get($context.actor)}
       toggleField={TidyFlags.skillsExpanded.prop}
     />
-    {#if !SettingsProvider.settings.moveTraitsBelowNpcResources.get()}
+    {#if !$context.settings.moveTraitsBelowNpcResources}
       <Traits
-        toggleable={!SettingsProvider.settings.alwaysShowNpcTraits.get()}
+        toggleable={!$context.settings.alwaysShowNpcTraits}
       />
     {/if}
   </div>
@@ -195,9 +194,9 @@
     >
       <NpcLegendaryActions />
     </ExpandableContainer>
-    {#if SettingsProvider.settings.moveTraitsBelowNpcResources.get()}
+    {#if $context.settings.moveTraitsBelowNpcResources}
       <Traits
-        toggleable={!SettingsProvider.settings.alwaysShowNpcTraits.get()}
+        toggleable={!$context.settings.alwaysShowNpcTraits}
       />
     {/if}
     {#each features as section (section.key)}
@@ -353,7 +352,7 @@
         {/if}
       {/if}
     {/each}
-    {#if !SettingsProvider.settings.showSpellbookTabNpc.get()}
+    {#if !$context.settings.showSpellbookTabNpc}
       {#if noSpellLevels}
         <h2>
           <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -437,7 +436,7 @@
 </section>
 <TabFooter mode="vertical" cssClass="abilities-footer">
   <Currency document={$context.actor} />
-  {#if SettingsProvider.settings.useNpcEncumbranceBar.get()}
+  {#if $context.settings.useNpcEncumbranceBar}
     <EncumbranceBar />
   {/if}
 </TabFooter>

--- a/src/sheets/npc/tabs/NpcAbilitiesTab.svelte
+++ b/src/sheets/npc/tabs/NpcAbilitiesTab.svelte
@@ -29,7 +29,6 @@
   import SpellbookFooter from 'src/components/spellbook/SpellbookFooter.svelte';
   import ItemFilterLayoutToggle from 'src/components/item-list/ItemFilterLayoutToggle.svelte';
   import SpellbookGrid from 'src/components/spellbook/SpellbookGrid.svelte';
-  import { settingStore } from 'src/settings/settings';
   import EncumbranceBar from '../../actor/EncumbranceBar.svelte';
   import TabFooter from '../../actor/TabFooter.svelte';
   import AmmoSelector from '../../actor/AmmoSelector.svelte';
@@ -57,6 +56,7 @@
   import { SheetPreferencesService } from 'src/features/user-preferences/SheetPreferencesService';
   import { ItemVisibility } from 'src/features/sections/ItemVisibility';
   import InlineContainerView from 'src/sheets/container/InlineContainerView.svelte';
+  import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<NpcSheetContext>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -85,7 +85,7 @@
   const itemIdsToShow = writable<Set<string> | undefined>(undefined);
   setContext(CONSTANTS.SVELTE_CONTEXT.ITEM_IDS_TO_SHOW, itemIdsToShow);
 
-  $: spellbook = !$settingStore.showSpellbookTabNpc
+  $: spellbook = !SettingsProvider.settings.showSpellbookTabNpc.get()
     ? SheetSections.configureSpellbook(
         $context.actor,
         tabId,
@@ -173,12 +173,14 @@
   <div class="side-panel">
     <SkillsList
       actor={$context.actor}
-      toggleable={!$settingStore.alwaysShowNpcSkills}
+      toggleable={!SettingsProvider.settings.alwaysShowNpcSkills.get()}
       expanded={!!TidyFlags.skillsExpanded.get($context.actor)}
       toggleField={TidyFlags.skillsExpanded.prop}
     />
-    {#if !$settingStore.moveTraitsBelowNpcResources}
-      <Traits toggleable={!$settingStore.alwaysShowNpcTraits} />
+    {#if !SettingsProvider.settings.moveTraitsBelowNpcResources.get()}
+      <Traits
+        toggleable={!SettingsProvider.settings.alwaysShowNpcTraits.get()}
+      />
     {/if}
   </div>
   <div
@@ -193,8 +195,10 @@
     >
       <NpcLegendaryActions />
     </ExpandableContainer>
-    {#if $settingStore.moveTraitsBelowNpcResources}
-      <Traits toggleable={!$settingStore.alwaysShowNpcTraits} />
+    {#if SettingsProvider.settings.moveTraitsBelowNpcResources.get()}
+      <Traits
+        toggleable={!SettingsProvider.settings.alwaysShowNpcTraits.get()}
+      />
     {/if}
     {#each features as section (section.key)}
       {#if section.show}
@@ -349,14 +353,15 @@
         {/if}
       {/if}
     {/each}
-    {#if !$settingStore.showSpellbookTabNpc}
+    {#if !SettingsProvider.settings.showSpellbookTabNpc.get()}
       {#if noSpellLevels}
         <h2>
-          <button
-            type="button"
+          <!-- svelte-ignore a11y-click-events-have-key-events -->
+          <!-- svelte-ignore a11y-no-static-element-interactions -->
+          <!-- svelte-ignore a11y-missing-attribute -->
+          <a
             class="transparent-button spellbook-title toggle-spellbook"
             on:click={() => (showNoSpellsView = !showNoSpellsView)}
-            tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
           >
             {localize('DND5E.Spellbook')}
             {#if showNoSpellsView}
@@ -364,7 +369,7 @@
             {:else}
               <i class="fas fa-caret-down" />
             {/if}
-          </button>
+          </a>
         </h2>
       {:else}
         <h2 class="spellbook-title">
@@ -432,7 +437,7 @@
 </section>
 <TabFooter mode="vertical" cssClass="abilities-footer">
   <Currency document={$context.actor} />
-  {#if $settingStore.useNpcEncumbranceBar}
+  {#if SettingsProvider.settings.useNpcEncumbranceBar.get()}
     <EncumbranceBar />
   {/if}
 </TabFooter>

--- a/src/sheets/npc/tabs/NpcBiographyTab.svelte
+++ b/src/sheets/npc/tabs/NpcBiographyTab.svelte
@@ -7,7 +7,6 @@
   import type { Readable } from 'svelte/store';
   import ContentEditableFormField from 'src/components/inputs/ContentEditableFormField.svelte';
   import RerenderAfterFormSubmission from 'src/components/utility/RerenderAfterFormSubmission.svelte';
-  import { settingStore } from 'src/settings/settings';
   import { TidyFlags } from 'src/foundry/TidyFlags';
 
   let context = getContext<Readable<NpcSheetContext>>(
@@ -104,19 +103,20 @@
       </article>
     </div>
     <div class="flex-row extra-small-gap full-height">
-      <button
-        type="button"
+      <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <!-- svelte-ignore a11y-no-static-element-interactions -->
+      <!-- svelte-ignore a11y-missing-attribute -->
+      <a
         on:click={togglePersonalityInfo}
         class="toggle-personality-info"
         title={localize('TIDY5E.TogglePersonalityInfo')}
-        tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
       >
         {#if showNpcPersonalityInfo}
           <i class="fas fa-angle-double-left" />
         {:else}
           <i class="fas fa-angle-double-right" />
         {/if}
-      </button>
+      </a>
       <div class="main-notes">
         {#if showNpcPersonalityInfo}
           <div

--- a/src/sheets/shared/ContainerPanel.svelte
+++ b/src/sheets/shared/ContainerPanel.svelte
@@ -5,16 +5,20 @@
   } from 'src/types/types';
   import CapacityBar from '../container/CapacityBar.svelte';
   import { CONSTANTS } from 'src/constants';
-  import type { Writable } from 'svelte/store';
+  import type { Readable, Writable } from 'svelte/store';
   import { getContext } from 'svelte';
   import type { Item5e } from 'src/types/item.types';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
   import { coalesce } from 'src/utils/formatting';
   import { TidyHooks } from 'src/foundry/TidyHooks';
-  import { SettingsProvider } from 'src/settings/settings';
+  import type { CurrentSettings } from 'src/settings/settings';
 
   export let containerPanelItems: ContainerPanelItemContext[] = [];
   export let searchCriteria: string = '';
+
+  let context = getContext<Readable<{ settings: CurrentSettings }>>(
+    CONSTANTS.SVELTE_CONTEXT.CONTEXT,
+  );
 
   $: visibleContainersIdsSubset = FoundryAdapter.searchItems(
     searchCriteria,
@@ -28,10 +32,7 @@
   async function onMouseEnter(event: Event, item: Item5e) {
     TidyHooks.tidy5eSheetsItemHoverOn(event, item);
 
-    if (
-      !item?.getChatData ||
-      !SettingsProvider.settings.itemCardsForAllItems.get()
-    ) {
+    if (!item?.getChatData || !$context.settings.itemCardsForAllItems) {
       return;
     }
 

--- a/src/sheets/shared/ContainerPanel.svelte
+++ b/src/sheets/shared/ContainerPanel.svelte
@@ -8,10 +8,10 @@
   import type { Writable } from 'svelte/store';
   import { getContext } from 'svelte';
   import type { Item5e } from 'src/types/item.types';
-  import { settingStore } from 'src/settings/settings';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
   import { coalesce } from 'src/utils/formatting';
   import { TidyHooks } from 'src/foundry/TidyHooks';
+  import { SettingsProvider } from 'src/settings/settings';
 
   export let containerPanelItems: ContainerPanelItemContext[] = [];
   export let searchCriteria: string = '';
@@ -28,7 +28,10 @@
   async function onMouseEnter(event: Event, item: Item5e) {
     TidyHooks.tidy5eSheetsItemHoverOn(event, item);
 
-    if (!item?.getChatData || !$settingStore.itemCardsForAllItems) {
+    if (
+      !item?.getChatData ||
+      !SettingsProvider.settings.itemCardsForAllItems.get()
+    ) {
       return;
     }
 
@@ -63,6 +66,7 @@
 
 <ul class="containers">
   {#each containerPanelItems as { container, ...capacity } (container.id)}
+    {@const disabled = !FoundryAdapter.userIsGm() && !container.isOwner}
     <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
     <li
       draggable="true"
@@ -80,13 +84,14 @@
       class:hidden={!visibleContainersIdsSubset.has(container.id)}
       aria-hidden={!visibleContainersIdsSubset.has(container.id)}
     >
-      <button
-        type="button"
+      <!-- svelte-ignore a11y-click-events-have-key-events -->
+      <!-- svelte-ignore a11y-no-static-element-interactions -->
+      <!-- svelte-ignore a11y-missing-attribute -->
+      <a
         class="container-image-button transparent-button"
-        on:click={() => container.sheet.render(true)}
+        on:click={() => !disabled && container.sheet.render(true)}
         data-context-menu={CONSTANTS.CONTEXT_MENU_TYPE_ITEMS}
         data-context-menu-document-uuid={container.uuid}
-        disabled={!FoundryAdapter.userIsGm() && !container.isOwner}
       >
         <div
           class="container-image"
@@ -102,7 +107,7 @@
             <i class="fas fa-question" />
           </div>
         </div>
-      </button>
+      </a>
       <CapacityBar
         showLabel={false}
         {container}

--- a/src/sheets/shared/InlineCreatureType.svelte
+++ b/src/sheets/shared/InlineCreatureType.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import { type ActorSheetContextV1 } from 'src/types/types';
   import { coalesce } from 'src/utils/formatting';
   import { getContext } from 'svelte';
@@ -22,15 +21,16 @@
 </script>
 
 {#if $context.editable && ($context.actor.type === 'npc' || $context.system.details?.race?.id)}
-  <button
-    type="button"
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <!-- svelte-ignore a11y-missing-attribute -->
+  <a
     class="configure-creature-type inline-transparent-button highlight-on-hover truncate"
     on:click={() => configFn($context.actor)}
     title={localize('DND5E.CreatureType')}
-    tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
   >
     {text}
-  </button>
+  </a>
 {:else}
   <span
     class="creature-type-label truncate"

--- a/src/sheets/shared/InlineSource.svelte
+++ b/src/sheets/shared/InlineSource.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import { isNil } from 'src/utils/data';
 
   export let document: any;
@@ -14,15 +13,16 @@
 </script>
 
 {#if editable}
-  <button
-    type="button"
-    class="configure-source inline-transparent-button highlight-on-hover truncate"
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <!-- svelte-ignore a11y-missing-attribute -->
+  <a
+    class="configure-source inline-transparent-button highlight-on-hover truncate align-self-center"
     class:placeholder={usePlaceholder}
     on:click={() => FoundryAdapter.renderSourceConfig(document, keyPath)}
-    tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
   >
     {text}
-  </button>
+  </a>
 {:else}
   <span
     class="source-label truncate"

--- a/src/sheets/shared/SheetHeaderEditModeToggle.svelte
+++ b/src/sheets/shared/SheetHeaderEditModeToggle.svelte
@@ -3,10 +3,10 @@
   import { TidyFlags } from 'src/foundry/TidyFlags';
   import TidySwitch from 'src/components/toggle/TidySwitch.svelte';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
   import type { ActorSheetContextV1 } from 'src/types/types';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
+  import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<ActorSheetContextV1>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -18,13 +18,13 @@
 
   $: allowEdit = TidyFlags.allowEdit.get($context.actor);
 
-  $: descriptionVariable = $settingStore.useTotalSheetLock
+  $: descriptionVariable = SettingsProvider.settings.useTotalSheetLock.get()
     ? localize('TIDY5E.SheetLock.Description')
     : localize('TIDY5E.SheetEdit.Description');
-  $: lockHintVariable = $settingStore.useTotalSheetLock
+  $: lockHintVariable = SettingsProvider.settings.useTotalSheetLock.get()
     ? 'TIDY5E.SheetLock.Unlock.Hint'
     : 'TIDY5E.SheetEdit.Enable.Hint';
-  $: unlockHintVariable = $settingStore.useTotalSheetLock
+  $: unlockHintVariable = SettingsProvider.settings.useTotalSheetLock.get()
     ? 'TIDY5E.SheetLock.Lock.Hint'
     : 'TIDY5E.SheetEdit.Disable.Hint';
   $: unlockTitle = localize(unlockHintVariable, {
@@ -40,7 +40,8 @@
 {#if $context.editable}
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div
-    class="header-sheet-edit-mode-toggle {$$restProps.class ?? ''}"
+    class="header-control header-sheet-edit-mode-toggle {$$restProps.class ??
+      ''}"
     data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.SHEET_LOCK_TOGGLE}
     on:dblclick|stopPropagation
   >

--- a/src/sheets/shared/SheetHeaderEditModeToggle.svelte
+++ b/src/sheets/shared/SheetHeaderEditModeToggle.svelte
@@ -6,7 +6,6 @@
   import type { ActorSheetContextV1 } from 'src/types/types';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
-  import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<ActorSheetContextV1>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -18,13 +17,13 @@
 
   $: allowEdit = TidyFlags.allowEdit.get($context.actor);
 
-  $: descriptionVariable = SettingsProvider.settings.useTotalSheetLock.get()
+  $: descriptionVariable = $context.settings.useTotalSheetLock
     ? localize('TIDY5E.SheetLock.Description')
     : localize('TIDY5E.SheetEdit.Description');
-  $: lockHintVariable = SettingsProvider.settings.useTotalSheetLock.get()
+  $: lockHintVariable = $context.settings.useTotalSheetLock
     ? 'TIDY5E.SheetLock.Unlock.Hint'
     : 'TIDY5E.SheetEdit.Enable.Hint';
-  $: unlockHintVariable = SettingsProvider.settings.useTotalSheetLock.get()
+  $: unlockHintVariable = $context.settings.useTotalSheetLock
     ? 'TIDY5E.SheetLock.Lock.Hint'
     : 'TIDY5E.SheetEdit.Disable.Hint';
   $: unlockTitle = localize(unlockHintVariable, {

--- a/src/sheets/shared/Source.svelte
+++ b/src/sheets/shared/Source.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import TextInput from 'src/components/inputs/TextInput.svelte';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
 
   export let document: any;
   export let keyPath: string;
@@ -29,13 +28,14 @@
     >
   {/if}
   {#if editable}
-    <button
-      type="button"
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y-missing-attribute -->
+    <a
       class="inline-icon-button config-button"
       on:click={() => FoundryAdapter.renderSourceConfig(document, keyPath)}
-      tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
-      ><i class="fas fa-cog" /></button
-    >
+      ><i class="fas fa-cog" />
+    </a>
   {/if}
 </div>
 

--- a/src/sheets/shared/ThemeSelectorButtonMenuCommand.svelte
+++ b/src/sheets/shared/ThemeSelectorButtonMenuCommand.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import ButtonMenuItem from 'src/components/button-menu/ButtonMenuItem.svelte';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { SettingsProvider } from 'src/settings/settings';
   import { getCoreThemes } from 'src/theme/theme-reference';
+
+  export let colorScheme: string;
 
   const themes = Object.entries(getCoreThemes(true));
 
@@ -22,7 +23,7 @@
   <select
     id="sheet-menu-{idSuffix}"
     on:change={(ev) => setTheme(ev.currentTarget.value)}
-    value={SettingsProvider.settings.colorScheme.get()}
+    value={colorScheme}
   >
     {#each themes as [key, value]}
       <option value={key}>{localize(value)}</option>

--- a/src/sheets/shared/ThemeSelectorButtonMenuCommand.svelte
+++ b/src/sheets/shared/ThemeSelectorButtonMenuCommand.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import ButtonMenuItem from 'src/components/button-menu/ButtonMenuItem.svelte';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
+  import { SettingsProvider } from 'src/settings/settings';
   import { getCoreThemes } from 'src/theme/theme-reference';
 
   const themes = Object.entries(getCoreThemes(true));
@@ -22,7 +22,7 @@
   <select
     id="sheet-menu-{idSuffix}"
     on:change={(ev) => setTheme(ev.currentTarget.value)}
-    value={$settingStore.colorScheme}
+    value={SettingsProvider.settings.colorScheme.get()}
   >
     {#each themes as [key, value]}
       <option value={key}>{localize(value)}</option>

--- a/src/sheets/vehicle/VehicleSheetFull.svelte
+++ b/src/sheets/vehicle/VehicleSheetFull.svelte
@@ -25,7 +25,6 @@
   import InlineSource from '../shared/InlineSource.svelte';
   import ActorOriginSummaryConfigFormApplication from 'src/applications/actor-origin-summary/ActorOriginSummaryConfigFormApplication';
   import ActorName from '../actor/ActorName.svelte';
-  import { SettingsProvider } from 'src/settings/settings';
 
   let selectedTabId: string;
 
@@ -64,7 +63,7 @@
   const localize = FoundryAdapter.localize;
 </script>
 
-{#if SettingsProvider.settings.itemCardsForNpcs.get()}
+{#if $context.settings.itemCardsForNpcs}
   <ItemInfoCard />
 {/if}
 
@@ -193,7 +192,7 @@
   <svelte:fragment slot="tab-end">
     {#if $context.editable}
       <SheetEditModeToggle
-        hint={SettingsProvider.settings.permanentlyUnlockVehicleSheetForGm.get() &&
+        hint={$context.settings.permanentlyUnlockVehicleSheetForGm &&
         FoundryAdapter.userIsGm()
           ? localize('TIDY5E.Settings.PermanentlyUnlockVehicleSheetForGM.title')
           : null}

--- a/src/sheets/vehicle/VehicleSheetFull.svelte
+++ b/src/sheets/vehicle/VehicleSheetFull.svelte
@@ -21,11 +21,11 @@
   import AttributeBlock from '../actor/AttributeBlock.svelte';
   import ItemInfoCard from 'src/components/item-info-card/ItemInfoCard.svelte';
   import SheetMenu from '../actor/SheetMenu.svelte';
-  import { settingStore } from 'src/settings/settings';
   import ActorWarnings from '../actor/ActorWarnings.svelte';
   import InlineSource from '../shared/InlineSource.svelte';
   import ActorOriginSummaryConfigFormApplication from 'src/applications/actor-origin-summary/ActorOriginSummaryConfigFormApplication';
   import ActorName from '../actor/ActorName.svelte';
+  import { SettingsProvider } from 'src/settings/settings';
 
   let selectedTabId: string;
 
@@ -64,7 +64,7 @@
   const localize = FoundryAdapter.localize;
 </script>
 
-{#if $settingStore.itemCardsForNpcs}
+{#if SettingsProvider.settings.itemCardsForNpcs.get()}
   <ItemInfoCard />
 {/if}
 
@@ -148,18 +148,19 @@
       {/key}
       <div class="flex-row align-items-center extra-small-gap">
         {#if $context.editable && !$context.lockSensitiveFields}
-          <button
-            type="button"
+          <!-- svelte-ignore a11y-click-events-have-key-events -->
+          <!-- svelte-ignore a11y-no-static-element-interactions -->
+          <!-- svelte-ignore a11y-missing-attribute -->
+          <a
             on:click={() =>
               new ActorOriginSummaryConfigFormApplication(
                 $context.actor,
               ).render(true)}
             class="origin-summary-tidy inline-icon-button"
             title={localize('TIDY5E.OriginSummaryConfig')}
-            tabindex={$settingStore.useAccessibleKeyboardSupport ? 0 : -1}
           >
             <i class="fas fa-cog" />
-          </button>
+          </a>
         {/if}
       </div>
     </div>
@@ -192,7 +193,7 @@
   <svelte:fragment slot="tab-end">
     {#if $context.editable}
       <SheetEditModeToggle
-        hint={$settingStore.permanentlyUnlockVehicleSheetForGm &&
+        hint={SettingsProvider.settings.permanentlyUnlockVehicleSheetForGm.get() &&
         FoundryAdapter.userIsGm()
           ? localize('TIDY5E.Settings.PermanentlyUnlockVehicleSheetForGM.title')
           : null}

--- a/src/sheets/vehicle/parts/VehicleHitPoints.svelte
+++ b/src/sheets/vehicle/parts/VehicleHitPoints.svelte
@@ -3,7 +3,6 @@
   import ResourceWithBar from 'src/components/bar/ResourceWithBar.svelte';
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { SettingsProvider } from 'src/settings/settings';
   import type { VehicleSheetContext } from 'src/types/types';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
@@ -29,7 +28,7 @@
       $context.lockHpMaxChanges ||
       $context.lockSensitiveFields}
     percentage={$context.healthPercentage}
-    Bar={SettingsProvider.settings.useHpBarVehicle.get() ? HpBar : null}
+    Bar={$context.settings.useHpBarVehicle ? HpBar : null}
   />
 </div>
 

--- a/src/sheets/vehicle/parts/VehicleHitPoints.svelte
+++ b/src/sheets/vehicle/parts/VehicleHitPoints.svelte
@@ -3,7 +3,7 @@
   import ResourceWithBar from 'src/components/bar/ResourceWithBar.svelte';
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { settingStore } from 'src/settings/settings';
+  import { SettingsProvider } from 'src/settings/settings';
   import type { VehicleSheetContext } from 'src/types/types';
   import { getContext } from 'svelte';
   import type { Readable } from 'svelte/store';
@@ -29,7 +29,7 @@
       $context.lockHpMaxChanges ||
       $context.lockSensitiveFields}
     percentage={$context.healthPercentage}
-    Bar={$settingStore.useHpBarVehicle ? HpBar : null}
+    Bar={SettingsProvider.settings.useHpBarVehicle.get() ? HpBar : null}
   />
 </div>
 

--- a/src/sheets/vehicle/parts/VehicleProfile.svelte
+++ b/src/sheets/vehicle/parts/VehicleProfile.svelte
@@ -7,11 +7,11 @@
   import VehicleDamageAndMishapThresholds from './VehicleDamageAndMishapThresholds.svelte';
   import ExhaustionTracker from 'src/sheets/actor/ExhaustionTracker.svelte';
   import VehicleMovement from './VehicleMovement.svelte';
-  import { settingStore } from 'src/settings/settings';
   import ExhaustionInput from 'src/sheets/actor/ExhaustionInput.svelte';
   import { ActiveEffectsHelper } from 'src/utils/active-effect';
   import { TidyFlags } from 'src/foundry/TidyFlags';
   import { CONSTANTS } from 'src/constants';
+  import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<VehicleSheetContext>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -20,21 +20,27 @@
   function onLevelSelected(event: CustomEvent<{ level: number }>) {
     TidyFlags.setFlag($context.actor, 'exhaustion', event.detail.level);
   }
+
+  $: exhaustionConfig = SettingsProvider.settings.exhaustionConfig.get();
+  $: specificExhaustionConfig =
+    exhaustionConfig?.type === 'specific' ? exhaustionConfig : null;
 </script>
 
-<ActorProfile useHpOverlay={$settingStore.useHpOverlayVehicle}>
-  {#if $settingStore.useExhaustion && $settingStore.vehicleExhaustionConfig.type === 'specific'}
+<ActorProfile
+  useHpOverlay={SettingsProvider.settings.useHpOverlayVehicle.get()}
+>
+  {#if SettingsProvider.settings.useExhaustion.get() && specificExhaustionConfig}
     <ExhaustionTracker
       level={TidyFlags.exhaustion.get($context.actor) ?? 0}
       radiusClass={$context.useRoundedPortraitStyle ? 'rounded' : 'top-left'}
       on:levelSelected={onLevelSelected}
-      exhaustionConfig={$settingStore.vehicleExhaustionConfig}
+      exhaustionConfig={specificExhaustionConfig}
       isActiveEffectApplied={ActiveEffectsHelper.isActiveEffectAppliedToField(
         $context.actor,
         TidyFlags.exhaustion.prop,
       )}
     />
-  {:else if $settingStore.useExhaustion && $settingStore.vehicleExhaustionConfig.type === 'open'}
+  {:else if SettingsProvider.settings.useExhaustion.get() && SettingsProvider.settings.vehicleExhaustionConfig.get().type === 'open'}
     <ExhaustionInput
       level={TidyFlags.exhaustion.get($context.actor) ?? 0}
       radiusClass={$context.useRoundedPortraitStyle ? 'rounded' : 'top-left'}
@@ -45,7 +51,7 @@
       )}
     />
   {/if}
-  {#if $settingStore.useVehicleMotion}
+  {#if SettingsProvider.settings.useVehicleMotion.get()}
     <VehicleMovement
       motion={TidyFlags.motion.get($context.actor) === true}
       radiusClass={$context.useRoundedPortraitStyle ? 'rounded' : 'top-right'}

--- a/src/sheets/vehicle/parts/VehicleProfile.svelte
+++ b/src/sheets/vehicle/parts/VehicleProfile.svelte
@@ -11,7 +11,6 @@
   import { ActiveEffectsHelper } from 'src/utils/active-effect';
   import { TidyFlags } from 'src/foundry/TidyFlags';
   import { CONSTANTS } from 'src/constants';
-  import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<VehicleSheetContext>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -21,15 +20,15 @@
     TidyFlags.setFlag($context.actor, 'exhaustion', event.detail.level);
   }
 
-  $: exhaustionConfig = SettingsProvider.settings.exhaustionConfig.get();
+  $: exhaustionConfig = $context.settings.exhaustionConfig;
   $: specificExhaustionConfig =
     exhaustionConfig?.type === 'specific' ? exhaustionConfig : null;
 </script>
 
 <ActorProfile
-  useHpOverlay={SettingsProvider.settings.useHpOverlayVehicle.get()}
+  useHpOverlay={$context.settings.useHpOverlayVehicle}
 >
-  {#if SettingsProvider.settings.useExhaustion.get() && specificExhaustionConfig}
+  {#if $context.settings.useExhaustion && specificExhaustionConfig}
     <ExhaustionTracker
       level={TidyFlags.exhaustion.get($context.actor) ?? 0}
       radiusClass={$context.useRoundedPortraitStyle ? 'rounded' : 'top-left'}
@@ -40,7 +39,7 @@
         TidyFlags.exhaustion.prop,
       )}
     />
-  {:else if SettingsProvider.settings.useExhaustion.get() && SettingsProvider.settings.vehicleExhaustionConfig.get().type === 'open'}
+  {:else if $context.settings.useExhaustion && $context.settings.vehicleExhaustionConfig.type === 'open'}
     <ExhaustionInput
       level={TidyFlags.exhaustion.get($context.actor) ?? 0}
       radiusClass={$context.useRoundedPortraitStyle ? 'rounded' : 'top-left'}
@@ -51,7 +50,7 @@
       )}
     />
   {/if}
-  {#if SettingsProvider.settings.useVehicleMotion.get()}
+  {#if $context.settings.useVehicleMotion}
     <VehicleMovement
       motion={TidyFlags.motion.get($context.actor) === true}
       radiusClass={$context.useRoundedPortraitStyle ? 'rounded' : 'top-right'}

--- a/src/sheets/vehicle/tabs/VehicleCargoAndCrewTab.svelte
+++ b/src/sheets/vehicle/tabs/VehicleCargoAndCrewTab.svelte
@@ -10,10 +10,10 @@
   import Currency from '../../actor/Currency.svelte';
   import EncumbranceBar from '../../actor/EncumbranceBar.svelte';
   import TabFooter from '../../actor/TabFooter.svelte';
-  import { settingStore } from 'src/settings/settings';
   import CargoList from '../parts/CargoList.svelte';
   import PassengerOrCrewList from '../parts/PassengerOrCrewList.svelte';
   import { CONSTANTS } from 'src/constants';
+  import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<VehicleSheetContext>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -50,7 +50,7 @@
     <Currency document={$context.actor} />
   </div>
 
-  {#if $settingStore.useVehicleEncumbranceBar}
+  {#if SettingsProvider.settings.useVehicleEncumbranceBar.get()}
     <EncumbranceBar />
   {/if}
 </TabFooter>

--- a/src/sheets/vehicle/tabs/VehicleCargoAndCrewTab.svelte
+++ b/src/sheets/vehicle/tabs/VehicleCargoAndCrewTab.svelte
@@ -13,7 +13,6 @@
   import CargoList from '../parts/CargoList.svelte';
   import PassengerOrCrewList from '../parts/PassengerOrCrewList.svelte';
   import { CONSTANTS } from 'src/constants';
-  import { SettingsProvider } from 'src/settings/settings';
 
   let context = getContext<Readable<VehicleSheetContext>>(
     CONSTANTS.SVELTE_CONTEXT.CONTEXT,
@@ -50,7 +49,7 @@
     <Currency document={$context.actor} />
   </div>
 
-  {#if SettingsProvider.settings.useVehicleEncumbranceBar.get()}
+  {#if $context.settings.useVehicleEncumbranceBar}
     <EncumbranceBar />
   {/if}
 </TabFooter>

--- a/src/types/group.types.ts
+++ b/src/types/group.types.ts
@@ -12,6 +12,7 @@ import type {
 } from './types';
 import type { DocumentFilters } from 'src/runtime/item/item.types';
 import type { RegisteredContent } from 'src/runtime/types';
+import type { CurrentSettings } from 'src/settings/settings';
 
 export type GroupSheetClassicContext = {
   config: any; // TODO: If possible, convert the full CONFIG (no modules on) to a typescript type.
@@ -37,6 +38,7 @@ export type GroupSheetClassicContext = {
   owner: boolean;
   items: Item5e[];
   effects: unknown[];
+  settings: CurrentSettings;
   showContainerPanel: boolean;
   showGroupMemberTabInfoPanel: boolean;
   source: unknown;

--- a/src/types/item.types.ts
+++ b/src/types/item.types.ts
@@ -12,6 +12,7 @@ import type {
   DocumentFilters,
   RegisteredEquipmentTypeGroup,
 } from 'src/runtime/item/item.types';
+import type { CurrentSettings } from 'src/settings/settings';
 
 export type ItemSheetContext = {
   activateEditors: (
@@ -30,6 +31,7 @@ export type ItemSheetContext = {
   originalContext: unknown;
   owner: boolean;
   itemOverrides: Set<string>;
+  settings: CurrentSettings;
   tabs: Tab[];
   viewableWarnings: DocumentPreparationWarning[];
 } & Record<string, any>;
@@ -82,6 +84,7 @@ export type ContainerSheetContext = {
   customContent: CustomContent[];
   originalContext: unknown;
   owner: boolean;
+  settings: CurrentSettings;
   tabs: Tab[];
   utilities: Utilities<ContainerSheetContext>;
   viewableWarnings: DocumentPreparationWarning[];

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -20,6 +20,7 @@ import type { UtilityToolbarCommandParams } from 'src/components/utility-bar/typ
 import type { CONSTANTS } from 'src/constants';
 import type { Dnd5eActorCondition } from 'src/foundry/foundry-and-system';
 import type { Group5e } from './group.types';
+import type { CurrentSettings } from 'src/settings/settings';
 
 export type Actor5e = any;
 
@@ -463,6 +464,7 @@ export type ActorSheetContextV1 = {
    */
   owner: boolean;
   saves: ActorSaves;
+  settings: CurrentSettings;
   showLimitedSheet: boolean;
   tabs: Tab[];
   tidyResources: TidyResource[];
@@ -623,6 +625,7 @@ export type ActorSheetContextV2<TActor = ActorV2> = {
   editable: boolean;
   healthPercentage: number;
   lockSensitiveFields: boolean;
+  settings: CurrentSettings;
   unlocked: boolean;
   useRoundedPortraitStyle: boolean;
 };

--- a/src/utils/applications.ts
+++ b/src/utils/applications.ts
@@ -75,7 +75,7 @@ export async function maintainCustomContentInputFocus(
   }
 }
 
-export function blurUntabbableButtonsOnClick(element: HTMLElement) {
+export function blurButtonsOnClick(element: HTMLElement) {
   element.removeEventListener('click', blurUntabbableButton);
   element.addEventListener('click', blurUntabbableButton);
 }
@@ -87,9 +87,7 @@ function blurUntabbableButton(event: MouseEvent) {
     return;
   }
 
-  const button = target.closest('button');
-
-  if (button?.tabIndex === -1) {
+  if (target.closest('button')) {
     target.blur();
   }
 }

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -1,3 +1,3 @@
-export function firstOfSet<T>(set: Set<T>): T {
+export function firstOfSet<T>(set: Set<T>): T | undefined {
   return set.values().next().value;
 }


### PR DESCRIPTION
Swapped out HTML buttons with href-less anchor tags, which do not capture focus when interacted with.

Reworked settings management to eliminate the settings store in an ongoing effort to fully restore svelte hot reload.

Generalized button blurring and tabindex code so that it can be completely excluded from svelte components and added ambiently, as a post-render adjustment when needed.