### PR TITLE
Quick fix translation issues

### DIFF
--- a/src/components/action-bar/FilterButtonMenuQuadrone.svelte
+++ b/src/components/action-bar/FilterButtonMenuQuadrone.svelte
@@ -44,13 +44,13 @@
 >
   <i class="fas fa-filter"></i>
   {#snippet menu()}
-    {#each Object.entries(categories) as [category, filters] (category)}
+    {#each Object.entries(categories) as [category, filters]}
       <section class="filter-group">
         <h4 class="filter-group-header">
           {localize(category)}
         </h4>
         <div class="filters">
-          {#each filters as filter (filter.text)}
+          {#each filters as filter}
             <FilterToggle filterGroupName={tabId} {filter}>
               {localize(filter.text)}
             </FilterToggle>

--- a/src/components/filter/FilterButton.svelte
+++ b/src/components/filter/FilterButton.svelte
@@ -48,13 +48,13 @@
     menuElement="div"
     buttonStyle="transparent-inline-icon"
   >
-    {#each Object.entries(categories) as [category, filters] (category)}
+    {#each Object.entries(categories) as [category, filters]}
       <section class="filter-group">
         <h4 class="filter-group-header">
           {localize(category)}
         </h4>
         <div class="filters">
-          {#each filters as filter (filter.text)}
+          {#each filters as filter}
             <FilterToggleButton filterGroupName={tabId} {filter}>
               {localize(filter.text)}
             </FilterToggleButton>

--- a/src/components/tabs/UnderlinedTabStrip.svelte
+++ b/src/components/tabs/UnderlinedTabStrip.svelte
@@ -11,7 +11,7 @@
 </script>
 
 <div class="underlined-tab-strip flex-row no-gap {rest.class ?? ''}">
-  {#each tabs as tab (tab)}
+  {#each tabs as tab}
     <button
       type="button"
       class="underlined-tab"

--- a/src/sheets/quadrone/shared/ActionBar.svelte
+++ b/src/sheets/quadrone/shared/ActionBar.svelte
@@ -14,9 +14,8 @@
   import FilterToggle from 'src/components/buttons/FilterToggle.svelte';
   import { ItemFilterRuntime } from 'src/runtime/item/ItemFilterRuntime.svelte';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import FilterMenuQuadrone from 'src/components/action-bar/FilterButtonMenuQuadrone.svelte';
+  import FilterButtonMenuQuadrone from 'src/components/action-bar/FilterButtonMenuQuadrone.svelte';
   import SortButtonWithMenuQuadrone from 'src/components/action-bar/SortButtonWithMenuQuadrone.svelte';
-  import { isNil } from 'src/utils/data';
   import type { ContainerSheetQuadroneContext } from 'src/types/item.types';
 
   interface Props {
@@ -82,7 +81,7 @@
   {/if}
 
   {#if Object.keys(context.filterData).length}
-    <FilterMenuQuadrone filterData={context.filterData} {tabId} />
+    <FilterButtonMenuQuadrone filterData={context.filterData} {tabId} />
   {/if}
 
   <SortButtonWithMenuQuadrone doc={context.document} {tabId} />


### PR DESCRIPTION
- Fixed: When two spell schools were translated as the same text, it would cause the Spellbook tab to crash.