### PR TITLE
quick fix: try/catch when submitting on close

### DIFF
--- a/src/mixins/TidyDocumentSheetMixin.svelte.ts
+++ b/src/mixins/TidyDocumentSheetMixin.svelte.ts
@@ -425,7 +425,11 @@ export function TidyExtensibleDocumentSheetMixin<
         this.options.submitOnClose && this.document.isOwner && this.isEditable;
 
       if (submit) {
-        await this.submit({ preventClose: true, preventRender: true });
+        try {
+          await this.submit({ preventClose: true, preventRender: true });
+        } catch (e) {
+          error('An error occurred while submitting changes', false, e);
+        }
       }
 
       await super.close(options);


### PR DESCRIPTION
Added try/catch to the close function in the App V2 doc sheet mixin when attempting to submit on close. The error will still log to the console, but the sheet will successfully close.