### PR TITLE
quick fix: Section Data Scrutiny, Input tuning

### DIFF
--- a/src/components/inputs/TextInputQuadrone.svelte
+++ b/src/components/inputs/TextInputQuadrone.svelte
@@ -85,12 +85,6 @@
       });
     }
 
-    await tick();
-
-    if (currentTarget.value !== value.toString()) {
-      currentTarget.value = value.toString();
-    }
-
     return result;
   }
 

--- a/src/foundry/TidyFlags.ts
+++ b/src/foundry/TidyFlags.ts
@@ -61,10 +61,13 @@ export class TidyFlags {
     unsetProp: TidyFlags.getFlagPropertyPath('-=actionSection'),
     /** Gets the item's Action Section setting. */
     get(item: Item5e): string | undefined {
-      const actionSection = TidyFlags.tryGetFlag<string>(
+      const actionSectionValue = TidyFlags.tryGetFlag(
         item,
         TidyFlags.actionSection.key
-      )?.trim();
+      );
+
+      const actionSection =
+        typeof actionSectionValue === 'string' ? actionSectionValue.trim() : '';
 
       return !isNil(actionSection, '') ? actionSection : undefined;
     },
@@ -829,10 +832,10 @@ export class TidyFlags {
     unsetProp: TidyFlags.getFlagPropertyPath('-=section'),
     /** Gets the custom section name for an item. */
     get(item: Item5e): string | undefined {
-      const section = TidyFlags.tryGetFlag<string>(
-        item,
-        TidyFlags.section.key
-      )?.trim();
+      const sectionValue = TidyFlags.tryGetFlag(item, TidyFlags.section.key);
+
+      const section =
+        typeof sectionValue === 'string' ? sectionValue.trim() : '';
 
       return !isNil(section, '') ? section : undefined;
     },


### PR DESCRIPTION
Removed drift correction logic from text input quadrone. It's not worth it.

Hardened section / action section flag getter logic to ignore non-strings.

From the community: https://discord.com/channels/170995199584108546/1400051691428253696