### PR TITLE
[#1148] TypeError fix on App V1 sheets

### DIFF
--- a/src/sheets/classic/Tidy5eCharacterSheet.svelte.ts
+++ b/src/sheets/classic/Tidy5eCharacterSheet.svelte.ts
@@ -1704,8 +1704,10 @@ export class Tidy5eCharacterSheet
       }
 
       await this._renderSheet(force, options);
-      const content = this.form.closest('.window-content');
-      this._dragDrop.forEach((d: any) => d.bind(content));
+      const content = this.form?.closest('.window-content');
+      if (content) {
+        this._dragDrop.forEach((d: any) => d.bind(content));
+      }
     });
     this.tidyRendering = false;
     debug('Sheet render end');

--- a/src/sheets/classic/Tidy5eKgarVehicleSheet.svelte.ts
+++ b/src/sheets/classic/Tidy5eKgarVehicleSheet.svelte.ts
@@ -732,8 +732,10 @@ export class Tidy5eVehicleSheet
       }
 
       await this._renderSheet(force, options);
-      const content = this.form.closest('.window-content');
-      this._dragDrop.forEach((d: any) => d.bind(content));
+      const content = this.form?.closest('.window-content');
+      if (content) {
+        this._dragDrop.forEach((d: any) => d.bind(content));
+      }
     });
     this.tidyRendering = false;
     debug('Sheet render end');

--- a/src/sheets/classic/Tidy5eNpcSheet.svelte.ts
+++ b/src/sheets/classic/Tidy5eNpcSheet.svelte.ts
@@ -1267,8 +1267,10 @@ export class Tidy5eNpcSheet
       }
 
       await this._renderSheet(force, options);
-      const content = this.form.closest('.window-content');
-      this._dragDrop.forEach((d: any) => d.bind(content));
+      const content = this.form?.closest('.window-content');
+      if (content) {
+        this._dragDrop.forEach((d: any) => d.bind(content));
+      }
     });
     this.tidyRendering = false;
     debug('Sheet render end');


### PR DESCRIPTION
Made dragdrop bind on app v1 sheets more defensive. Some modules may cause `this.form` to be unavailable, apparently.