### PR TITLE
compat: Double drakkenheims

### DIFF
--- a/src/integration/integration.ts
+++ b/src/integration/integration.ts
@@ -11,6 +11,7 @@ import { DrakkenheimCoreModuleIntegration } from './modules/Drakkenheim/Drakkenh
 import { TidyCustomSectionsInDefaultItemSheetIntegration } from './system/TidyCustomSectionsInDefaultItemSheetIntegration';
 import { ColorisThirdPartyIntegration } from './third-party/Coloris.svelte';
 import { DndTashasCauldronModuleIntegration } from './modules/DndTashasCauldron/DndTashasCauldron';
+import { SebastianCrowesGuideToDrakkenheimModuleIntegration } from './modules/Drakkenheim/SebastianCrowesGuideToDrakkenheim';
 
 export function setupIntegrations(api: Tidy5eSheetsApi) {
   setupSystemIntegrations(api);
@@ -41,6 +42,7 @@ const moduleIntegrations: ModuleIntegrationBase[] = [
   new PopoutModuleIntegration(),
   new CustomCharacterSheetsModuleIntegration(),
   new DrakkenheimCoreModuleIntegration(),
+  new SebastianCrowesGuideToDrakkenheimModuleIntegration(),
   new DndTashasCauldronModuleIntegration(),
   // Add other module integrations here
 ];
@@ -66,7 +68,11 @@ function setupThirdPartyIntegrations(api: Tidy5eSheetsApi) {
     try {
       m.init(api);
     } catch (e) {
-      error(`Module integration failed for third party script ${m.name}`, false, e);
+      error(
+        `Module integration failed for third party script ${m.name}`,
+        false,
+        e
+      );
     }
   });
 }

--- a/src/integration/modules/Drakkenheim/DrakkenheimCore.ts
+++ b/src/integration/modules/Drakkenheim/DrakkenheimCore.ts
@@ -26,7 +26,15 @@ export class DrakkenheimCoreModuleIntegration implements ModuleIntegrationBase {
       title: () => FoundryAdapter.localize('DRAKKENHEIM.CONTAMINATION.tab'),
       tabId: 'drakkenheim-contamination-tab',
       component: DrakkenheimCoreContaminationTab,
-      getContext(context) {
+      getContext(context: Map<string, any>) {
+        context ??= new Map<string, any>();
+        context.set(
+          DRAKKENHEIM_CORE_CONSTANTS.SVELTE_CONTEXT.VERSION,
+          FoundryAdapter.getGameSetting(
+            DRAKKENHEIM_CORE_CONSTANTS.MODULE_ID,
+            DRAKKENHEIM_CORE_CONSTANTS.SETTING_VERSION
+          )
+        );
         return context;
       },
       iconClass: 'fa-solid fa-meteor',

--- a/src/integration/modules/Drakkenheim/DrakkenheimCoreConstants.ts
+++ b/src/integration/modules/Drakkenheim/DrakkenheimCoreConstants.ts
@@ -6,4 +6,7 @@ export const DRAKKENHEIM_CORE_CONSTANTS = {
   CONTAMINATION_LEVEL_FLAG_PROP: `flags.drakkenheim.contamination`,
   VERSION_MODERN: 'modern',
   VERSION_LEGACY: 'legacy',
+  SVELTE_CONTEXT: {
+    VERSION: 'drakkenheimVersion'
+  }
 } as const;

--- a/src/integration/modules/Drakkenheim/DrakkenheimCoreConstants.ts
+++ b/src/integration/modules/Drakkenheim/DrakkenheimCoreConstants.ts
@@ -1,5 +1,6 @@
 export const DRAKKENHEIM_CORE_CONSTANTS = {
   MODULE_ID: 'drakkenheim-core',
+  SEBASTIAN_CROWE_MODULE_ID: 'drakkenheim-scgd',
   SETTING_VERSION: 'VERSION',
   SETTING_DISABLE_TAB: 'DISABLE_TAB',
   CONTAMINATION_LEVEL_FLAG_PROP: `flags.drakkenheim.contamination`,

--- a/src/integration/modules/Drakkenheim/DrakkenheimCoreContaminationTab.svelte
+++ b/src/integration/modules/Drakkenheim/DrakkenheimCoreContaminationTab.svelte
@@ -7,6 +7,7 @@
   } from 'src/types/types';
   import { DRAKKENHEIM_CORE_CONSTANTS } from './DrakkenheimCoreConstants';
   import { getSheetContext } from 'src/sheets/sheet-context.svelte';
+  import { getContext } from 'svelte';
 
   const context =
     $derived(
@@ -24,9 +25,8 @@
 
   let levels = Array.fromRange(6, 1);
 
-  let version = FoundryAdapter.getGameSetting(
-    DRAKKENHEIM_CORE_CONSTANTS.MODULE_ID,
-    DRAKKENHEIM_CORE_CONSTANTS.SETTING_VERSION,
+  let version = $derived(
+    getContext<string>(DRAKKENHEIM_CORE_CONSTANTS.SVELTE_CONTEXT.VERSION),
   );
 
   let enrichedPromises = levels.map((level) =>
@@ -49,7 +49,9 @@
   <table class="contamination-table">
     <thead class="theme-dark">
       <tr>
-        <th class="symptom">{localize('DRAKKENHEIM.CONTAMINATION.TABLE.symptoms')}</th>
+        <th class="symptom"
+          >{localize('DRAKKENHEIM.CONTAMINATION.TABLE.symptoms')}</th
+        >
       </tr>
     </thead>
     <tbody>

--- a/src/integration/modules/Drakkenheim/SebastianCrowesGuideToDrakkenheim.ts
+++ b/src/integration/modules/Drakkenheim/SebastianCrowesGuideToDrakkenheim.ts
@@ -4,16 +4,18 @@ import DrakkenheimCoreContaminationTab from './DrakkenheimCoreContaminationTab.s
 import { FoundryAdapter } from 'src/foundry/foundry-adapter';
 import { DRAKKENHEIM_CORE_CONSTANTS } from './DrakkenheimCoreConstants';
 
-export class DrakkenheimCoreModuleIntegration implements ModuleIntegrationBase {
+export class SebastianCrowesGuideToDrakkenheimModuleIntegration
+  implements ModuleIntegrationBase
+{
   get moduleId(): string {
-    return DRAKKENHEIM_CORE_CONSTANTS.MODULE_ID;
+    return DRAKKENHEIM_CORE_CONSTANTS.SEBASTIAN_CROWE_MODULE_ID;
   }
 
   init(api: Tidy5eSheetsApi): void {
     // Since the setting requires a reload to toggle, we will simply avoid registering a column if it's disabled.
     if (
       FoundryAdapter.getGameSetting(
-        DRAKKENHEIM_CORE_CONSTANTS.MODULE_ID,
+        DRAKKENHEIM_CORE_CONSTANTS.SEBASTIAN_CROWE_MODULE_ID,
         DRAKKENHEIM_CORE_CONSTANTS.SETTING_DISABLE_TAB
       )
     ) {

--- a/src/integration/modules/Drakkenheim/SebastianCrowesGuideToDrakkenheim.ts
+++ b/src/integration/modules/Drakkenheim/SebastianCrowesGuideToDrakkenheim.ts
@@ -33,7 +33,7 @@ export class SebastianCrowesGuideToDrakkenheimModuleIntegration
         context.set(
           DRAKKENHEIM_CORE_CONSTANTS.SVELTE_CONTEXT.VERSION,
           FoundryAdapter.getGameSetting(
-            DRAKKENHEIM_CORE_CONSTANTS.MODULE_ID,
+            DRAKKENHEIM_CORE_CONSTANTS.SEBASTIAN_CROWE_MODULE_ID,
             DRAKKENHEIM_CORE_CONSTANTS.SETTING_VERSION
           )
         );

--- a/src/integration/modules/Drakkenheim/SebastianCrowesGuideToDrakkenheim.ts
+++ b/src/integration/modules/Drakkenheim/SebastianCrowesGuideToDrakkenheim.ts
@@ -28,7 +28,15 @@ export class SebastianCrowesGuideToDrakkenheimModuleIntegration
       title: () => FoundryAdapter.localize('DRAKKENHEIM.CONTAMINATION.tab'),
       tabId: 'drakkenheim-contamination-tab',
       component: DrakkenheimCoreContaminationTab,
-      getContext(context) {
+      getContext(context: Map<string, any>) {
+        context ??= new Map<string, any>();
+        context.set(
+          DRAKKENHEIM_CORE_CONSTANTS.SVELTE_CONTEXT.VERSION,
+          FoundryAdapter.getGameSetting(
+            DRAKKENHEIM_CORE_CONSTANTS.MODULE_ID,
+            DRAKKENHEIM_CORE_CONSTANTS.SETTING_VERSION
+          )
+        );
         return context;
       },
       iconClass: 'fa-solid fa-meteor',


### PR DESCRIPTION
Upgrade Drakkenheim to dual compatibility between Sebastian Crowe's Guide to Drakkenheim and Dungeons of Drakkenheim.