### PR TITLE
Fixed: when providing a header background URL with spaces (`%20`), th…

### DIFF
--- a/src/theme/theme-styles-provider.ts
+++ b/src/theme/theme-styles-provider.ts
@@ -258,6 +258,6 @@ function getUrlValue(path: string) {
       : // This backs the file directory location out of the Tidy module
         '../../';
 
-  const urlValue = `url(${pathPrefix}${path})`;
+  const urlValue = `url("${pathPrefix}${path}")`;
   return urlValue;
 }


### PR DESCRIPTION
…e background would not load, and the default background would show.