### PR TITLE
quick fix: Activity Context Menu not showing options

### DIFF
--- a/src/components/table-quadrone/TidyActivityTableRow.svelte
+++ b/src/components/table-quadrone/TidyActivityTableRow.svelte
@@ -51,6 +51,7 @@
 <TidyTableRow
   rowContainerAttributes={{
     ['data-activity-id']: activity?.id,
+    ['data-configurable']: configurable,
   }}
   rowContainerClass="activity"
   rowClass="tidy-table-row-v2 {rowClass} {expanded ? 'expanded' : ''}"
@@ -58,7 +59,6 @@
     ['data-tidy-table-row']: '',
     ['data-tidy-draggable']: '',
     ['data-tidy-sheet-part']: CONSTANTS.SHEET_PARTS.ACTIVITY_TABLE_ROW,
-    ['data-configurable']: configurable,
     ['data-info-card']: 'activity',
     ['data-info-card-entity-uuid']: activity.uuid,
     ['data-context-menu']: CONSTANTS.CONTEXT_MENU_TYPE_ACTIVITIES,


### PR DESCRIPTION
Moved data-configurable adjacent to data-activity-id to allow for activity configurability filtering with the context menu. Without it paired up, all standard options were being filtered out, as the activity was considered unconfigurable.