### PR TITLE
quick fix: Undefined Item Subtype

### DIFF
--- a/src/sheets/classic/Tidy5eItemSheetClassic.svelte.ts
+++ b/src/sheets/classic/Tidy5eItemSheetClassic.svelte.ts
@@ -253,7 +253,6 @@ export class Tidy5eItemSheetClassic extends DragAndDropMixin(
       // Item Type, Status, and Details
       // @ts-expect-error
       itemType: game.i18n.localize(CONFIG.Item.typeLabels[this.item.type]),
-      itemSubtypes: {},
       itemStatus: this._getItemStatus(),
       baseItems: await this._getItemBaseTypes(),
       isPhysical: this.document.system.hasOwnProperty('quantity'),

--- a/src/types/item.types.ts
+++ b/src/types/item.types.ts
@@ -96,7 +96,7 @@ export type ItemSheetContext = {
   itemDescriptions: ItemDescription[];
   itemType: string;
   itemStatus: string | null;
-  itemSubtypes: Record<string, string>;
+  itemSubtypes?: Record<string, string>;
   labels: Record<string, string>;
   limited: boolean;
   lockItemQuantity: boolean;


### PR DESCRIPTION
Made itemSubtypes `undefined` by default so that the subtype template logic works properly.