### PR TITLE
UI overhaul maintenance 1 2025 08 01

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -885,5 +885,6 @@
   "TIDY5E.HitDice.Current.Label": "Current Hit Dice",
   "TIDY5E.HitDice.Max.Label": "Max Hit Dice",
   "TIDY5E.CharacterTraits.Title": "Character Traits",
+  "TIDY5E.UseSpecificDefaultValue.Label": "Use Default ({value})",
   "TIDY5E.Notifications.FirstTimeWelcome1": "Welcome to Tidy 5e Sheets! To get started, you'll need to change {sheetLinkStart}a sheet{sheetLinkEnd} (or {allSheetsLinkStart}all your sheets{allSheetsLinkEnd}!) to use the Tidy version. Learn more about this module and what it can do on the {wikiLinkStart}official wiki{wikiLinkEnd}."
 }

--- a/src/applications/theme/ThemeSettingColorFormGroupQuadrone.svelte
+++ b/src/applications/theme/ThemeSettingColorFormGroupQuadrone.svelte
@@ -7,10 +7,17 @@
     key: string;
     label: string;
     value: string;
+    placeholder?: string;
     colorSelected?: () => void;
   }
 
-  let { label, value = $bindable(), key, colorSelected }: Props = $props();
+  let {
+    label,
+    value = $bindable(),
+    key,
+    colorSelected,
+    placeholder = '#FFFFFF',
+  }: Props = $props();
 
   const eyeDropperEnabled = 'EyeDropper' in window;
 
@@ -68,7 +75,7 @@
       id={inputId}
       {value}
       class="theme-color-textbox"
-      placeholder="#FFFFFF"
+      {placeholder}
       oninput={(ev) => onColorSelected(ev.currentTarget.value)}
     />
 

--- a/src/applications/theme/ThemeSettingsQuadrone.svelte
+++ b/src/applications/theme/ThemeSettingsQuadrone.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type {
+    ThemeColorSettingConfigEntry,
     ThemeSettingsContext,
     ThemeSettingsQuadroneApplication,
   } from './ThemeSettingsQuadroneApplication.svelte';
@@ -17,15 +18,47 @@
   interface Props {
     app: ThemeSettingsQuadroneApplication;
     settings: ThemeSettingsContext;
+    placeholders: ThemeSettingsContext | undefined;
   }
 
-  let { app, settings: context }: Props = $props();
+  let { app, settings: context, placeholders }: Props = $props();
 
   const localize = FoundryAdapter.localize;
 
   let idPrefix = `theme-settings-${foundry.utils.randomID()}`;
 
   let portraitShapes = ThemeQuadrone.getActorPortraitShapes();
+
+  let portraitShapeDefaultValue =
+    placeholders?.value?.portraitShape ?? ThemeQuadrone.DEFAULT_PORTRAIT_SHAPE;
+
+  let portraitShapeDefaultLabel = localize(
+    'TIDY5E.UseSpecificDefaultValue.Label',
+    {
+      value: localize(
+        `TIDY5E.ThemeSettings.PortraitShape.option.${portraitShapeDefaultValue}`,
+      ),
+    },
+  );
+
+  let modeColorPlaceholders = createColorPlaceholderMap(
+    placeholders?.value.spellPreparationModeColors,
+  );
+
+  let rarityColorPlaceholders = createColorPlaceholderMap(
+    placeholders?.value.rarityColors,
+  );
+
+  function createColorPlaceholderMap(colors?: ThemeColorSettingConfigEntry[]) {
+    return (
+      colors?.reduce<Record<string, string>>((prev, curr) => {
+        if (!isNil(curr.value, '')) {
+          prev[curr.key] = curr.value;
+        }
+        return prev;
+      }, {}) ?? {}
+    );
+  }
 
   $effect(() => {
     const liveSettings = app.mapContextToSettings(context);
@@ -82,6 +115,7 @@
       key="accent-color"
       bind:value={context.value.accentColor}
       label={localize('TIDY5E.ThemeSettings.AccentColor.title')}
+      placeholder={placeholders?.value.accentColor}
     />
     <p class="hint">
       {localize('TIDY5E.ThemeSettings.SheetTheme.hint')}
@@ -99,7 +133,7 @@
             id="{idPrefix}-actor-portrait-shape"
             bind:value={context.value.portraitShape}
           >
-            <option value={undefined}></option>
+            <option value={undefined}>{portraitShapeDefaultLabel}</option>
             {#each portraitShapes as shape}
               <option value={shape}
                 >{localize(
@@ -119,6 +153,7 @@
             id="{idPrefix}-actor-header-background"
             type="text"
             bind:value={context.value.actorHeaderBackground}
+            placeholder={placeholders?.value.actorHeaderBackground}
           />
           <ImagePickerButton
             current={context.value.actorHeaderBackground}
@@ -139,6 +174,7 @@
             id="{idPrefix}-item-sidebar-background"
             type="text"
             bind:value={context.value.itemSidebarBackground}
+            placeholder={placeholders?.value.itemSidebarBackground}
           />
           <ImagePickerButton
             current={context.value.itemSidebarBackground}
@@ -160,6 +196,7 @@
         key={color.key}
         bind:value={color.value}
         label={color.label.titleCase()}
+        placeholder={rarityColorPlaceholders[color.key]}
       />
     {/each}
   </fieldset>
@@ -175,6 +212,7 @@
         key={color.key}
         bind:value={color.value}
         label={color.label}
+        placeholder={modeColorPlaceholders[color.key]}
       />
     {/each}
   </fieldset>

--- a/src/applications/theme/ThemeSettingsQuadroneApplication.svelte.ts
+++ b/src/applications/theme/ThemeSettingsQuadroneApplication.svelte.ts
@@ -93,12 +93,16 @@ export class ThemeSettingsQuadroneApplication extends SvelteApplicationMixin<Con
 
   _createComponent(node: HTMLElement): Record<string, any> {
     this._settings = this._getSettings();
+    const placeholders = this.document
+      ? this._mapSettings(ThemeQuadrone.getWorldThemeSettings())
+      : undefined;
 
     const component = mount(ThemeSettingsQuadrone, {
       target: node,
       props: {
         app: this,
         settings: this._settings,
+        placeholders,
       },
     });
 
@@ -118,11 +122,18 @@ export class ThemeSettingsQuadroneApplication extends SvelteApplicationMixin<Con
         this.document
           ? ThemeQuadrone.getSheetThemeSettings({
               doc: this.document,
+              applyWorldThemeSetting: false,
             })
           : ThemeQuadrone.getWorldThemeSettings()
       );
 
-    let context: ThemeSettingsContext = {
+    let context: ThemeSettingsContext = this._mapSettings(themeSettings);
+
+    return context;
+  }
+
+  private _mapSettings(themeSettings: ThemeSettingsV2): ThemeSettingsContext {
+    return {
       value: {
         accentColor: themeSettings.accentColor,
         actorHeaderBackground: themeSettings.actorHeaderBackground,
@@ -148,8 +159,6 @@ export class ThemeSettingsQuadroneApplication extends SvelteApplicationMixin<Con
         }),
       },
     };
-
-    return context;
   }
 
   /* -------------------------------------------- */

--- a/src/runtime/tab/TabManager.ts
+++ b/src/runtime/tab/TabManager.ts
@@ -28,6 +28,7 @@ export class TabManager {
           onRender: sheetTab.onRender,
           content: await getTabContent(context, sheetTab),
           autoHeight: sheetTab.autoHeight,
+          itemCount: sheetTab.itemCount,
         };
 
         tabs.push(tab);

--- a/src/sheets/quadrone/item/parts/ItemHeaderStart.svelte
+++ b/src/sheets/quadrone/item/parts/ItemHeaderStart.svelte
@@ -1,12 +1,21 @@
 <script lang="ts">
   import ConfigurableSource from '../../shared/ConfigurableSource.svelte';
   import SheetHeaderEditModeToggleV2 from 'src/sheets/classic/shared/SheetHeaderModeToggleV2.svelte';
-  import { getContainerSheetQuadroneContext } from 'src/sheets/sheet-context.svelte';
+  import { getSheetContext } from 'src/sheets/sheet-context.svelte';
+  import type {
+    ContainerSheetQuadroneContext,
+    ItemSheetQuadroneContext,
+  } from 'src/types/item.types';
 
-  const context = $derived(getContainerSheetQuadroneContext());
+  const context =
+    $derived(
+      getSheetContext<
+        ItemSheetQuadroneContext | ContainerSheetQuadroneContext
+      >(),
+    );
 
   let sourceText = $derived(
-    (context.unlocked && !context.system.source?.label)
+    context.unlocked && !context.system.source?.label
       ? game.i18n.localize('DND5E.SOURCE.FIELDS.source.label')
       : context.system.source?.label,
   );

--- a/src/theme/theme-quadrone.svelte.ts
+++ b/src/theme/theme-quadrone.svelte.ts
@@ -23,9 +23,8 @@ export type ThemeableSheetType =
   | Tidy5eItemSheetQuadrone
   | Tidy5eContainerSheetQuadrone;
 
-const DEFAULT_PORTRAIT_SHAPE: PortraitShape = 'round';
-
 export class ThemeQuadrone {
+  static readonly DEFAULT_PORTRAIT_SHAPE: PortraitShape = 'round';
   static onReady() {
     setTimeout(() => {
       // Establish color mappings for Item Rarity and Spell Prep Mode
@@ -76,7 +75,11 @@ export class ThemeQuadrone {
   static getSheetThemeSettings(
     options: ThemeSettingsConfigurationOptions
   ): ThemeSettingsV2 {
-    let defaultSettings = this.getDefaultThemeSettings();
+    options.applyWorldThemeSetting ??= true;
+
+    let defaultSettings = options.applyWorldThemeSetting
+      ? this.getWorldThemeSettings()
+      : this.getDefaultThemeSettings();
 
     if (options.doc?.parent) {
       let parentSettings = this.getSheetThemeSettings({
@@ -218,7 +221,7 @@ export class ThemeQuadrone {
     return coalesce(
       TidyFlags.sheetThemeSettings.get(doc)?.portraitShape,
       settings.value.worldThemeSettings?.portraitShape,
-      DEFAULT_PORTRAIT_SHAPE
+      this.DEFAULT_PORTRAIT_SHAPE
     ) as PortraitShape;
   }
 

--- a/src/theme/theme-quadrone.types.ts
+++ b/src/theme/theme-quadrone.types.ts
@@ -27,8 +27,14 @@ export type ThemeQuadroneStyleDeclaration = {
 };
 
 export type ThemeSettingsConfigurationOptions = {
-  
+  /**
+   * Optional document whose theming is being configured.
+   * If not provided, then World Theme Settings are assumed.
+   */
   doc?: any;
+  /**
+   * Use these theme settings when applying the appropriate CSS updates.
+   */
   settingsOverride?: ThemeSettingsV2;
   /**
    * Some applications are related to a document but are
@@ -36,6 +42,12 @@ export type ThemeSettingsConfigurationOptions = {
    * their own style declarations related to their related document.
    */
   idOverride?: string;
+  /** 
+   * Use world theme settings as a baseline when deriving the final styles.
+   * Set to false when performing activities like presenting a Sheet-specific Theme Settings form. 
+   * default: true
+   */
+  applyWorldThemeSetting?: boolean;
 };
 
 export type PortraitShape = 'transparent' | 'round' | 'square' | 'token';

--- a/src/todo.md
+++ b/src/todo.md
@@ -2,7 +2,9 @@
 
 ### The Short List
 
-- [ ] Refactor rename and move the following to Actor space and out of Character space
+
+- [ ] Investigate: Setting default image shape does not update image shapes for sheets with no settings
+- [ ] (wait for another hightouch PR) Refactor rename and move the following to Actor space and out of Character space
   - [ ] (confirm) CharacterPortrait 
   - [ ] (confirm) CharacterExhaustionBar 
   - [ ] (confirm) src/sheets/quadrone/actor/character-parts/traits/CharacterTraitConfigurableListEntry.svelte
@@ -267,6 +269,8 @@ Limited:
     - [x] Functionality
     - [x] Drag drop
     - [x] Context menu
+- [x] Fix: column counts on item sheets is missing
+
 
 #### NPC Statblock Sections notes
 

--- a/src/todo.md
+++ b/src/todo.md
@@ -9,24 +9,21 @@
   - [ ] (confirm) src/sheets/quadrone/actor/character-parts/traits/CharacterTraits.svelte
   - [ ] (confirm) src/sheets/quadrone/actor/character-parts/CharacterSubtitle.svelte
   - [ ] (confirm) src/sheets/quadrone/actor/character-parts/SavingThrowsCard.svelte
-- [ ] Chase NPC
-
-### NPC Sheet
-
-- [ ] Header
-  - [ ] Portrait
-  - [ ] AC and Vitals
-  - [ ] Name
-  - [ ] Subtitle
-  - [ ] Sheet header buttons
-  - [ ] CR
-  - [ ] Image switcher toggle (show on unlocked, left of subtitle contents)
-  - [ ] abilities
-- [ ] Refactor: If biography tab stays the same between PC and NPC after NPC is completed, consider extracting and sharing a base component that the bio tabs pass data into, to receive biography content.
-- [ ] Refactor idea: Gather row actions as derived values of the sheet's own context state on the sheet class itself. See if it will reactively update based on context changes.
+- [ ] NPC Sheet
+  - [ ] Header
+    - [ ] Portrait
+    - [ ] AC and Vitals
+    - [ ] Name
+    - [ ] Subtitle
+    - [ ] Sheet header buttons
+    - [ ] CR
+    - [ ] Image switcher toggle (show on unlocked, left of subtitle contents)
+    - [ ] abilities
 
 ### (Almost) Everything after the short list
 
+- [ ] Refactor: If biography tab stays the same between PC and NPC after NPC is completed, consider extracting and sharing a base component that the bio tabs pass data into, to receive biography content.
+- [ ] Refactor idea: Gather row actions as derived values of the sheet's own context state on the sheet class itself. See if it will reactively update based on context changes.
 - [ ] Effect table rows: when effect is disabled / suppressed, use the italicized / sad styles from unprepared spells and unidentified items.
 - [ ] Create attachment for inlineWidth observer so that a callback can supply the inline width for the caller to react to. We can take the width and update a stateful value that is also included in context, so that all descendents have access to the inline width.
   - [ ] Identify all resize observers which can be removed.

--- a/src/todo.md
+++ b/src/todo.md
@@ -10,6 +10,7 @@
   - [ ] (confirm) src/sheets/quadrone/actor/character-parts/CharacterSubtitle.svelte
   - [ ] (confirm) src/sheets/quadrone/actor/character-parts/SavingThrowsCard.svelte
 - [ ] NPC Sheet
+  - [ ] Make loyalty tracker match legendary trackers
   - [ ] Header
     - [ ] Portrait
     - [ ] AC and Vitals

--- a/src/todo.md
+++ b/src/todo.md
@@ -2,7 +2,6 @@
 
 ### The Short List
 
-- [ ] Fix: Source is missing in NPC header
 - [ ] (wait for another hightouch PR) Refactor rename and move the following to Actor space and out of Character space
   - [ ] (confirm) CharacterPortrait 
   - [ ] (confirm) CharacterExhaustionBar 
@@ -270,6 +269,7 @@ Limited:
     - [x] Context menu
 - [x] Fix: column counts on item sheets is missing
 - [x] Fix: Setting default image shape does not update image shapes for sheets with no settings
+- [x] Fix: Source is missing in NPC header -- gave the code to hightouch to plug in, since he's working in the area.
 
 
 #### NPC Statblock Sections notes

--- a/src/todo.md
+++ b/src/todo.md
@@ -2,8 +2,7 @@
 
 ### The Short List
 
-
-- [ ] Investigate: Setting default image shape does not update image shapes for sheets with no settings
+- [ ] Fix: Source is missing in NPC header
 - [ ] (wait for another hightouch PR) Refactor rename and move the following to Actor space and out of Character space
   - [ ] (confirm) CharacterPortrait 
   - [ ] (confirm) CharacterExhaustionBar 
@@ -270,6 +269,7 @@ Limited:
     - [x] Drag drop
     - [x] Context menu
 - [x] Fix: column counts on item sheets is missing
+- [x] Fix: Setting default image shape does not update image shapes for sheets with no settings
 
 
 #### NPC Statblock Sections notes


### PR DESCRIPTION
- Fixed: When changing portrait shape in World Theme Settings, it would not apply to actors.
- New: For sheet theme configuration, any world theme settings will show up as input placeholders.
- Fixed: Item Sheet tab item counts went missing.