### PR TITLE
Activities in the Attribute Pins now fall back to their item's image …

### DIFF
--- a/src/components/item-list/ActivityUseButton.svelte
+++ b/src/components/item-list/ActivityUseButton.svelte
@@ -5,12 +5,14 @@
     activity: any;
     disabled?: boolean;
     showDiceIconOnHover?: boolean;
+    img?: string;
   }
 
   let {
     activity,
     disabled = false,
     showDiceIconOnHover = true,
+    img,
   }: Props = $props();
 </script>
 
@@ -21,7 +23,7 @@
   <img
     class="item-image"
     alt={activity.name}
-    src={activity.img}
+    src={img ?? activity.img}
     data-tidy-sheet-part={CONSTANTS.SHEET_PARTS.GROUP_MEMBER_PORTRAIT}
   />
 

--- a/src/sheets/classic/character/parts/AttributeActivityPin.svelte
+++ b/src/sheets/classic/character/parts/AttributeActivityPin.svelte
@@ -17,6 +17,14 @@
 
   let { ctx }: Props = $props();
 
+  let img = $derived(
+    ctx.document.img ===
+      ctx.document.documentConfig?.[ctx.document.type]?.documentClass?.metadata
+        ?.img
+      ? ctx.document.item.img
+      : ctx.document.img,
+  );
+
   let { usesDocument, valueProp, spentProp, maxProp, value, maxText, uses } =
     $derived.by(() => {
       const uses = ctx.document.uses;
@@ -72,7 +80,7 @@
   ondragstart={onDragStart}
 >
   <div class="attribute-document-image">
-    <ActivityUseButton activity={ctx.document} />
+    <ActivityUseButton activity={ctx.document} {img} />
   </div>
   <div class="attribute-pin-details">
     <div


### PR DESCRIPTION
…rather than the default activity icon. If a specific icon is used other than the default one, then Tidy honors the activity img.