### PR TITLE
Drag and drop refinements of the current setup

### DIFF
--- a/src/components/item-list/v1/EffectTableRow.svelte
+++ b/src/components/item-list/v1/EffectTableRow.svelte
@@ -43,6 +43,11 @@
   }
 
   function handleDragStart(event: DragEvent) {
+    if (event.target !== event.currentTarget) {
+      // Allow for draggables within this containing element to be handled elsewhere.
+      return;
+    }
+
     const dragData = effectDocument.toDragData?.();
     if (dragData) {
       event.dataTransfer?.setData('text/plain', JSON.stringify(dragData));
@@ -83,6 +88,7 @@
   data-context-menu={CONSTANTS.CONTEXT_MENU_TYPE_EFFECTS}
   data-effect-id={effectDocument?.id}
   data-parent-id={activeEffect?.parentId ?? activeEffect?.parent?.id}
+  data-tidy-always-draggable
   onmousedown={(event) =>
     FoundryAdapter.editOnMiddleClick(event, effectDocument)}
   ondragstart={handleDragStart}

--- a/src/components/item-list/v1/ItemTableRow.svelte
+++ b/src/components/item-list/v1/ItemTableRow.svelte
@@ -89,6 +89,11 @@
 
     onMouseLeave(event);
 
+    if (event.target !== event.currentTarget) {
+      // Allow for draggables within this containing element to be handled elsewhere.
+      return;
+    }
+
     const dragData = getDragData?.() ?? item.toDragData?.();
     if (dragData) {
       event.dataTransfer?.setData('text/plain', JSON.stringify(dragData));

--- a/src/components/item-list/v2/ItemTableRowV2.svelte
+++ b/src/components/item-list/v2/ItemTableRowV2.svelte
@@ -79,6 +79,11 @@
 
     onMouseLeave(event);
 
+    if (event.target !== event.currentTarget) {
+      // Allow for draggables within this containing element to be handled elsewhere.
+      return;
+    }
+    
     const dragData = item.toDragData();
     event.dataTransfer?.setData('text/plain', JSON.stringify(dragData));
   }

--- a/src/components/spellbook/SpellbookGrid.svelte
+++ b/src/components/spellbook/SpellbookGrid.svelte
@@ -64,6 +64,11 @@
 
     onMouseLeave(event, item);
 
+    if (event.target !== event.currentTarget) {
+      // Allow for draggables within this containing element to be handled elsewhere.
+      return;
+    }
+
     const dragData = item.toDragData();
     event.dataTransfer?.setData('text/plain', JSON.stringify(dragData));
   }

--- a/src/components/table-quadrone/TidyActivityTableRow.svelte
+++ b/src/components/table-quadrone/TidyActivityTableRow.svelte
@@ -39,6 +39,11 @@
   }
 
   function handleDragStart(event: DragEvent) {
+    if (event.target !== event.currentTarget) {
+      // Allow for draggables within this containing element to be handled elsewhere.
+      return;
+    }
+    
     const dragData = activity.doc.toDragData?.();
     if (dragData) {
       event.dataTransfer?.setData('text/plain', JSON.stringify(dragData));
@@ -57,7 +62,7 @@
   rowClass="tidy-table-row-v2 {rowClass} {expanded ? 'expanded' : ''}"
   rowAttributes={{
     ['data-tidy-table-row']: '',
-    ['data-tidy-draggable']: '',
+    ['data-tidy-always-draggable']: '',
     ['data-tidy-sheet-part']: CONSTANTS.SHEET_PARTS.ACTIVITY_TABLE_ROW,
     ['data-info-card']: 'activity',
     ['data-info-card-entity-uuid']: activity.uuid,

--- a/src/components/table-quadrone/TidyAdvancementTableRow.svelte
+++ b/src/components/table-quadrone/TidyAdvancementTableRow.svelte
@@ -30,6 +30,11 @@
   let doc = $derived(item.advancement?.byId[advancement.id]);
 
   function handleDragStart(event: DragEvent) {
+    if (event.target !== event.currentTarget) {
+      // Allow for draggables within this containing element to be handled elsewhere.
+      return;
+    }
+
     const dragData = doc?.toDragData?.();
     if (dragData) {
       event.dataTransfer?.setData('text/plain', JSON.stringify(dragData));
@@ -44,7 +49,7 @@
   rowContainerClass="activity"
   rowClass="tidy-table-row-v2 {rowClass} {expanded ? 'expanded' : ''}"
   rowAttributes={{
-    ['data-tidy-draggable']: '',
+    ['data-tidy-always-draggable']: '',
     ['data-tidy-table-row']: '',
     ['data-tidy-sheet-part']: CONSTANTS.SHEET_PARTS.ADVANCEMENT_TABLE_ROW,
   }}

--- a/src/components/table-quadrone/TidyEffectTableRow.svelte
+++ b/src/components/table-quadrone/TidyEffectTableRow.svelte
@@ -38,6 +38,11 @@
   }
 
   function handleDragStart(event: DragEvent) {
+    if (event.target !== event.currentTarget) {
+      // Allow for draggables within this containing element to be handled elsewhere.
+      return;
+    }
+
     const dragData = effectContext.effect.toDragData?.();
     if (dragData) {
       event.dataTransfer?.setData('text/plain', JSON.stringify(dragData));
@@ -74,7 +79,7 @@
   rowClass="tidy-table-row-v2 {rowClass} {expanded ? 'expanded' : ''}"
   rowAttributes={{
     ['data-context-menu']: CONSTANTS.CONTEXT_MENU_TYPE_EFFECTS,
-    ['data-tidy-draggable']: '',
+    ['data-tidy-always-draggable']: '',
     ['data-tidy-table-row']: '',
     ['data-tidy-sheet-part']: CONSTANTS.SHEET_PARTS.EFFECT_TABLE_ROW,
     ['data-info-card']: 'effect',

--- a/src/components/table-quadrone/TidyItemTableRow.svelte
+++ b/src/components/table-quadrone/TidyItemTableRow.svelte
@@ -72,6 +72,11 @@
   function handleDragStart(event: DragEvent) {
     onMouseLeave(event);
 
+    if (event.target !== event.currentTarget) {
+      // Allow for draggables within this containing element to be handled elsewhere.
+      return;
+    }
+
     const dragData = item.toDragData();
     event.dataTransfer?.setData('text/plain', JSON.stringify(dragData));
   }

--- a/src/mixins/DragAndDropBaseMixin.ts
+++ b/src/mixins/DragAndDropBaseMixin.ts
@@ -1,3 +1,4 @@
+import { CONSTANTS } from 'src/constants';
 import { firstOfSet } from 'src/utils/set';
 
 export type DropEffectValue = 'copy' | 'move' | 'link' | 'none';
@@ -42,7 +43,9 @@ export function DragAndDropMixin(BaseApplication: any) {
 
     /** @inheritdoc */
     _canDragStart(selector: string) {
-      return this.isEditable;
+      return (
+        ['[data-tidy-always-draggable]'].includes(selector) || this.isEditable
+      );
     }
 
     /* -------------------------------------------- */
@@ -65,7 +68,6 @@ export function DragAndDropMixin(BaseApplication: any) {
         foundry.utils.getType(data) === 'Object'
           ? this._dropBehavior(event, data)
           : 'copy';
-
     }
 
     _onDrop(

--- a/src/scss/quadrone/tables.scss
+++ b/src/scss/quadrone/tables.scss
@@ -537,6 +537,10 @@
     position: relative;
     transition: all var(--t5e-transition-default);
 
+    img {
+      border: 0;
+    }
+
     i {
       grid-column: 1;
       font-size: 1.125rem;

--- a/src/sheets/classic/Tidy5eCharacterSheet.svelte.ts
+++ b/src/sheets/classic/Tidy5eCharacterSheet.svelte.ts
@@ -151,6 +151,10 @@ export class Tidy5eCharacterSheet
       scrollY: ['[data-tidy-track-scroll-y]', '.scroll-container'],
       dragDrop: [
         {
+          dragSelector: `[data-tidy-always-draggable]`,
+          dropSelector: null,
+        },
+        {
           dragSelector: '[data-tidy-draggable]',
           dropSelector: null,
         },
@@ -1582,6 +1586,14 @@ export class Tidy5eCharacterSheet
 
   onLongRest(event: Event) {
     return this._onLongRest(event);
+  }
+
+  /** @inheritDoc */
+  _canDragStart(selector: string) {
+    return (
+      ['[data-tidy-always-draggable]'].includes(selector) ||
+      super._canDragStart(selector)
+    );
   }
 
   async _onDropSingleItem(itemData: any, event: DragEvent) {

--- a/src/sheets/classic/Tidy5eContainerSheetClassic.svelte.ts
+++ b/src/sheets/classic/Tidy5eContainerSheetClassic.svelte.ts
@@ -86,6 +86,10 @@ export class Tidy5eContainerSheetClassic extends TidyExtensibleDocumentSheetMixi
     actions: {},
     dragDrop: [
       {
+        dragSelector: `[data-tidy-always-draggable]`,
+        dropSelector: null,
+      },
+      {
         dragSelector: '[data-tidy-draggable]',
         dropSelector: null,
       },

--- a/src/sheets/classic/Tidy5eGroupSheetClassic.svelte.ts
+++ b/src/sheets/classic/Tidy5eGroupSheetClassic.svelte.ts
@@ -52,7 +52,9 @@ import { SheetSections } from 'src/features/sections/SheetSections';
 import { ExpansionTracker } from 'src/features/expand-collapse/ExpansionTracker.svelte';
 import { ItemContext } from 'src/features/item/ItemContext';
 import { TidyExtensibleDocumentSheetMixin } from 'src/mixins/TidyDocumentSheetMixin.svelte';
-import GroupSheetClassicRuntime, { defaultGroupClassicTabs } from 'src/runtime/actor/GroupSheetClassicRuntime.svelte';
+import GroupSheetClassicRuntime, {
+  defaultGroupClassicTabs,
+} from 'src/runtime/actor/GroupSheetClassicRuntime.svelte';
 
 type MemberStats = {
   currentHP: number;
@@ -111,6 +113,10 @@ export class Tidy5eGroupSheetClassic extends Tidy5eActorSheetBaseMixin(
       height: 700,
     },
     dragDrop: [
+      {
+        dragSelector: `[data-tidy-always-draggable]`,
+        dropSelector: null,
+      },
       {
         dragSelector: '[data-tidy-draggable]',
         dropSelector: null,
@@ -506,9 +512,10 @@ export class Tidy5eGroupSheetClassic extends Tidy5eActorSheetBaseMixin(
       xp: xp,
     };
 
-    context.customContent = await GroupSheetClassicRuntime.getContent(context),
-
-    await this._prepareItems(context);
+    (context.customContent = await GroupSheetClassicRuntime.getContent(
+      context
+    )),
+      await this._prepareItems(context);
 
     let tabs = await GroupSheetClassicRuntime.getTabs(context);
 
@@ -900,13 +907,18 @@ export class Tidy5eGroupSheetClassic extends Tidy5eActorSheetBaseMixin(
     return await super.close(options);
   }
 
-  // ---------------------------------------------
-  // Drag and Drop
-  // ---------------------------------------------
-
+  /* -------------------------------------------- */
+  /*  Drag and Drop                               */
+  /* -------------------------------------------- */
+  
   _onDragStart(
     event: DragEvent & { currentTarget: HTMLElement; target: HTMLElement }
   ): void {
+    if (event.target !== event.currentTarget) {
+      // Allow for draggables within this containing element to be handled elsewhere.
+      return;
+    }
+
     const memberId = event.currentTarget
       .closest('[data-tidy-draggable][data-member-id]')
       ?.getAttribute('data-member-id');

--- a/src/sheets/classic/Tidy5eKgarVehicleSheet.svelte.ts
+++ b/src/sheets/classic/Tidy5eKgarVehicleSheet.svelte.ts
@@ -117,6 +117,10 @@ export class Tidy5eVehicleSheet
       scrollY: ['[data-tidy-track-scroll-y]', '.scroll-container'],
       dragDrop: [
         {
+          dragSelector: `[data-tidy-always-draggable]`,
+          dropSelector: null,
+        },
+        {
           dragSelector: '[data-tidy-draggable]',
           dropSelector: null,
         },
@@ -830,6 +834,14 @@ export class Tidy5eVehicleSheet
       debug('Saved scroll positions', this._scrollPositions);
       return save;
     }
+  }
+
+  /** @inheritDoc */
+  _canDragStart(selector: string) {
+    return (
+      ['[data-tidy-always-draggable]'].includes(selector) ||
+      super._canDragStart(selector)
+    );
   }
 
   async _onDropSingleItem(itemData: any, event: DragEvent) {

--- a/src/sheets/classic/Tidy5eNpcSheet.svelte.ts
+++ b/src/sheets/classic/Tidy5eNpcSheet.svelte.ts
@@ -135,6 +135,10 @@ export class Tidy5eNpcSheet
       scrollY: ['[data-tidy-track-scroll-y]', '.scroll-container'],
       dragDrop: [
         {
+          dragSelector: `[data-tidy-always-draggable]`,
+          dropSelector: null,
+        },
+        {
           dragSelector: '[data-tidy-draggable]',
           dropSelector: null,
         },
@@ -729,7 +733,9 @@ export class Tidy5eNpcSheet
       customActorTraits: CustomActorTraitsRuntime.getEnabledTraits(
         defaultDocumentContext
       ),
-      customContent: await NpcSheetClassicRuntime.getContent(defaultDocumentContext),
+      customContent: await NpcSheetClassicRuntime.getContent(
+        defaultDocumentContext
+      ),
       defaultSkills: new Set<string>(
         FoundryAdapter.getSystemSetting(CONSTANTS.SYSTEM_SETTING_DEFAULT_SKILLS)
       ),
@@ -1162,6 +1168,13 @@ export class Tidy5eNpcSheet
     return this._onToggleAbilityProficiency(event);
   }
 
+  _canDragStart(selector: string) {
+    return (
+      selector === `[data-tidy-always-draggable]` ||
+      super._canDragStart(selector)
+    );
+  }
+  
   async _onDropSingleItem(itemData: any, event: DragEvent) {
     // Create a Consumable spell scroll on the Inventory tab
     if (

--- a/src/sheets/classic/actor/InventoryGrid.svelte
+++ b/src/sheets/classic/actor/InventoryGrid.svelte
@@ -76,6 +76,11 @@
 
     onMouseLeave(event, item);
 
+    if (event.target !== event.currentTarget) {
+      // Allow for draggables within this containing element to be handled elsewhere.
+      return;
+    }
+
     const dragData = item.toDragData();
     event.dataTransfer?.setData('text/plain', JSON.stringify(dragData));
   }

--- a/src/sheets/classic/item/tabs/ItemActiveEffectsTab.svelte
+++ b/src/sheets/classic/item/tabs/ItemActiveEffectsTab.svelte
@@ -32,6 +32,11 @@
       return;
     }
 
+    if (event.target !== event.currentTarget) {
+      // Allow for draggables within this containing element to be handled elsewhere.
+      return;
+    }
+
     const dragData = effect.toDragData();
     event.dataTransfer?.setData('text/plain', JSON.stringify(dragData));
   }
@@ -81,7 +86,7 @@
           {#each effectEntries as { effect }}
             <li
               class="item effect flexrow"
-              data-tidy-draggable
+              data-tidy-always-draggable
               data-effect-id={effect.id}
               onmousedown={(event) => handleMiddleClickToEdit(event, effect)}
               ondragstart={(ev) => handleDragStart(ev, effect)}

--- a/src/sheets/classic/item/tabs/ItemActivitiesTab.svelte
+++ b/src/sheets/classic/item/tabs/ItemActivitiesTab.svelte
@@ -12,10 +12,15 @@
 
   const localize = FoundryAdapter.localize;
 
-  function handleDragStart(ev: DragEvent, activityId: string) {
+  function handleDragStart(event: DragEvent, activityId: string) {
+    if (event.target !== event.currentTarget) {
+      // Allow for draggables within this containing element to be handled elsewhere.
+      return;
+    }
+
     const activity = context.item.system.activities?.get(activityId);
 
-    ev.dataTransfer?.setData(
+    event.dataTransfer?.setData(
       'text/plain',
       JSON.stringify(activity.toDragData()),
     );
@@ -40,7 +45,7 @@
     {#each context.activities as activity (activity.id)}
       <div
         class="activity card"
-        data-tidy-draggable
+        data-tidy-always-draggable
         data-activity-id={activity.id}
         data-configurable={Activities.isConfigurable(activity)}
         data-context-menu={CONSTANTS.CONTEXT_MENU_TYPE_ACTIVITIES}

--- a/src/sheets/classic/item/tabs/ItemAdvancementTab.svelte
+++ b/src/sheets/classic/item/tabs/ItemAdvancementTab.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import InlineSvg from 'src/components/utility/InlineSvg.svelte';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
   import { settings } from 'src/settings/settings.svelte';
   import { getItemSheetContext } from 'src/sheets/sheet-context.svelte';
@@ -25,6 +24,11 @@
 
   function handleAdvancementDragStart(event: DragEvent, advancement: any) {
     if (!advancement) {
+      return;
+    }
+
+    if (event.target !== event.currentTarget) {
+      // Allow for draggables within this containing element to be handled elsewhere.
       return;
     }
 
@@ -125,7 +129,7 @@
         {@const isSvgIcon = isSvg(advancement.icon)}
         <li
           class="advancement-item item flexrow"
-          data-tidy-draggable
+          data-tidy-always-draggable
           data-id={advancement.id}
           ondragstart={(ev) => handleAdvancementDragStart(ev, advancement)}
         >

--- a/src/sheets/classic/shared/ContainerPanel.svelte
+++ b/src/sheets/classic/shared/ContainerPanel.svelte
@@ -29,6 +29,11 @@
     // Don't show cards while dragging
     onMouseLeave(event, item);
 
+    if (event.target !== event.currentTarget) {
+      // Allow for draggables within this containing element to be handled elsewhere.
+      return;
+    }
+
     const dragData = item.toDragData();
     event.dataTransfer?.setData('text/plain', JSON.stringify(dragData));
   }

--- a/src/sheets/quadrone/Tidy5eCharacterSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eCharacterSheetQuadrone.svelte.ts
@@ -3,7 +3,10 @@ import { ImportSheetControl } from 'src/features/sheet-header-controls/ImportShe
 import { SvelteApplicationMixin } from 'src/mixins/SvelteApplicationMixin.svelte';
 import { Tidy5eActorSheetBaseMixin } from 'src/mixins/Tidy5eActorSheetBaseMixin';
 import { TidyExtensibleDocumentSheetMixin } from 'src/mixins/TidyDocumentSheetMixin.svelte';
-import type { ApplicationConfiguration, ApplicationRenderOptions } from 'src/types/application.types';
+import type {
+  ApplicationConfiguration,
+  ApplicationRenderOptions,
+} from 'src/types/application.types';
 import type { GroupSheetClassicContext } from 'src/types/group.types';
 import CharacterSheet from './actor/CharacterSheet.svelte';
 import { mount } from 'svelte';
@@ -84,6 +87,10 @@ export class Tidy5eCharacterSheetQuadrone extends Tidy5eActorSheetBaseMixin(
     },
     dragDrop: [
       {
+        dragSelector: `[data-tidy-always-draggable]`,
+        dropSelector: null,
+      },
+      {
         dragSelector: '[data-tidy-draggable]',
         dropSelector: null,
       },
@@ -131,11 +138,7 @@ export class Tidy5eCharacterSheetQuadrone extends Tidy5eActorSheetBaseMixin(
 
     const html = globalThis.$(this.element);
 
-    initTidy5eContextMenu(
-      this,
-      html,
-      CONSTANTS.SHEET_LAYOUT_QUADRONE
-    );
+    initTidy5eContextMenu(this, html, CONSTANTS.SHEET_LAYOUT_QUADRONE);
 
     return component;
   }
@@ -145,19 +148,19 @@ export class Tidy5eCharacterSheetQuadrone extends Tidy5eActorSheetBaseMixin(
     return [];
   }
 
-   async _prepareContext(
-      options: ApplicationRenderOptions
-    ): Promise<CharacterSheetQuadroneContext> {
-      const baseContext = await super._prepareContext(options) as DocumentSheetQuadroneContext<Actor5e>;
+  async _prepareContext(
+    options: ApplicationRenderOptions
+  ): Promise<CharacterSheetQuadroneContext> {
+    const baseContext = (await super._prepareContext(
+      options
+    )) as DocumentSheetQuadroneContext<Actor5e>;
 
-      const context: CharacterSheetQuadroneContext = {
-        ...baseContext,
-        actor: this.actor,
-        token: this.token,
-      }
+    const context: CharacterSheetQuadroneContext = {
+      ...baseContext,
+      actor: this.actor,
+      token: this.token,
+    };
 
-      return context;
-    }
-
-    
+    return context;
+  }
 }

--- a/src/sheets/quadrone/Tidy5eContainerSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eContainerSheetQuadrone.svelte.ts
@@ -99,6 +99,10 @@ export class Tidy5eContainerSheetQuadrone
     actions: {},
     dragDrop: [
       {
+        dragSelector: `[data-tidy-always-draggable]`,
+        dropSelector: null,
+      },
+      {
         dragSelector: '[data-tidy-draggable]',
         dropSelector: null,
       },
@@ -386,7 +390,7 @@ export class Tidy5eContainerSheetQuadrone
   /* -------------------------------------------- */
   /*  Drag and Drop                               */
   /* -------------------------------------------- */
-
+  
   /** @inheritDoc */
   async _onDrop(
     event: DragEvent & { currentTarget: HTMLElement; target: HTMLElement }

--- a/src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte.ts
@@ -83,6 +83,10 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin(
         dragSelector: '[data-tidy-draggable]',
         dropSelector: null,
       },
+      {
+        dragSelector: `[data-tidy-always-draggable]`,
+        dropSelector: null,
+      },
     ],
     submitOnClose: true,
   };
@@ -757,15 +761,6 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin(
   /* -------------------------------------------- */
 
   /** @inheritDoc */
-  _canDragStart(selector: string) {
-    if (['.advancement-item', '[data-effect-id]'].includes(selector))
-      return true;
-    return this.isEditable;
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritDoc */
   _canDragDrop(selector: string) {
     return this.isEditable;
   }
@@ -776,21 +771,25 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin(
   _onDragStart(
     event: DragEvent & { currentTarget: HTMLElement; target: HTMLElement }
   ) {
-    const li = event.currentTarget;
-    if (event.target.classList.contains('content-link')) return;
+    if (event.target !== event.currentTarget) {
+      // Allow for draggables within this containing element to be handled elsewhere.
+      return;
+    }
+
+    const dragged = event.currentTarget;
 
     // Create drag data
     let dragData;
 
     // Active Effect
-    if (li.dataset.effectId) {
-      const effect = this.item.effects.get(li.dataset.effectId);
+    if (dragged.dataset.effectId) {
+      const effect = this.item.effects.get(dragged.dataset.effectId);
       dragData = effect.toDragData();
     } else if (
-      li.classList.contains('advancement-item') &&
-      !isNil(li.dataset.id)
+      dragged.classList.contains('advancement-item') &&
+      !isNil(dragged.dataset.id)
     ) {
-      dragData = this.item.advancement.byId[li.dataset.id]?.toDragData();
+      dragData = this.item.advancement.byId[dragged.dataset.id]?.toDragData();
     }
 
     if (!dragData) return;
@@ -870,13 +869,13 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin(
    */
   _onDropActivity(
     event: DragEvent & { currentTarget: HTMLElement; target: HTMLElement },
-    { data }: any
+    { data, uuid }: any
   ) {
     const { _id: id, type } = data;
-    const source = this.item.system.activities.get(id);
 
     // Reordering
-    if (source) {
+    if (this.item.id === foundry.utils.parseUuid(uuid)?.documentId) {
+      const source = this.item.system.activities.get(id);
       const targetId = event.target.closest<HTMLElement>(
         '.activity[data-activity-id]'
       )?.dataset.activityId;

--- a/src/todo.md
+++ b/src/todo.md
@@ -55,6 +55,8 @@
 - [ ] Implement quadrone default tab settings (no UI)
   - [ ] Item
     - [ ] This has to explode out into unique tabs per item type.
+- [ ] Editor style needs CSS help: https://discord.com/channels/1167985253072257115/1169792539545587733/1362188451910258869
+- [ ] Make inline activities draggable / droppable within the scope of an item table row / summary
 
 ### Scratch - Finding the effective theme for a sheet
 


### PR DESCRIPTION
Reviewed and refined the drag/drop setup. For now, added data-tidy-always-draggable attribute for those things that are always draggable, no matter the circumstances.

Fixed a bug where activities won't get properly added when their ID matches an activity ID on the trigger, instead triggering a sort.

Removed a rogue border on item images in the tidy table row use button.