### PR TITLE
[#857] fix: Public Font Paths in Tidy disagree with route prefixing

### DIFF
--- a/src/scss/core.scss
+++ b/src/scss/core.scss
@@ -1,13 +1,13 @@
 @font-face {
   font-family: 'Signika';
-  src: url('../../../fonts/signika/signika-light.woff2') format('woff2');
+  src: url('../../fonts/signika/signika-light.woff2') format('woff2');
   font-weight: 300;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'Signika';
-  src: url('../../../fonts/signika/signika-semibold.woff2') format('woff2');
+  src: url('../../fonts/signika/signika-semibold.woff2') format('woff2');
   font-weight: 500;
   font-style: normal;
 }


### PR DESCRIPTION
#857 