### PR TITLE
future fixed: the sheet editor magic wand button is missing

### DIFF
--- a/src/components/editor/SheetEditorV2.svelte
+++ b/src/components/editor/SheetEditorV2.svelte
@@ -100,6 +100,16 @@
 
     proseMirrorContainerEl.innerHTML = element.outerHTML;
 
+    proseMirrorContainerEl.firstChild?.addEventListener(
+      'plugins',
+      (event: any) => {
+        event.detail['highlightDocumentMatches'] =
+          ProseMirror.ProseMirrorHighlightMatchesPlugin.build(
+            ProseMirror.defaultSchema,
+          );
+      },
+    );
+
     bindSecretUi();
   });
 </script>

--- a/src/foundry/foundry-and-system.d.ts
+++ b/src/foundry/foundry-and-system.d.ts
@@ -43,6 +43,7 @@ declare global {
   var Items: any;
   var KeyboardManager: any;
   var ModuleManagement: any;
+  var ProseMirror: any;
   var renderTemplate: any;
   var Roll: any;
   var SortingHelpers: any;


### PR DESCRIPTION
Added the necessary code to fix this in Foundry V13. It won't work in V12 because I am using the `prose-mirror` HTML element.