### PR TITLE
Added inline container table styles

### DIFF
--- a/src/scss/quadrone/apps.scss
+++ b/src/scss/quadrone/apps.scss
@@ -13,6 +13,8 @@
   box-shadow: var(--t5e-drop-shadow-sheet);
   background-size: cover;
 
+
+  // TODO: This isn't working and is being overridden by a blur effect on the container that can't be removed.
   &::before,
   &::after {
     content: '';
@@ -30,14 +32,12 @@
     background: var(--t5e-component-card-ondefault-default);
 
     &::before {
-      background: url(../../modules/tidy5e-sheet/images/texture-gray-1.webp)
-        no-repeat top center;
+      background: url(../../modules/tidy5e-sheet/images/texture-gray-1.webp) no-repeat top center;
       background-size: cover;
     }
 
     &::after {
-      background: url(../../modules/tidy5e-sheet/images/texture-gray-2.webp)
-        no-repeat bottom center;
+      background: url(../../modules/tidy5e-sheet/images/texture-gray-2.webp) no-repeat bottom center;
       background-size: cover;
     }
   }
@@ -46,8 +46,7 @@
     background: var(--t5e-component-card-oninverse-darker);
 
     &::before {
-      background: url(../../modules/tidy5e-sheet/images/denim065.png) no-repeat
-        top center;
+      background: url(../../modules/tidy5e-sheet/images/denim065.png) repeat top center;
       background-size: cover;
     }
   }
@@ -99,7 +98,7 @@
     align-items: center;
     padding-inline-start: 0.75rem;
 
-    > * {
+    >* {
       max-block-size: 100%;
     }
 
@@ -124,7 +123,7 @@
       box-shadow: 0 0 0.375rem var(--dnd5e-shadow-45);
     }
 
-    .header-control > button {
+    .header-control>button {
       color: var(--t5e-color-text-ondefault-lighter);
       justify-content: flex-start;
       gap: 0.5rem;
@@ -151,9 +150,7 @@
     }
   }
 
-  &[data-tidy-lock-configure-sheet='true']
-    .window-header
-    [data-action='configureSheet'] {
+  &[data-tidy-lock-configure-sheet='true'] .window-header [data-action='configureSheet'] {
     display: none;
   }
 
@@ -163,6 +160,7 @@
   }
 
   &.minimized {
+
     &::before,
     &::after {
       display: none;

--- a/src/scss/quadrone/items.scss
+++ b/src/scss/quadrone/items.scss
@@ -2,13 +2,10 @@
   --sidebar-expanded-width: 9rem;
   --sidebar-width: var(--sidebar-expanded-width);
   --sidebar-background-image-height: 510px;
-  $sidebar-bg: linear-gradient(
-      180deg,
+  $sidebar-bg: linear-gradient(180deg,
       #31313140 0%,
-      #303236 var(--sidebar-background-image-height)
-    ),
-    url(../../systems/dnd5e/ui/official/banner-character-dark.webp) lightgray
-      top center / auto no-repeat;
+      #303236 var(--sidebar-background-image-height)),
+    url(../../systems/dnd5e/ui/official/banner-character-dark.webp) lightgray top center / auto no-repeat;
 
   // Items and Containers feature a sidebar that extends to the top of the sheet, inside the header area.
   .window-header {
@@ -73,8 +70,7 @@
       }
     }
 
-    &:has(.item-name-wrapper:not(.off-screen))
-      .item-header-start-document-name {
+    &:has(.item-name-wrapper:not(.off-screen)) .item-header-start-document-name {
       display: none;
     }
 
@@ -242,7 +238,7 @@
     width: 100%;
 
     &,
-    & > *,
+    &>*,
     & img {
       aspect-ratio: 112 / 107;
     }
@@ -308,7 +304,32 @@
       /* title/small */
       font: var(--t5e-font-title-small);
     }
+
+    &:where(.theme-light) {
+      background: var(--t5e-component-card-ondefault-default);
+
+      &::before {
+        background: url(../../modules/tidy5e-sheet/images/texture-gray-1.webp) no-repeat top center;
+        background-size: cover;
+      }
+
+      &::after {
+        background: url(../../modules/tidy5e-sheet/images/texture-gray-2.webp) no-repeat bottom center;
+        background-size: cover;
+      }
+    }
+
+    &:where(.theme-dark) {
+      background: var(--t5e-component-card-oninverse-darker);
+
+      &::before {
+        background: url(../../modules/tidy5e-sheet/images/denim065.png) repeat top center;
+        background-size: cover;
+      }
+    }
   }
+
+
 
   .item-header-summary {
     margin-top: var(--t5e-spacing-2x);
@@ -316,14 +337,14 @@
     row-gap: var(--t5e-spacing-1x);
     flex-wrap: wrap;
 
-    > * {
+    >* {
       text-wrap-mode: nowrap;
       display: flex;
       align-items: center;
       gap: var(--t5e-spacing-1x);
     }
 
-    > * + *::before {
+    >*+*::before {
       content: '';
       width: 0.0625rem;
       height: var(--t5e-spacing-4x);
@@ -399,11 +420,9 @@
     &:is(input) {
       border-radius: 0.125rem;
       border: 1px solid var(--t5e-color-gold, #9f9275);
-      background: linear-gradient(
-          0deg,
+      background: linear-gradient(0deg,
           rgba(255, 255, 255, 0.5) 0%,
-          rgba(255, 255, 255, 0.5) 100%
-        ),
+          rgba(255, 255, 255, 0.5) 100%),
         var(--t5e-component-card-ondefault-default, #f8f4f1);
 
       // Typography
@@ -478,6 +497,7 @@
 
   // TODO: Move editor to its own file and layer.
   .editor {
+
     h1,
     h2,
     h3,

--- a/src/scss/quadrone/tables.scss
+++ b/src/scss/quadrone/tables.scss
@@ -184,6 +184,13 @@
         }
       }
     }
+
+    &.expanded {
+      background: linear-gradient(0deg,
+          rgba(255, 255, 255, 0.10) 0%,
+          rgba(255, 255, 255, 0.10) 100%),
+        var(--t5e-component-card-ondefault-default);
+    }
   }
 
   /* Cell styles */
@@ -545,22 +552,31 @@
 
   &:where(.theme-light) {
     .inline-content-view {
-      .tidy-table-header-row .tidy-table-header-cell {}
+      .tidy-table-header-row {
+        border: none;
+      }
+    }
+  }
+
+  &:where(.theme-dark) {
+    .tidy-table-row.expanded {
+      background: linear-gradient(0deg,
+          rgba(255, 255, 255, 0.10) 0%,
+          rgba(255, 255, 255, 0.10) 100%),
+        var(--t5e-component-card-oninverse-default);
     }
 
-    &:where(.theme-dark) {
-      .inline-content-view {
-        background: linear-gradient(90deg,
-            var(--t5e-component-card-oninverse-darker, #1B1D23) 0.59%,
-            var(--t5e-component-card-oninverse-default, #252830) 44%);
+    .inline-content-view {
+      background: linear-gradient(90deg,
+          var(--t5e-component-card-oninverse-darker, #1B1D23) 0.59%,
+          var(--t5e-component-card-oninverse-default, #252830) 44%);
 
-        .tidy-table-header-row {
-          background: rgba(255, 255, 255, 0.12);
-        }
+      .tidy-table-header-row {
+        background: rgba(255, 255, 255, 0.12);
+      }
 
-        .tidy-table-row-container {
-          background: var(--t5e-component-card-oninverse-default);
-        }
+      .tidy-table-row-container {
+        background: var(--t5e-component-card-oninverse-default);
       }
     }
   }

--- a/src/scss/quadrone/tables.scss
+++ b/src/scss/quadrone/tables.scss
@@ -23,11 +23,9 @@
   }
 
   .tidy-table-header-row {
-    background: linear-gradient(
-      to right,
-      var(--t5e-theme-color-darkest),
-      var(--t5e-theme-color-default)
-    );
+    background: linear-gradient(to right,
+        var(--t5e-theme-color-darkest),
+        var(--t5e-theme-color-default));
     border: 1px solid rgba(0, 0, 0, 0.15);
     border-radius: 0.125rem;
     color: var(--t5e-color-text-ondefault-default);
@@ -83,7 +81,7 @@
       padding-inline-start: 0;
       padding-block-end: 0.09375rem;
 
-      > * {
+      >* {
         font-family: var(--t5e-font-family-title);
         font-size: var(--font-size-16);
         line-height: 1rem;
@@ -109,51 +107,39 @@
     }
 
     &.prepared {
-      background: linear-gradient(
-        to right,
-        var(--t5e-spellcasting-default-darker),
-        var(--t5e-spellcasting-default)
-      );
+      background: linear-gradient(to right,
+          var(--t5e-spellcasting-default-darker),
+          var(--t5e-spellcasting-default));
     }
 
     &.always-prepared {
-      background: linear-gradient(
-        to right,
-        var(--t5e-spellcasting-always-darker),
-        var(--t5e-spellcasting-always)
-      );
+      background: linear-gradient(to right,
+          var(--t5e-spellcasting-always-darker),
+          var(--t5e-spellcasting-always));
     }
 
     &.pact {
-      background: linear-gradient(
-        to right,
-        var(--t5e-spellcasting-pact-darker),
-        var(--t5e-spellcasting-pact)
-      );
+      background: linear-gradient(to right,
+          var(--t5e-spellcasting-pact-darker),
+          var(--t5e-spellcasting-pact));
     }
 
     &.at-will {
-      background: linear-gradient(
-        to right,
-        var(--t5e-spellcasting-atwill-darker),
-        var(--t5e-spellcasting-atwill)
-      );
+      background: linear-gradient(to right,
+          var(--t5e-spellcasting-atwill-darker),
+          var(--t5e-spellcasting-atwill));
     }
 
     &.ritual {
-      background: linear-gradient(
-        to right,
-        var(--t5e-spellcasting-ritual-darker),
-        var(--t5e-spellcasting-ritual)
-      );
+      background: linear-gradient(to right,
+          var(--t5e-spellcasting-ritual-darker),
+          var(--t5e-spellcasting-ritual));
     }
 
     &.innate {
-      background: linear-gradient(
-        to right,
-        var(--t5e-spellcasting-innate-darker),
-        var(--t5e-spellcasting-innate)
-      );
+      background: linear-gradient(to right,
+          var(--t5e-spellcasting-innate-darker),
+          var(--t5e-spellcasting-innate));
     }
   }
 
@@ -161,14 +147,11 @@
     border-radius: 0.125rem;
     border-width: 0 0 1px 0;
     border-style: solid;
-    border-image: linear-gradient(
-        to right,
+    border-image: linear-gradient(to right,
         rgba(143, 123, 78, 0) 0%,
         rgba(143, 123, 78, 0.25) 20%,
         rgba(143, 123, 78, 0.25) 80%,
-        rgba(143, 123, 78, 0) 100%
-      )
-      0 0 1 0;
+        rgba(143, 123, 78, 0) 100%) 0 0 1 0;
 
     &.equipped {
       background-color: var(--t5e-component-card-ondefault-default);
@@ -179,6 +162,7 @@
     }
 
     &.spell:not(.equipped) {
+
       .item-label,
       .item-context {
         font-style: italic;
@@ -187,11 +171,9 @@
     }
 
     &.rarity {
-      background: linear-gradient(
-        to right,
-        oklch(from var(--t5e-item-row-color) l c h / 0.3) 10%,
-        transparent 50%
-      );
+      background: linear-gradient(to right,
+          oklch(from var(--t5e-item-row-color) l c h / 0.3) 10%,
+          transparent 50%);
 
       .item-use-button {
         outline: 1px solid var(--t5e-item-use-button-border-color);
@@ -219,14 +201,11 @@
 
     &:not(:last-child) {
       border-right: 1px solid var(--t5e-table-row-divider);
-      border-image: linear-gradient(
-          to bottom,
+      border-image: linear-gradient(to bottom,
           transparent 10%,
           var(--t5e-table-row-divider) 10%,
           var(--t5e-table-row-divider) 90%,
-          transparent 90%
-        )
-        1;
+          transparent 90%) 1;
 
       &.tidy-table-header-cell {
         border-right-color: transparent;
@@ -239,7 +218,7 @@
       justify-content: stretch;
       border-right: none;
 
-      > * {
+      >* {
         align-content: center;
       }
     }
@@ -386,7 +365,7 @@
         display: flex;
         align-items: stretch;
 
-        > * {
+        >* {
           align-content: center;
         }
       }
@@ -529,4 +508,60 @@
 
   /* Inline Containers */
   // TODO
+  .expandable-expanded {
+    // background: linear-gradient(90deg, var(--t5e-component-card-onDefault-darker, #1B1D23) 0.59%, var(--t5e-component-card-onDefault-default, #252830) 44%);
+  }
+
+  .empty-container {
+    min-height: var(--t5e-spacing-8x);
+    align-content: center;
+    background-color: var(--t5e-component-card-default);
+    color: var(--t5e-color-text-ondefault-lightest);
+  }
+
+  .inline-content-view {
+    border-radius: 0 0 0.125rem 0.125rem;
+    background-color: red;
+    background: linear-gradient(90deg,
+        var(--t5e-color-palette-white) 0.59%,
+        var(--t5e-component-card-ondefault-default) 44%);
+    padding: var(--t5e-spacing-1x) 0 var(--t5e-spacing-2x) var(--t5e-spacing-4x);
+    border-width: 0 0 1px 0;
+    border-style: solid;
+    border-image: linear-gradient(to right,
+        rgba(143, 123, 78, 0) 0%,
+        rgba(143, 123, 78, 0.25) 20%,
+        rgba(143, 123, 78, 0.25) 80%,
+        rgba(143, 123, 78, 0) 100%) 0 0 1 0;
+
+    .tidy-table-header-row {
+      background: rgba(0, 0, 0, 0.12);
+    }
+
+    .tidy-table-row-container {
+      background: var(--t5e-component-card-ondefault-default);
+    }
+  }
+
+  &:where(.theme-light) {
+    .inline-content-view {
+      .tidy-table-header-row .tidy-table-header-cell {}
+    }
+
+    &:where(.theme-dark) {
+      .inline-content-view {
+        background: linear-gradient(90deg,
+            var(--t5e-component-card-oninverse-darker, #1B1D23) 0.59%,
+            var(--t5e-component-card-oninverse-default, #252830) 44%);
+
+        .tidy-table-header-row {
+          background: rgba(255, 255, 255, 0.12);
+        }
+
+        .tidy-table-row-container {
+          background: var(--t5e-component-card-oninverse-default);
+        }
+      }
+    }
+  }
 }

--- a/src/sheets/quadrone/container/parts/ContainerContentsSections.svelte
+++ b/src/sheets/quadrone/container/parts/ContainerContentsSections.svelte
@@ -112,6 +112,7 @@
       data-custom-section={section.custom ? true : null}
     >
       {#snippet header()}
+        <!-- TODO: Remove .dark for nested table header rows -->
         <TidyTableHeaderRow class="dark">
           <TidyTableHeaderCell primary={true} class="header-label-cell">
             <h3>
@@ -163,6 +164,7 @@
             'legendary',
             'artifact',
           ].includes(item.system.rarity)}
+          <!-- TODO: Add .expanded class to the row when the item is expanded -->
           <TidyItemTableRow
             {item}
             hidden={!searchResults.show(item.uuid)}

--- a/src/sheets/quadrone/container/parts/InlineContainerView.svelte
+++ b/src/sheets/quadrone/container/parts/InlineContainerView.svelte
@@ -70,7 +70,6 @@
   class={!searchResults.show(container.uuid) ? 'hidden' : ''}
 >
   <div class="inline-content-view filigree-guideline-and-contents full-height">
-    <VerticalFiligreeGuideline />
     <div
       class="flex-column extra-small-gap flex-1 inline-container-view"
       data-tidy-container-id={container.id}


### PR DESCRIPTION
First pass at inline container style fixes.

Todos
1) In apps.scss move background images like denim out of the ::before. There's some kind of background blur applied to the container that I can't figure out how to turn off. Container sheet denim image moved to a working location for now.
2) Add `.expanded` class on a tidy table row if it's been expanded to either show description or container contents. 
3) For inline nested containers, remove the `.dark` class from the nested table header rows
4) I removed the filigree for now. It likely needs to be added to the container contents in the DOM hierarchy, but I didn't want to mess it up for now. Might rethink it anyhow