### PR TITLE
fix: Item Piles item preview compatibility

### DIFF
--- a/src/components/tabs/Tabs.svelte
+++ b/src/components/tabs/Tabs.svelte
@@ -32,7 +32,7 @@
   let nav: HTMLElement;
 
   function selectTab(tab: Tab) {
-    if (sheet && !FoundryAdapter.onTabSelecting(sheet, tab.id)) {
+    if (sheet?.element && !FoundryAdapter.onTabSelecting(sheet, tab.id)) {
       return;
     }
     selectedTabId = tab.id;


### PR DESCRIPTION
Minor adjustment to prevent tidy item sheets from erroring on render when a module like Item Piles constructs a preview item that has no database backing.