### PR TITLE
Misc updates

### DIFF
--- a/src/scss/quadrone/forms.scss
+++ b/src/scss/quadrone/forms.scss
@@ -293,6 +293,10 @@
         padding: 0;
         // text-align: center;
       }
+
+      select {
+        width: auto;
+      }
     }
 
     label.label-icon {

--- a/src/sheets/classic/item/tabs/ItemSpellDetailsTab.svelte
+++ b/src/sheets/classic/item/tabs/ItemSpellDetailsTab.svelte
@@ -174,47 +174,56 @@
   <div class="form-group">
     <label for="{appId}-sourceClass">{localize('DND5E.SpellSourceClass')}</label
     >
-    <Select
-      id="{appId}-sourceClass"
-      document={context.item}
-      field="system.sourceClass"
-      value={context.source.sourceClass}
-      disabled={!context.editable}
-      blankValue=""
-    >
-      <SelectOptions
-        data={context.document.parent.spellcastingClasses}
-        labelProp="name"
-        blank=""
-      />
-    </Select>
+    <div class="form-fields">
+      <Select
+        id="{appId}-sourceClass"
+        document={context.item}
+        field="system.sourceClass"
+        value={context.source.sourceClass}
+        disabled={!context.editable}
+        blankValue=""
+      >
+        <SelectOptions
+          data={context.document.parent.spellcastingClasses}
+          labelProp="name"
+          blank=""
+        />
+      </Select>
+    </div>
   </div>
 
-  <Select
-    id="{appId}-ability"
-    document={context.item}
-    field="system.ability"
-    value={context.source.ability}
-    disabled={!context.editable}
-    blankValue=""
-  >
-    <SelectOptions
-      data={context.config.abilities}
-      labelProp="label"
-      blank={context.defaultAbility}
-    />
-  </Select>
+  <div class="form-group">
+    <label for="{appId}-ability">{localize('DND5E.SpellAbility')}</label>
+    <div class="form-fields">
+      <Select
+        id="{appId}-ability"
+        document={context.item}
+        field="system.ability"
+        value={context.source.ability}
+        disabled={!context.editable}
+        blankValue=""
+      >
+        <SelectOptions
+          data={context.config.abilities}
+          labelProp="label"
+          blank={context.defaultAbility}
+        />
+      </Select>
+    </div>
+  </div>
 {:else}
   <div class="form-group">
     <label for="{appId}-sourceClass">{localize('DND5E.SpellSourceClass')}</label
     >
-    <TextInput
-      id="{appId}-sourceClass"
-      document={context.item}
-      field="system.sourceClass"
-      value={context.source.sourceClass}
-      disabled={!context.editable}
-    />
+    <div class="form-fields">
+      <TextInput
+        id="{appId}-sourceClass"
+        document={context.item}
+        field="system.sourceClass"
+        value={context.source.sourceClass}
+        disabled={!context.editable}
+      />
+    </div>
   </div>
 {/if}
 

--- a/src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte.ts
@@ -164,7 +164,7 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin(
       ),
     };
 
-    const systemSource = this.item.system.toObject();
+    let systemObject = this.item.system.toObject();
 
     const isIdentifiable = 'identified' in this.document.system;
     const unidentified = this.item.system.identified === false;
@@ -176,7 +176,7 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin(
     if (!showOnlyUnidentified) {
       itemDescriptions.push({
         enriched: enriched.description,
-        content: systemSource.description.value,
+        content: systemObject.description.value,
         field: 'system.description.value',
         label: FoundryAdapter.localize('DND5E.Description'),
       });
@@ -185,7 +185,7 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin(
     if (isIdentifiable) {
       itemDescriptions.push({
         enriched: enriched.unidentified,
-        content: systemSource.unidentified.description,
+        content: systemObject.unidentified.description,
         field: 'system.unidentified.description',
         label: FoundryAdapter.localize('DND5E.DescriptionUnidentified'),
       });
@@ -197,7 +197,7 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin(
     if (isIdentifiable && !showOnlyUnidentified) {
       itemDescriptions.push({
         enriched: enriched.chat,
-        content: systemSource.description.chat,
+        content: systemObject.description.chat,
         field: 'system.description.chat',
         label: FoundryAdapter.localize('DND5E.DescriptionChat'),
       });
@@ -210,6 +210,8 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin(
     const editable = this.isEditable;
 
     const unlocked = FoundryAdapter.isSheetUnlocked(this.item) && editable;
+
+    const systemSource = !unlocked ? this.item.system : systemObject;
 
     const target = this.item.type === 'spell' ? this.item.system.target : null;
 
@@ -399,10 +401,6 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin(
       damageTypes: [],
       denominationOptions: [],
     };
-
-    if (!context.editable) {
-      context.source = context.system;
-    }
 
     // Physical items
     context.baseItems = await this._getItemBaseTypes(context);

--- a/src/sheets/quadrone/container/tabs/ContainerDetailsTab.svelte
+++ b/src/sheets/quadrone/container/tabs/ContainerDetailsTab.svelte
@@ -24,7 +24,6 @@
       <NumberInputQuadrone
         id="{appId}-weight-value"
         value={context.source.weight.value}
-        disabledValue={context.system.weight.value}
         step="any"
         field="system.weight.value"
         document={context.item}
@@ -35,7 +34,6 @@
         document={context.item}
         field="system.weight.units"
         value={context.source.weight.units}
-        disabledValue={context.system.weight.units}
         disabled={!context.unlocked}
       >
         <SelectOptions
@@ -53,7 +51,6 @@
       <NumberInputQuadrone
         id="{appId}-price-value"
         value={context.source.price.value}
-        disabledValue={context.system.price.value}
         step="any"
         field="system.price.value"
         document={context.item}
@@ -63,7 +60,6 @@
       />
       <SelectQuadrone
         value={context.source.price.denomination}
-        disabledValue={context.system.price.denomination}
         field="system.price.denomination"
         document={context.item}
         disabled={!context.unlocked}
@@ -113,7 +109,6 @@
           document={context.item}
           field="system.attunement"
           value={context.source.attunement}
-          disabledValue={context.system.attunement}
           disabled={!context.unlocked}
         >
           <SelectOptions
@@ -139,7 +134,6 @@
         document={context.item}
         field="system.capacity.count"
         value={context.source.capacity.count}
-        disabledValue={context.system.capacity.count}
         step="1"
         min="0"
         placeholder="—"
@@ -160,7 +154,6 @@
             document={context.item}
             field="system.capacity.volume.value"
             value={context.source.capacity.volume.value}
-            disabledValue={context.system.capacity.volume.value}
             step="any"
             min="0"
             placeholder="—"
@@ -176,7 +169,6 @@
             document={context.item}
             field="system.capacity.volume.units"
             value={context.source.capacity.volume.units}
-            disabledValue={context.system.capacity.volume.units}
             blankValue=""
             disabled={!context.unlocked}
           >
@@ -201,7 +193,6 @@
             document={context.item}
             field="system.capacity.weight.value"
             value={context.source.capacity.weight.value}
-            disabledValue={context.system.capacity.weight.value}
             step="any"
             min="0"
             placeholder="—"
@@ -217,7 +208,6 @@
             document={context.item}
             field="system.capacity.weight.units"
             value={context.source.capacity.weight.units}
-            disabledValue={context.system.capacity.weight.units}
             blankValue=""
             disabled={!context.unlocked}
           >

--- a/src/sheets/quadrone/item/parts/DetailsMountable.svelte
+++ b/src/sheets/quadrone/item/parts/DetailsMountable.svelte
@@ -33,7 +33,6 @@
         document={context.item}
         field="system.armor.value"
         value={context.source.armor.value}
-        disabledValue={context.system.armor.value}
         disabled={!context.unlocked}
         step="1"
       />
@@ -51,7 +50,6 @@
         document={context.item}
         field="system.cover"
         value={context.source.cover}
-        disabledValue={context.system.cover}
         disabled={!context.unlocked}
       >
         <SelectOptions
@@ -79,7 +77,6 @@
           document={context.item}
           field="system.hp.value"
           value={context.source.hp?.value}
-          disabledValue={context.system.hp?.value ?? 0}
           disabled={!context.unlocked}
           placeholder="0"
           min="0"
@@ -95,7 +92,6 @@
             document={context.item}
             field="system.hp.max"
             value={context.source.hp?.max}
-            disabledValue={context.system.hp?.max ?? 0}
             disabled={!context.unlocked}
             placeholder="0"
             min="0"
@@ -112,7 +108,6 @@
             document={context.item}
             field="system.hp.dt"
             value={context.source.hp?.dt}
-            disabledValue={context.system.hp?.dt ?? 0}
             disabled={!context.unlocked}
             placeholder="—"
             min="0"
@@ -126,7 +121,6 @@
       document={context.item}
       field="system.hp.conditions"
       value={context.source.hp?.conditions}
-      disabledValue={context.system.hp?.conditions ?? 0}
       placeholder={localize(
         'DND5E.VEHICLE.MOUNTABLE.FIELDS.hp.conditions.label',
       )}
@@ -151,7 +145,6 @@
               document={context.item}
               field="system.speed.value"
               value={context.source.system.speed.value}
-              disabledValue={context.system.speed.value}
               min="0"
               placeholder="0"
               disabled={!context.unlocked}
@@ -165,7 +158,6 @@
         document={context.item}
         field="system.speed.conditions"
         value={context.source.speed.conditions}
-        disabledValue={context.system.speed.conditions}
         placeholder={localize(
           'DND5E.VEHICLE.MOUNTABLE.FIELDS.speed.conditions.label',
         )}

--- a/src/sheets/quadrone/item/parts/DetailsSpellcasting.svelte
+++ b/src/sheets/quadrone/item/parts/DetailsSpellcasting.svelte
@@ -23,7 +23,6 @@
       document={context.item}
       field="system.spellcasting.progression"
       value={context.source.spellcasting.progression}
-      disabledValue={context.system.spellcasting.progression}
       disabled={!context.unlocked}
     >
       <SelectOptions data={context.config.spellProgression} />
@@ -41,7 +40,6 @@
       document={context.item}
       field="system.spellcasting.ability"
       value={context.source.spellcasting.ability}
-      disabledValue={context.system.spellcasting.ability}
       disabled={!context.unlocked}
     >
       <SelectOptions
@@ -63,7 +61,6 @@
       document={context.item}
       field="system.spellcasting.preparation.formula"
       value={context.source.spellcasting.preparation.formula}
-      disabledValue={context.system.spellcasting.preparation.formula}
       data-formula-editor="true"
       disabled={!context.unlocked}
     />

--- a/src/sheets/quadrone/item/parts/FieldActivation.svelte
+++ b/src/sheets/quadrone/item/parts/FieldActivation.svelte
@@ -30,7 +30,6 @@
             document={context.item}
             field="system.activation.value"
             value={context.source.activation.value}
-            disabledValue={context.system.activation.value}
             placeholder="—"
             min="0"
             disabled={!context.unlocked}
@@ -50,7 +49,6 @@
           document={context.item}
           field="system.activation.type"
           value={context.source.activation.type}
-          disabledValue={context.system.activation.type}
           disabled={!context.unlocked}
         >
           <SelectOptions
@@ -69,7 +67,6 @@
     document={context.item}
     field="system.activation.condition"
     value={context.source.activation.condition}
-    disabledValue={context.system.activation.condition}
     placeholder={localize('DND5E.ItemActivationCondition')}
     class="full-width"
     disabled={!context.unlocked}

--- a/src/sheets/quadrone/item/parts/FieldDamage.svelte
+++ b/src/sheets/quadrone/item/parts/FieldDamage.svelte
@@ -56,7 +56,6 @@
         document={context.item}
         field="{prefix}custom.formula"
         value={source.custom.formula}
-        disabledValue={system.custom.formula}
         disabled={!context.unlocked}
       />
     {/if}
@@ -81,7 +80,6 @@
             document={context.item}
             field="{prefix}number"
             value={source.number}
-            disabledValue={system.number}
             placeholder={numberPlaceholder}
             min="0"
             step="1"
@@ -99,7 +97,6 @@
             document={context.item}
             field="{prefix}denomination"
             value={source.denomination}
-            disabledValue={system.denomination}
             blankValue=""
             disabled={!context.unlocked}
           >
@@ -123,7 +120,6 @@
             document={context.item}
             field="{prefix}bonus"
             value={source.bonus}
-            disabledValue={system.bonus}
             disabled={!context.unlocked}
           />
         </div>

--- a/src/sheets/quadrone/item/parts/FieldDuration.svelte
+++ b/src/sheets/quadrone/item/parts/FieldDuration.svelte
@@ -26,7 +26,6 @@
             document={context.item}
             field="system.duration.value"
             value={context.source.duration.value}
-            disabledValue={context.system.duration.value}
             placeholder="—"
             disabled={!context.unlocked}
           />
@@ -45,7 +44,6 @@
           document={context.item}
           field="system.duration.units"
           value={context.source.duration.units}
-          disabledValue={context.system.duration.units}
           disabled={!context.unlocked}
         >
           <SelectOptions
@@ -65,7 +63,6 @@
       document={context.item}
       field="system.duration.special"
       value={context.source.duration.special}
-      disabledValue={context.system.duration.special}
       placeholder={localize('DND5E.DURATION.FIELDS.duration.special.label')}
       class="full-width"
       disabled={!context.unlocked}

--- a/src/sheets/quadrone/item/parts/FieldRange.svelte
+++ b/src/sheets/quadrone/item/parts/FieldRange.svelte
@@ -26,7 +26,6 @@
             document={context.item}
             field="system.range.value"
             value={context.source.range.value}
-            disabledValue={context.system.range.value}
             disabled={!context.unlocked}
           />
         </div>
@@ -42,7 +41,6 @@
           document={context.item}
           field="system.range.units"
           value={context.source.range.units}
-          disabledValue={context.system.range.units}
           disabled={!context.unlocked}
         >
           <SelectOptions
@@ -61,7 +59,6 @@
     document={context.item}
     field="system.range.special"
     value={context.source.range.special}
-    disabledValue={context.system.range.special}
     class="full-width"
     placeholder={localize('DND5E.RANGE.FIELDS.range.special.label')}
     disabled={!context.unlocked}

--- a/src/sheets/quadrone/item/parts/FieldTargets.svelte
+++ b/src/sheets/quadrone/item/parts/FieldTargets.svelte
@@ -35,7 +35,6 @@
               document={context.item}
               field="system.target.affects.count"
               value={context.source.target.affects.count}
-              disabledValue={context.system.target.affects.count}
               placeholder={context.affectsPlaceholder}
               disabled={!context.unlocked}
             />
@@ -53,7 +52,6 @@
             document={context.item}
             field="system.target.affects.type"
             value={context.source.target.affects.type}
-            disabledValue={context.system.target.affects.type}
             blankValue=""
             disabled={!context.unlocked}
           >
@@ -74,7 +72,6 @@
         document={context.item}
         field="system.target.affects.special"
         value={context.source.target.affects.special}
-        disabledValue={context.system.target.affects.special}
         class="full-width"
         placeholder={localize(
           'DND5E.TARGET.FIELDS.target.affects.special.label',
@@ -123,7 +120,6 @@
         document={context.item}
         field="system.target.template.type"
         value={context.source.target.template.type}
-        disabledValue={context.system.target.template.type}
         disabled={!context.unlocked}
       >
         <SelectOptions
@@ -151,7 +147,6 @@
               document={context.item}
               field="system.target.template.size"
               value={context.source.target.template.size}
-              disabledValue={context.system.target.template.size}
               disabled={!context.unlocked}
             />
           </div>
@@ -169,7 +164,6 @@
                 document={context.item}
                 field="system.target.template.width"
                 value={context.source.target.template.width}
-                disabledValue={context.system.target.template.width}
                 disabled={!context.unlocked}
               />
             </div>
@@ -188,7 +182,6 @@
                 document={context.item}
                 field="system.target.template.height"
                 value={context.source.target.template.height}
-                disabledValue={context.system.target.template.height}
                 disabled={!context.unlocked}
               />
             </div>
@@ -206,7 +199,6 @@
               document={context.item}
               field="system.target.template.units"
               value={context.source.target.template.units}
-              disabledValue={context.system.target.template.units}
               disabled={!context.unlocked}
             >
               <SelectOptions
@@ -236,7 +228,6 @@
               document={context.item}
               field="system.target.template.count"
               value={context.source.target.template.count}
-              disabledValue={context.system.target.template.count}
               placeholder="1"
               disabled={!context.unlocked}
             />

--- a/src/sheets/quadrone/item/parts/FieldUses.svelte
+++ b/src/sheets/quadrone/item/parts/FieldUses.svelte
@@ -31,7 +31,6 @@
           document={context.item}
           field="system.uses.spent"
           value={context.source.uses.spent}
-          disabledValue={context.system.uses.spent}
           disabled={!context.unlocked}
         />
       </div>
@@ -45,7 +44,6 @@
             document={context.item}
             field="system.uses.max"
             value={context.source.uses.max}
-            disabledValue={context.system.uses.max}
             disabled={!context.unlocked}
           />
         </div>

--- a/src/sheets/quadrone/item/parts/ItemStartingEquipment.svelte
+++ b/src/sheets/quadrone/item/parts/ItemStartingEquipment.svelte
@@ -50,7 +50,6 @@
         document={context.item}
         field="system.wealth"
         value={context.source.wealth}
-        disabledValue={context.system.wealth}
         disabled={!context.unlocked}
       />
     </div>

--- a/src/sheets/quadrone/item/tabs/ItemBackgroundDetailsTab.svelte
+++ b/src/sheets/quadrone/item/tabs/ItemBackgroundDetailsTab.svelte
@@ -19,7 +19,6 @@
       document={context.item}
       field="system.identifier"
       value={context.source.identifier}
-      disabledValue={context.system.identifier}
       placeholder={context.item.identifier}
       disabled={!context.unlocked}
     />

--- a/src/sheets/quadrone/item/tabs/ItemClassDetailsTab.svelte
+++ b/src/sheets/quadrone/item/tabs/ItemClassDetailsTab.svelte
@@ -32,7 +32,6 @@
         document={context.item}
         field="system.identifier"
         value={context.source.identifier}
-        disabledValue={context.system.identifier}
         placeholder={context.item.identifier}
         disabled={!context.unlocked}
       />
@@ -58,7 +57,6 @@
             document={context.item}
             field="system.hd.denomination"
             value={context.source.hd.denomination}
-            disabledValue={context.system.hd.denomination}
             disabled={!context.unlocked}
           >
             {#each context.config.hitDieTypes as type}
@@ -78,7 +76,6 @@
             document={context.item}
             field="system.hd.spent"
             value={context.source.hd.spent}
-            disabledValue={context.system.hd.spent}
             placeholder="0"
             disabled={!context.unlocked}
           />
@@ -94,7 +91,6 @@
         document={context.item}
         field="system.hd.additional"
         value={context.source.hd.additional}
-        disabledValue={context.system.hd.additional}
         disabled={!context.unlocked}
       />
     </div>

--- a/src/sheets/quadrone/item/tabs/ItemConsumableDetailsTab.svelte
+++ b/src/sheets/quadrone/item/tabs/ItemConsumableDetailsTab.svelte
@@ -27,7 +27,6 @@
       <NumberInputQuadrone
         id="{appId}-weight-value"
         value={context.source.weight.value}
-        disabledValue={context.system.weight.value}
         step="any"
         field="system.weight.value"
         document={context.item}
@@ -38,7 +37,6 @@
         document={context.item}
         field="system.weight.units"
         value={context.source.weight.units}
-        disabledValue={context.system.weight.units}
         disabled={!context.unlocked}
       >
         <SelectOptions
@@ -56,7 +54,6 @@
       <NumberInputQuadrone
         id="{appId}-price-value"
         value={context.source.price.value}
-        disabledValue={context.system.price.value}
         step="any"
         field="system.price.value"
         document={context.item}
@@ -66,7 +63,6 @@
       />
       <SelectQuadrone
         value={context.source.price.denomination}
-        disabledValue={context.system.price.denomination}
         field="system.price.denomination"
         document={context.item}
         disabled={!context.unlocked}
@@ -96,7 +92,6 @@
         document={context.item}
         field="system.type.value"
         value={context.source.type.value}
-        disabledValue={context.system.type.value}
         disabled={!context.unlocked}
         blankValue=""
       >
@@ -122,7 +117,6 @@
           document={context.item}
           field="system.type.subtype"
           value={context.source.type.subtype}
-          disabledValue={context.system.type.subtype}
           disabled={!context.unlocked}
         >
           <SelectOptions data={context.itemSubtypes} blank="" />
@@ -173,7 +167,6 @@
               document={context.item}
               field="system.attunement"
               value={context.source.attunement}
-              disabledValue={context.system.attunement}
               disabled={!context.unlocked}
               class="flex-1"
             >
@@ -192,7 +185,6 @@
               <NumberInputQuadrone
                 id="{appId}-magical-bonus"
                 value={context.source.magicalBonus}
-                disabledValue={context.system.magicalBonus}
                 field="system.magicalBonus"
                 document={context.item}
                 disabled={!context.unlocked}

--- a/src/sheets/quadrone/item/tabs/ItemEquipmentDetailsTab.svelte
+++ b/src/sheets/quadrone/item/tabs/ItemEquipmentDetailsTab.svelte
@@ -26,7 +26,6 @@
       <NumberInputQuadrone
         id="{appId}-weight-value"
         value={context.source.weight.value}
-        disabledValue={context.system.weight.value}
         step="any"
         field="system.weight.value"
         document={context.item}
@@ -37,7 +36,6 @@
         document={context.item}
         field="system.weight.units"
         value={context.source.weight.units}
-        disabledValue={context.system.weight.units}
         disabled={!context.unlocked}
       >
         <SelectOptions
@@ -55,7 +53,6 @@
       <NumberInputQuadrone
         id="{appId}-price-value"
         value={context.source.price.value}
-        disabledValue={context.system.price.value}
         step="any"
         field="system.price.value"
         document={context.item}
@@ -65,7 +62,6 @@
       />
       <SelectQuadrone
         value={context.source.price.denomination}
-        disabledValue={context.system.price.denomination}
         field="system.price.denomination"
         document={context.item}
         disabled={!context.unlocked}
@@ -95,7 +91,6 @@
         document={context.item}
         field="system.type.value"
         value={context.source.type.value}
-        disabledValue={context.system.type.value}
         blankValue=""
         disabled={!context.unlocked}
       >
@@ -121,7 +116,6 @@
           document={context.item}
           field="system.type.baseItem"
           value={context.source.type.baseItem}
-          disabledValue={context.system.type.baseItem}
           blankValue=""
           disabled={!context.unlocked}
         >
@@ -145,7 +139,6 @@
         document={context.item}
         field="system.proficient"
         value={context.source.proficient}
-        disabledValue={context.system.proficient}
         blankValue=""
         disabled={!context.unlocked}
       >
@@ -173,7 +166,6 @@
               document={context.item}
               field="system.armor.value"
               value={context.source.armor.value}
-              disabledValue={context.system.armor.value}
               step="1"
               disabled={!context.unlocked}
             />
@@ -191,7 +183,6 @@
                 document={context.item}
                 field="system.armor.dex"
                 value={context.source.armor.dex}
-                disabledValue={context.system.armor.dex}
                 step="1"
                 placeholder="∞"
                 disabled={!context.unlocked}
@@ -210,7 +201,6 @@
               document={context.item}
               field="system.strength"
               value={context.source.strength}
-              disabledValue={context.system.strength}
               step="1"
               placeholder="—"
               disabled={!context.unlocked}
@@ -261,7 +251,6 @@
                 document={context.item}
                 field="system.attunement"
                 value={context.source.attunement}
-                disabledValue={context.system.attunement}
                 disabled={!context.unlocked}
                 class="flex-1"
               >
@@ -279,7 +268,6 @@
             <NumberInputQuadrone
               id="{appId}-magical-bonus"
               value={context.source.armor.magicalBonus}
-              disabledValue={context.system.armor.magicalBonus}
               field="system.armor.magicalBonus"
               document={context.item}
               disabled={!context.unlocked}

--- a/src/sheets/quadrone/item/tabs/ItemFacilityDetailsTab.svelte
+++ b/src/sheets/quadrone/item/tabs/ItemFacilityDetailsTab.svelte
@@ -30,7 +30,6 @@
         document={context.document}
         field="system.type.value"
         value={context.source.type.value}
-        disabledValue={context.system.type.value}
         id="{appId}-system-type-value"
         blankValue={null}
         disabled={!context.unlocked}
@@ -54,7 +53,6 @@
         document={context.document}
         field="system.type.subtype"
         value={context.source.type.subtype}
-        disabledValue={context.system.type.subtype}
         id="{appId}-system-type-subtype"
         disabled={!context.unlocked}
       >
@@ -78,7 +76,6 @@
         document={context.document}
         field="system.size"
         value={context.source.size}
-        disabledValue={context.system.size}
         id="{appId}-system-size"
         disabled={!context.unlocked}
       >
@@ -100,7 +97,6 @@
           document={context.document}
           field="system.level"
           value={context.source.level}
-          disabledValue={context.system.level}
           selectOnFocus={true}
           min="1"
           step="1"
@@ -128,7 +124,6 @@
               document={context.document}
               field="system.level"
               value={context.source.level}
-              disabledValue={context.system.level}
               selectOnFocus={true}
               min="1"
               step="1"
@@ -147,7 +142,6 @@
               document={context.document}
               field="system.order"
               value={context.source.order}
-              disabledValue={context.system.order}
               id="{appId}-system-order"
               disabled={!context.unlocked}
             >
@@ -180,7 +174,6 @@
               document={context.document}
               field="system.hirelings.max"
               value={context.source.hirelings.max}
-              disabledValue={context.system.hirelings.max}
               selectOnFocus={true}
               min="1"
               step="1"
@@ -201,7 +194,6 @@
               document={context.document}
               field="system.defenders.max"
               value={context.source.defenders.max}
-              disabledValue={context.system.defenders.max}
               selectOnFocus={true}
               min="1"
               step="1"
@@ -311,7 +303,6 @@
         document={context.document}
         field="system.progress.order"
         value={context.source.progress.order}
-        disabledValue={context.system.progress.order}
         disabled={!context.unlocked}
         id="{appId}-system-progress-order"
       >
@@ -343,7 +334,6 @@
               document={context.document}
               field="system.progress.value"
               value={context.source.progress.value}
-              disabledValue={context.system.progress.value}
               selectOnFocus={true}
               min="0"
               step="0"
@@ -365,7 +355,6 @@
             document={context.document}
             field="system.progress.max"
             value={context.source.progress.max}
-            disabledValue={context.system.progress.max}
             selectOnFocus={true}
             min="1"
             step="1"
@@ -429,7 +418,6 @@
             document={context.document}
             field="system.craft.quantity"
             value={context.source.craft.quantity}
-            disabledValue={context.system.craft.quantity}
             selectOnFocus={true}
             disabled={!context.unlocked}
           />
@@ -480,7 +468,6 @@
               document={context.document}
               field="system.trade.stock.value"
               value={context.source.trade.stock.value}
-              disabledValue={context.system.trade.stock.value}
               selectOnFocus={true}
               min="0"
               step="0"
@@ -501,7 +488,6 @@
               document={context.document}
               field="system.trade.stock.max"
               value={context.source.trade.stock.max}
-              disabledValue={context.system.trade.stock.max}
               selectOnFocus={true}
               min="1"
               step="1"
@@ -524,7 +510,6 @@
           document={context.document}
           field="system.trade.creatures.max"
           value={context.source.trade.creatures.max}
-          disabledValue={context.system.trade.creatures.max}
           selectOnFocus={true}
           min="1"
           step="1"
@@ -545,7 +530,6 @@
           document={context.document}
           field="system.trade.profit"
           value={context.source.trade.profit}
-          disabledValue={context.system.trade.profit}
           selectOnFocus={true}
           min="0"
           step="0"

--- a/src/sheets/quadrone/item/tabs/ItemFeatDetailsTab.svelte
+++ b/src/sheets/quadrone/item/tabs/ItemFeatDetailsTab.svelte
@@ -32,7 +32,6 @@
         document={context.item}
         field="system.type.value"
         value={context.source.type.value}
-        disabledValue={context.system.type.value}
         disabled={!context.unlocked}
       >
         <SelectOptions
@@ -58,7 +57,6 @@
           document={context.item}
           field="system.type.subtype"
           value={context.source.type.subtype}
-          disabledValue={context.system.type.subtype}
           disabled={!context.unlocked}
         >
           <SelectOptions data={context.itemSubtypes} blank="" />
@@ -78,7 +76,6 @@
           document={context.item}
           field="system.cover"
           value={context.source.cover}
-          disabledValue={context.system.cover}
           disabled={!context.unlocked}
         >
           <SelectOptions
@@ -105,7 +102,6 @@
         document={context.item}
         field="system.prerequisites.level"
         value={context.source.prerequisites.level}
-        disabledValue={context.system.prerequisites.level}
         disabled={!context.unlocked}
         step="1"
       />
@@ -165,7 +161,6 @@
           document={context.item}
           field="system.enchant.max"
           value={context.source.enchant.max}
-          disabledValue={context.system.enchant.max}
           disabled={!context.unlocked}
         />
       </div>
@@ -188,7 +183,6 @@
           document={context.item}
           field="system.enchant.period"
           value={context.source.enchant.period}
-          disabledValue={context.system.enchant.period}
           blankValue=""
           disabled={!context.unlocked}
         >

--- a/src/sheets/quadrone/item/tabs/ItemLootDetailsTab.svelte
+++ b/src/sheets/quadrone/item/tabs/ItemLootDetailsTab.svelte
@@ -23,7 +23,6 @@
       <NumberInputQuadrone
         id="{appId}-weight-value"
         value={context.source.weight.value}
-        disabledValue={context.system.weight.value}
         step="any"
         field="system.weight.value"
         document={context.item}
@@ -34,7 +33,6 @@
         document={context.item}
         field="system.weight.units"
         value={context.source.weight.units}
-        disabledValue={context.system.weight.units}
         disabled={!context.unlocked}
       >
         <SelectOptions
@@ -52,7 +50,6 @@
       <NumberInputQuadrone
         id="{appId}-price-value"
         value={context.source.price.value}
-        disabledValue={context.system.price.value}
         step="any"
         field="system.price.value"
         document={context.item}
@@ -62,7 +59,6 @@
       />
       <SelectQuadrone
         value={context.source.price.denomination}
-        disabledValue={context.system.price.denomination}
         field="system.price.denomination"
         document={context.item}
         disabled={!context.unlocked}
@@ -91,7 +87,6 @@
         document={context.item}
         field="system.type.value"
         value={context.source.type.value}
-        disabledValue={context.system.type.value}
         disabled={!context.unlocked}
       >
         <SelectOptions
@@ -117,7 +112,6 @@
           document={context.item}
           field="system.type.subtype"
           value={context.source.type.subtype}
-          disabledValue={context.system.type.subtype}
           disabled={!context.unlocked}
           blankValue=""
         >

--- a/src/sheets/quadrone/item/tabs/ItemSpeciesDetailsTab.svelte
+++ b/src/sheets/quadrone/item/tabs/ItemSpeciesDetailsTab.svelte
@@ -24,7 +24,6 @@
           document={context.item}
           field="system.identifier"
           value={context.source.identifier}
-          disabledValue={context.system.identifier}
           placeholder={context.item.identifier}
           disabled={!context.unlocked}
         />

--- a/src/sheets/quadrone/item/tabs/ItemSpellDetailsTab.svelte
+++ b/src/sheets/quadrone/item/tabs/ItemSpellDetailsTab.svelte
@@ -36,7 +36,6 @@
       document={context.item}
       field="system.level"
       value={context.source.level}
-      disabledValue={context.system.level}
       disabled={!context.unlocked}
     >
       <SelectOptions data={context.config.spellLevels} />
@@ -51,7 +50,6 @@
       document={context.item}
       field="system.school"
       value={context.source.school}
-      disabledValue={context.system.school}
       disabled={!context.unlocked}
     >
       <SelectOptions
@@ -88,7 +86,6 @@
             document={context.item}
             field="system.materials.supply"
             value={context.source.materials.supply}
-            disabledValue={context.system.materials.supply}
             min="0"
             disabled={!context.unlocked}
           />
@@ -110,7 +107,6 @@
               document={context.item}
               field="system.materials.cost"
               value={context.source.materials.cost}
-              disabledValue={context.system.materials.cost}
               min="0"
               placeholder="—"
               disabled={!context.unlocked}
@@ -140,7 +136,6 @@
         document={context.item}
         field="system.materials.value"
         value={context.source.materials.value}
-        disabledValue={context.system.materials.value}
         class="full-width"
         disabled={!context.unlocked}
       />
@@ -175,7 +170,6 @@
         document={context.item}
         field="system.preparation.mode"
         value={context.source.preparation.mode}
-        disabledValue={context.system.preparation.mode}
         disabled={!context.unlocked}
       >
         <SelectOptions
@@ -198,7 +192,6 @@
           document={context.item}
           field="system.sourceClass"
           value={context.source.sourceClass}
-          disabledValue={context.system.sourceClass}
           disabled={!context.unlocked}
           blankValue=""
         >
@@ -219,7 +212,6 @@
           document={context.item}
           field="system.ability"
           value={context.source.ability}
-          disabledValue={context.system.ability}
           disabled={!context.unlocked}
           blankValue=""
         >
@@ -242,7 +234,6 @@
           document={context.item}
           field="system.sourceClass"
           value={context.source.sourceClass}
-          disabledValue={context.system.sourceClass}
           disabled={!context.unlocked}
         />
       </div>

--- a/src/sheets/quadrone/item/tabs/ItemSpellDetailsTab.svelte
+++ b/src/sheets/quadrone/item/tabs/ItemSpellDetailsTab.svelte
@@ -211,21 +211,26 @@
       </div>
     </div>
 
-    <SelectQuadrone
-      id="{appId}-ability"
-      document={context.item}
-      field="system.ability"
-      value={context.source.ability}
-      disabledValue={context.system.ability}
-      disabled={!context.unlocked}
-      blankValue=""
-    >
-      <SelectOptions
-        data={context.config.abilities}
-        labelProp="label"
-        blank={context.defaultAbility}
-      />
-    </SelectQuadrone>
+    <div class="form-group">
+      <label for="{appId}-ability">{localize('DND5E.SpellAbility')}</label>
+      <div class="form-fields">
+        <SelectQuadrone
+          id="{appId}-ability"
+          document={context.item}
+          field="system.ability"
+          value={context.source.ability}
+          disabledValue={context.system.ability}
+          disabled={!context.unlocked}
+          blankValue=""
+        >
+          <SelectOptions
+            data={context.config.abilities}
+            labelProp="label"
+            blank={context.defaultAbility}
+          />
+        </SelectQuadrone>
+      </div>
+    </div>
   {:else}
     <div class="form-group">
       <label for="{appId}-sourceClass"

--- a/src/sheets/quadrone/item/tabs/ItemSpellDetailsTab.svelte
+++ b/src/sheets/quadrone/item/tabs/ItemSpellDetailsTab.svelte
@@ -31,33 +31,37 @@
   <!-- Spell Level -->
   <div class="form-group">
     <label for="{appId}-level">{localize('DND5E.SpellLevel')}</label>
-    <SelectQuadrone
-      id="{appId}-level"
-      document={context.item}
-      field="system.level"
-      value={context.source.level}
-      disabled={!context.unlocked}
-    >
-      <SelectOptions data={context.config.spellLevels} />
-    </SelectQuadrone>
+    <div class="form-fields">
+      <SelectQuadrone
+        id="{appId}-level"
+        document={context.item}
+        field="system.level"
+        value={context.source.level}
+        disabled={!context.unlocked}
+      >
+        <SelectOptions data={context.config.spellLevels} />
+      </SelectQuadrone>
+    </div>
   </div>
 
   <!-- Spell School -->
   <div class="form-group">
     <label for="{appId}-school">{localize('DND5E.SpellSchool')}</label>
-    <SelectQuadrone
-      id="{appId}-school"
-      document={context.item}
-      field="system.school"
-      value={context.source.school}
-      disabled={!context.unlocked}
-    >
-      <SelectOptions
-        data={context.config.spellSchools}
-        labelProp="label"
-        blank=""
-      />
-    </SelectQuadrone>
+    <div class="form-fields">
+      <SelectQuadrone
+        id="{appId}-school"
+        document={context.item}
+        field="system.school"
+        value={context.source.school}
+        disabled={!context.unlocked}
+      >
+        <SelectOptions
+          data={context.config.spellSchools}
+          labelProp="label"
+          blank=""
+        />
+      </SelectQuadrone>
+    </div>
   </div>
 
   <!-- Spell Components -->
@@ -81,14 +85,16 @@
           <label for="{appId}-materials-supply"
             >{localize('DND5E.Supply')}</label
           >
-          <NumberInputQuadrone
-            id="{appId}-materials-supply"
-            document={context.item}
-            field="system.materials.supply"
-            value={context.source.materials.supply}
-            min="0"
-            disabled={!context.unlocked}
-          />
+          <div class="form-fields">
+            <NumberInputQuadrone
+              id="{appId}-materials-supply"
+              document={context.item}
+              field="system.materials.supply"
+              value={context.source.materials.supply}
+              min="0"
+              disabled={!context.unlocked}
+            />
+          </div>
         </div>
 
         <!-- Material Cost -->
@@ -118,14 +124,16 @@
         <div class="form-group checkbox">
           <label for="{appId}-materials-consumed" class="checkbox"
             >{localize('DND5E.Consumed')}
-            <CheckboxQuadrone
-              id="{appId}-materials-consumed"
-              document={context.item}
-              field="system.materials.consumed"
-              checked={context.source.materials.consumed}
-              disabledChecked={context.system.materials.consumed}
-              disabled={!context.unlocked}
-            />
+            <div class="form-fields">
+              <CheckboxQuadrone
+                id="{appId}-materials-consumed"
+                document={context.item}
+                field="system.materials.consumed"
+                checked={context.source.materials.consumed}
+                disabledChecked={context.system.materials.consumed}
+                disabled={!context.unlocked}
+              />
+            </div>
           </label>
         </div>
       </div>

--- a/src/sheets/quadrone/item/tabs/ItemSubclassDetailsTab.svelte
+++ b/src/sheets/quadrone/item/tabs/ItemSubclassDetailsTab.svelte
@@ -24,7 +24,6 @@
         document={context.item}
         field="system.identifier"
         value={context.source.identifier}
-        disabledValue={context.system.identifier}
         placeholder={context.item.identifier}
         disabled={!context.unlocked}
       />
@@ -42,7 +41,6 @@
         document={context.item}
         field="system.classIdentifier"
         value={context.source.classIdentifier}
-        disabledValue={context.system.classIdentifier}
         disabled={!context.unlocked}
       />
     </div>

--- a/src/sheets/quadrone/item/tabs/ItemToolDetailsTab.svelte
+++ b/src/sheets/quadrone/item/tabs/ItemToolDetailsTab.svelte
@@ -26,7 +26,6 @@
       <NumberInputQuadrone
         id="{appId}-weight-value"
         value={context.source.weight.value}
-        disabledValue={context.system.weight.value}
         step="any"
         field="system.weight.value"
         document={context.item}
@@ -37,7 +36,6 @@
         document={context.item}
         field="system.weight.units"
         value={context.source.weight.units}
-        disabledValue={context.system.weight.units}
         disabled={!context.unlocked}
       >
         <SelectOptions
@@ -55,7 +53,6 @@
       <NumberInputQuadrone
         id="{appId}-price-value"
         value={context.source.price.value}
-        disabledValue={context.system.price.value}
         step="any"
         field="system.price.value"
         document={context.item}
@@ -65,7 +62,6 @@
       />
       <SelectQuadrone
         value={context.source.price.denomination}
-        disabledValue={context.system.price.denomination}
         field="system.price.denomination"
         document={context.item}
         disabled={!context.unlocked}
@@ -88,7 +84,6 @@
       document={context.item}
       field="system.type.value"
       value={context.source.type.value}
-      disabledValue={context.system.type.value}
       disabled={!context.unlocked}
     >
       <SelectOptions data={context.config.toolTypes} blank="" />
@@ -106,7 +101,6 @@
         document={context.item}
         field="system.type.baseItem"
         value={context.source.type.baseItem}
-        disabledValue={context.system.type.baseItem}
         disabled={!context.unlocked}
       >
         <SelectOptions data={context.baseItems} blank="" />
@@ -136,7 +130,6 @@
           document={context.item}
           field="system.proficient"
           value={context.source.proficient}
-          disabledValue={context.system.proficient}
           disabled={!context.unlocked}
         >
           <SelectOptions
@@ -156,7 +149,6 @@
           document={context.item}
           field="system.ability"
           value={context.source.ability}
-          disabledValue={context.system.ability}
           disabled={!context.unlocked}
         >
           <SelectOptions
@@ -179,7 +171,6 @@
       document={context.item}
       field="system.bonus"
       value={context.source.bonus}
-      disabledValue={context.system.bonus}
       disabled={!context.unlocked}
     />
   </div>
@@ -210,7 +201,6 @@
         document={context.item}
         field="system.attunement"
         value={context.source.attunement}
-        disabledValue={context.system.attunement}
         disabled={!context.unlocked}
       >
         <SelectOptions

--- a/src/sheets/quadrone/item/tabs/ItemWeaponDetailsTab.svelte
+++ b/src/sheets/quadrone/item/tabs/ItemWeaponDetailsTab.svelte
@@ -27,7 +27,6 @@
       <NumberInputQuadrone
         id="{appId}-weight-value"
         value={context.source.weight.value}
-        disabledValue={context.system.weight.value}
         step="any"
         field="system.weight.value"
         document={context.item}
@@ -38,7 +37,6 @@
         document={context.item}
         field="system.weight.units"
         value={context.source.weight.units}
-        disabledValue={context.system.weight.units}
         disabled={!context.unlocked}
       >
         <SelectOptions
@@ -56,7 +54,6 @@
       <NumberInputQuadrone
         id="{appId}-price-value"
         value={context.source.price.value}
-        disabledValue={context.system.price.value}
         step="any"
         field="system.price.value"
         document={context.item}
@@ -66,7 +63,6 @@
       />
       <SelectQuadrone
         value={context.source.price.denomination}
-        disabledValue={context.system.price.denomination}
         field="system.price.denomination"
         document={context.item}
         disabled={!context.unlocked}
@@ -95,7 +91,6 @@
         document={context.item}
         field="system.type.value"
         value={context.source.type.value}
-        disabledValue={context.system.type.value}
         disabled={!context.unlocked}
         blankValue=""
       >
@@ -116,7 +111,6 @@
           document={context.item}
           field="system.type.baseItem"
           value={context.source.type.baseItem}
-          disabledValue={context.system.type.baseItem}
           disabled={!context.unlocked}
         >
           <SelectOptions data={context.baseItems} blank="" />
@@ -137,7 +131,6 @@
           document={context.item}
           field="system.proficient"
           value={context.source.proficient}
-          disabledValue={context.system.proficient}
           disabled={!context.unlocked}
         >
           <SelectOptions
@@ -160,7 +153,6 @@
         document={context.item}
         field="system.mastery"
         value={context.source.mastery}
-        disabledValue={context.system.mastery}
         blankValue=""
         disabled={!context.unlocked}
       >
@@ -216,7 +208,6 @@
                 document={context.item}
                 field="system.attunement"
                 value={context.source.attunement}
-                disabledValue={context.system.attunement}
                 disabled={!context.unlocked}
                 class="flex-1"
               >
@@ -235,7 +226,6 @@
             <NumberInputQuadrone
               id="{appId}-magical-bonus"
               value={context.source.magicalBonus}
-              disabledValue={context.system.magicalBonus}
               field="system.magicalBonus"
               document={context.item}
               disabled={!context.unlocked}
@@ -261,7 +251,6 @@
           document={context.item}
           field="system.ammunition.type"
           value={context.source.ammunition.type}
-          disabledValue={context.system.ammunition.type}
           blankValue=""
           disabled={!context.unlocked}
         >
@@ -294,7 +283,6 @@
               document={context.item}
               field="system.range.value"
               value={context.source.range.value}
-              disabledValue={context.system.range.value}
               min="0"
               disabled={!context.unlocked}
             />
@@ -310,7 +298,6 @@
               document={context.item}
               field="system.range.long"
               value={context.source.range.long}
-              disabledValue={context.system.range.long}
               min="0"
               disabled={!context.unlocked}
             />
@@ -329,7 +316,6 @@
                 document={context.item}
                 field="system.range.reach"
                 value={context.source.range.reach}
-                disabledValue={context.system.range.reach}
                 min="0"
                 placeholder={context.system.range.reach === null
                   ? '—'
@@ -351,7 +337,6 @@
           document={context.item}
           field="system.range.units"
           value={context.source.range.units}
-          disabledValue={context.system.range.units}
           blankValue=""
           disabled={!context.unlocked}
         >
@@ -379,7 +364,6 @@
                 document={context.item}
                 field="system.range.reach"
                 value={context.source.range.reach}
-                disabledValue={context.system.range.reach}
                 min="0"
                 placeholder={context.system.range.reach === null
                   ? '—'
@@ -401,7 +385,6 @@
               document={context.item}
               field="system.range.units"
               value={context.source.range.units}
-              disabledValue={context.system.range.units}
               disabled={!context.unlocked}
             >
               <SelectOptions


### PR DESCRIPTION
Fixed spell ability form fields in classic/q spell details tab.
Fixed: Properties were not showing the final state when locked. 
Corrected swap logic for context.source to account for sheet Mode.
Removed all usages of disabledValue, now that it is being supplied innately from source.
Added missing form field wrappers where found in Spell Sheet.










