### PR TITLE
NPC inline legendary styles, and header finalized

### DIFF
--- a/src/applications-quadrone/configure-sections/ConfigureSections.svelte
+++ b/src/applications-quadrone/configure-sections/ConfigureSections.svelte
@@ -41,7 +41,7 @@
           <label for="">
             {localize(group.title)}
           </label>
-          <div class="form-fields">
+          <div class="form-fields vertical">
             {#each group.settings as setting}
               {#if setting.type === 'boolean'}
                 <label class="checkbox">

--- a/src/scss/quadrone/actors.scss
+++ b/src/scss/quadrone/actors.scss
@@ -470,8 +470,9 @@
           left: 50%;
           transform: translateY(-50%) translateX(-50%);
           text-shadow: 0 0 10.375rem rgba(0, 0, 0, 0.72);
+          transition: opacity var(--t5e-transition-default);
 
-          &:hover {
+          &.button-borderless.button-icon-only:hover {
             background: none;
 
             i {
@@ -1401,7 +1402,6 @@
         background-size: contain;
       }
 
-      // 👋 hightouch - POC styles for toggling visibility on mod/value and the score input
       &:has(.ability-score-input:focus) :where(.modifier, .value) {
         visibility: hidden;
       }
@@ -2171,17 +2171,12 @@
 
   .saving-throws {
     .use-ability-header {
-      // gap: var(--t5e-size-2x);
-      // padding: 0 var(--t5e-size-2x);
-
       i {
         flex: 0;
       }
     }
   }
 
-
-  // 👋 hightouch - I'm not sure the best location for our Skills Card CSS; it's here temporarily
   .use-ability-list {
 
     button.proficiency {

--- a/src/scss/quadrone/actors.scss
+++ b/src/scss/quadrone/actors.scss
@@ -624,7 +624,7 @@
           box-shadow: 0.125rem 0 0 var(--t5e-color-gold);
         }
 
-        .button {
+        .button.button-icon-only.button-borderless {
           &:not(.editMode) {
             position: absolute;
             right: 0;
@@ -720,6 +720,28 @@
           height: calc(100% + 0.125rem);
           width: 0.125rem;
           background-color: var(--t5e-color-gold);
+        }
+
+        input[type="text"].max-hp {
+          height: calc(var(--t5e-field-size-default) - 0.125rem);
+          color: var(--t5e-color-text-default);
+          font-size: var(--font-size-15);
+          font-weight: var(--font-weight-label);
+
+          &:hover,
+          &:focus,
+          &:active {
+            background-color: var(--t5e-component-field-background-hover-emphasis);
+          }
+
+          &::placeholder {
+            color: var(--t5e-color-text-gold);
+            font: var(--t5e-font-label-medium);
+          }
+
+          &::selection {
+            background-color: var(--t5e-theme-color-darker);
+          }
         }
 
         .exhaustion {
@@ -1578,96 +1600,6 @@
       }
     }
   }
-
-  // .concentration {
-  //   width: 100%;
-  //   overflow: hidden;
-  //   display: flex;
-  //   flex-direction: column-reverse;
-
-  //   span,
-  //   i {
-  //     transition: text-shadow var(--t5e-transition-default);
-  //   }
-
-  //   &:hover,
-  //   &:focus,
-  //   &:focus-within,
-  //   &:active {
-  //     text-shadow: 0 0 0.375rem var(--t5e-color-text-gold);
-
-  //     span {
-  //       text-shadow: 0 0 0.375rem var(--t5e-color-text-gold);
-  //     }
-  //   }
-
-  //   .concentration-roll-button {
-  //     height: auto;
-  //     min-height: auto;
-  //     margin-bottom: -2rem;
-  //     padding-bottom: 2.0625rem;
-  //     margin-left: -0.5rem;
-  //     margin-right: -0.5rem;
-
-  //     .label {
-  //       color: var(--t5e-color-text-gold);
-  //       overflow: hidden;
-  //       text-overflow: ellipsis;
-  //       width: 100%;
-  //       text-align: center;
-  //       margin-top: var(--t5e-size-2x);
-  //       text-transform: none;
-  //     }
-
-  //     &:focus,
-  //     &:focus-within,
-  //     &:active {
-  //       background: transparent;
-  //       outline: none;
-  //       box-shadow: none;
-  //     }
-  //   }
-
-  //   .concentration-bonus {
-  //     display: flex;
-  //     flex-direction: row;
-  //     align-items: center;
-  //     justify-content: center;
-  //     gap: var(--t5e-size-1);
-  //     margin-top: var(--t5e-size-1x);
-
-  //     >* {
-  //       flex-grow: 0;
-  //     }
-  //   }
-
-  //   i {
-  //     margin-bottom: 0.0625rem;
-  //     margin-right: 0.1875rem;
-  //   }
-
-  //   .modifier,
-  //   .value {
-  //     font-size: var(--font-size-14);
-  //     line-height: var(--line-height-14);
-  //   }
-
-  //   .config-container {
-  //     display: flex;
-  //     align-items: center;
-  //     justify-content: center;
-  //     width: 1rem;
-  //     height: 1rem;
-  //   }
-
-  //   .button-config {
-  //     display: inline-flex;
-  //     margin-left: var(--t5e-size-1x);
-  //     position: relative;
-  //     right: auto;
-  //     bottom: auto;
-  //   }
-  // }
 
   @mixin ability-smaller {
     --collapse-font-medium: 1.4375rem;

--- a/src/scss/quadrone/actors.scss
+++ b/src/scss/quadrone/actors.scss
@@ -2114,18 +2114,59 @@
     }
   }
 
-  .card {
+  .filigree-card {
     background-color: var(--t5e-component-card-default);
     padding: 0.3125rem 0.875rem 0.5rem;
+  }
 
-    .card-header {
+  .card-header {
+    display: flex;
+    gap: var(--t5e-size-2x);
+    padding: 0 var(--t5e-size-2x);
+    height: var(--t5e-field-size-default);
+
+    i {
+      flex: 0;
+    }
+  }
+
+  .cards-container {
+    align-items: stretch;
+    gap: var(--t5e-size-2x);
+    flex-wrap: wrap;
+
+    .card {
+      background: var(--t5e-component-card-darker);
+      border: 0.0625rem solid var(--t5e-component-field-border);
+      border-radius: 0.25rem;
+      box-shadow: var(--t5e-drop-shadow-field);
       display: flex;
-      gap: var(--t5e-size-2x);
-      padding: 0 var(--t5e-size-2x);
-      height: var(--t5e-field-size-default);
+      flex-direction: column;
+      flex: 1;
+      min-width: 10rem;
+      max-width: calc(50% - var(--t5e-size-1x));
+      padding: 0 0.75rem 0.5rem;
+      transition: box-shadow var(--t5e-transition-default);
 
-      i {
-        flex: 0;
+      .card-header {
+        text-align: center;
+        padding: 0;
+      }
+
+      .card-content {
+        display: flex;
+        flex: 1;
+        align-items: center;
+        justify-content: center;
+      }
+
+      &:hover,
+      &:focus-within {
+        box-shadow: var(--t5e-drop-shadow-card);
+      }
+
+      >* {
+        gap: var(--t5e-size-1x);
       }
     }
   }

--- a/src/scss/quadrone/character-parts/favorites.scss
+++ b/src/scss/quadrone/character-parts/favorites.scss
@@ -184,16 +184,14 @@
         }
       }
 
-      .item-use-button {
-        img {
-          --icon-fill: var(--t5e-color-icon-default);
-          fill: var(--icon-fill);
-          background: var(--t5e-color-palette-gold-56);
+      .item-image {
+        --icon-fill: var(--t5e-color-icon-default);
+        fill: var(--icon-fill);
 
-          &[src$=".svg"] {
-            fill: var(--t5e-color-icon-default);
-            color: white;
-          }
+        &[src$=".svg"] {
+          fill: var(--t5e-color-icon-default);
+          color: white;
+          background: var(--t5e-color-palette-gold-56);
         }
       }
     }

--- a/src/scss/quadrone/character-parts/favorites.scss
+++ b/src/scss/quadrone/character-parts/favorites.scss
@@ -145,7 +145,6 @@
               opacity: 0;
             }
 
-            // TODO: hightouch, this was one of the few ways to make an SVG icon go hidden. It doesn't animate, well (or possibly at all).
             dnd5e-icon {
               --icon-fill: transparent;
             }

--- a/src/scss/quadrone/forms.scss
+++ b/src/scss/quadrone/forms.scss
@@ -222,7 +222,8 @@
       margin-top: calc(var(--font-size-small) + 0.25rem);
     }
 
-    &:has(input[type='radio']) {
+    &:has(input[type='radio']),
+    &:has(.vertical) {
       align-items: flex-start;
 
       >label {
@@ -423,10 +424,14 @@
       align-items: end;
     }
 
-    &:has(input[type='radio']) {
+    &.vertical {
       justify-content: flex-start;
       flex-direction: column;
-      align-items: flex-start;
+      align-items: stretch;
+    }
+
+    >*:only-child {
+      flex: 1;
     }
   }
 

--- a/src/scss/quadrone/npc.scss
+++ b/src/scss/quadrone/npc.scss
@@ -191,6 +191,10 @@
       flex: 0 0 auto;
       height: var(--font-size-15);
       align-content: center;
+
+      .concentration-roll-button>* {
+        flex-wrap: nowrap;
+      }
     }
   }
 
@@ -493,11 +497,6 @@
           right: calc(50% - 0.875rem);
         }
       }
-
-      .concentration-roll-button {
-        margin-bottom: -1rem;
-        padding-bottom: 1rem;
-      }
     }
 
 
@@ -508,6 +507,10 @@
 
       .ability-roll-button {
         margin-bottom: -2.125rem;
+
+        &:active {
+          border: none;
+        }
       }
 
       .bonus-container .ability-score-input {
@@ -572,6 +575,10 @@
       }
     }
 
+    .ability-score-input {
+      font-size: var(--collapse-font-medium);
+    }
+
     .save {
       margin-right: var(--t5e-size-halfx);
     }
@@ -583,17 +590,6 @@
       .bonus {
         font-size: var(--collapse-font-medium);
         margin-left: 0;
-      }
-    }
-
-    .concentration {
-      max-width: 3rem;
-      padding: 0 0.25rem;
-
-      .concentration-roll-button {
-        margin-top: 0.5rem;
-        margin-left: 0;
-        margin-right: 0;
       }
     }
   }
@@ -637,57 +633,6 @@
   .sheet-header .abilities-container.ability-collapsed .abilities-container-inner {
     @include collapse-abilities;
   }
-
-  // @container abilities (width < 47.5rem) {
-  //   .sheet-header .abilities-container .abilities-container-inner {
-  //     &:has(:nth-child(11)) {
-  //       @include ability-smaller;
-  //     }
-  //   }
-  // }
-
-  // @container abilities (width < 45rem) {
-  //   .sheet-header .abilities-container .abilities-container-inner {
-
-  //     &:has(:nth-child(11)) {
-  //       @include collapse-abilities;
-  //       overflow-x: auto;
-  //       overflow-y: hidden;
-  //     }
-  //   }
-  // }
-
-  // @container abilities (width < 40rem) {
-
-  //   .sheet-header .abilities-container {
-  //     margin-right: var(--t5e-size-2x);
-
-  //     .abilities-container-inner:has(:nth-child(9)) {
-  //       @include ability-smaller;
-  //     }
-  //   }
-  // }
-
-  // @container abilities (width < 33.75rem) {
-
-  //   .sheet-header .abilities-container .abilities-container-inner {
-  //     &:has(:nth-child(8)):not(:has(:nth-child(9))) {
-  //       @include ability-smaller;
-
-  //       .initiative-container .initiative.score {
-  //         min-height: 3.375rem;
-  //       }
-  //     }
-
-  //     &:has(:nth-child(9)) {
-  //       @include collapse-abilities;
-
-  //       .concentration .concentration-roll-button {
-  //         margin-top: 0.375rem;
-  //       }
-  //     }
-  //   }
-  // }
 
   @container actor-sheet (width > 50rem) {
     --header-padding: 1.5rem;

--- a/src/scss/quadrone/npc.scss
+++ b/src/scss/quadrone/npc.scss
@@ -148,6 +148,10 @@
 
     input[type="text"]:not(:disabled):not(.uninput) {
 
+      &.actor-name {
+        margin-top: -0.25rem;
+      }
+
       &.xp-value,
       &.actor-name {
         --t5e-field-background-color: rgba(0, 0, 0, 0.2);
@@ -220,8 +224,12 @@
     align-items: center;
     justify-content: center;
     margin-right: var(--t5e-size-2x);
-    margin-top: var(--t5e-size-2x);
+    margin-top: 0.4375rem;
     gap: 0;
+
+    &:has(.challenge-rating-input) .label {
+      margin: 0.0625rem 0 0;
+    }
 
     >* {
       flex: 0;

--- a/src/scss/quadrone/npc.scss
+++ b/src/scss/quadrone/npc.scss
@@ -452,50 +452,6 @@
   }
 
   /* TABS */
-
-  .tidy-tab.statblock {
-    .legendaries {
-      align-items: stretch;
-      gap: var(--t5e-size-2x);
-      flex-wrap: wrap;
-    }
-
-    .npc-score-tracker {
-      background: var(--t5e-component-card-darker);
-      border: 0.0625rem solid var(--t5e-component-field-border);
-      border-radius: 0.25rem;
-      box-shadow: var(--t5e-drop-shadow-field);
-      display: flex;
-      flex-direction: column;
-      flex: 1;
-      min-width: 10rem;
-      max-width: calc(50% - var(--t5e-size-1x));
-      padding: 0 0.75rem 0.5rem;
-      transition: box-shadow var(--t5e-transition-default);
-
-      .card-header {
-        text-align: center;
-        padding: 0;
-      }
-
-      .card-content {
-        display: flex;
-        flex: 1;
-        align-items: center;
-        justify-content: center;
-      }
-
-      &:hover,
-      &:focus-within {
-        box-shadow: var(--t5e-drop-shadow-card);
-      }
-
-      >* {
-        gap: var(--t5e-size-1x);
-      }
-    }
-  }
-
   /* ----- */
 
   @mixin collapse-abilities {

--- a/src/scss/quadrone/npc.scss
+++ b/src/scss/quadrone/npc.scss
@@ -91,6 +91,15 @@
           padding-left: 0;
           max-width: 3.5rem;
         }
+
+        .hit-points {
+          position: relative;
+
+          .max-hp-override-indicator {
+            font-size: 0.375rem;
+            margin: 0 0 0.5rem -0.0625rem;
+          }
+        }
       }
 
       .exhaustion-bar {
@@ -300,6 +309,10 @@
           flex: 0;
         }
       }
+    }
+
+    .ability-roll-button:active {
+      border: none;
     }
 
     .ability-labels {
@@ -515,10 +528,6 @@
 
       .ability-roll-button {
         margin-bottom: -2.125rem;
-
-        &:active {
-          border: none;
-        }
       }
 
       .bonus-container .ability-score-input {

--- a/src/scss/quadrone/npc.scss
+++ b/src/scss/quadrone/npc.scss
@@ -423,6 +423,7 @@
     }
   }
 
+
   .npc-score-tracker {
     input {
       font-size: var(--font-size-18);
@@ -453,11 +454,45 @@
   /* TABS */
 
   .tidy-tab.statblock {
+    .legendaries {
+      align-items: stretch;
+      gap: var(--t5e-size-2x);
+      flex-wrap: wrap;
+    }
+
     .npc-score-tracker {
-      background: solid var(--t5e-component-card-darker);
-      border: 0.125rem solid var(--t5e-color-gold);
-      border-radius: 0.1875rem;
+      background: var(--t5e-component-card-darker);
+      border: 0.0625rem solid var(--t5e-component-field-border);
+      border-radius: 0.25rem;
       box-shadow: var(--t5e-drop-shadow-field);
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      min-width: 10rem;
+      max-width: calc(50% - var(--t5e-size-1x));
+      padding: 0 0.75rem 0.5rem;
+      transition: box-shadow var(--t5e-transition-default);
+
+      .card-header {
+        text-align: center;
+        padding: 0;
+      }
+
+      .card-content {
+        display: flex;
+        flex: 1;
+        align-items: center;
+        justify-content: center;
+      }
+
+      &:hover,
+      &:focus-within {
+        box-shadow: var(--t5e-drop-shadow-card);
+      }
+
+      >* {
+        gap: var(--t5e-size-1x);
+      }
     }
   }
 

--- a/src/scss/quadrone/tables.scss
+++ b/src/scss/quadrone/tables.scss
@@ -701,9 +701,9 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      align-self: stretch;
       font-size: var(--font-size-12);
       width: var(--t5e-icon-size-7x);
-      height: var(--t5e-icon-size-7x);
 
       i {
         color: var(--t5e-color-icon-disabled);

--- a/src/scss/quadrone/tables.scss
+++ b/src/scss/quadrone/tables.scss
@@ -173,9 +173,12 @@
     }
 
     .item-image {
-      background: var(--t5e-color-text-gold-emphasis);
       width: var(--t5e-icon-size-7x);
       height: var(--t5e-icon-size-7x);
+
+      &:has([src$=".svg"]) {
+        background: var(--t5e-color-text-gold-emphasis);
+      }
     }
 
     >* {
@@ -909,7 +912,9 @@
       // --t5e-item-row-background: rgba(255, 255, 255, 0.08);
 
       .item-image {
-        background-color: var(--t5e-color-palette-gold-56);
+        &:has([src$=".svg"]) {
+          background-color: var(--t5e-color-palette-gold-56);
+        }
       }
 
       &.expanded {

--- a/src/sheets/quadrone/actor/NpcSheet.svelte
+++ b/src/sheets/quadrone/actor/NpcSheet.svelte
@@ -285,6 +285,11 @@
               >
                 {effectiveMaxHp}
               </div>
+
+              {#if effectiveMaxHp !== hpMax}
+                <i class="fas fa-asterisk max-hp-override-indicator"></i>
+                <!-- TODO: hightouch - relatively positioned tiny pencil to denote altered max HP -->
+              {/if}
             </button>
             <TextInputQuadrone
               bind:this={hpValueInput}
@@ -382,10 +387,6 @@
             >
               <i class="fas fa-cog"></i>
             </button>
-          {/if}
-
-          {#if effectiveMaxHp !== hpMax}
-            <!-- TODO: hightouch - relatively positioned tiny pencil to denote altered max HP -->
           {/if}
         </div>
         <div class="actor-vitals-row">

--- a/src/sheets/quadrone/actor/NpcSheet.svelte
+++ b/src/sheets/quadrone/actor/NpcSheet.svelte
@@ -414,19 +414,21 @@
               </button>
             </div>
 
-            <TextInputQuadrone
-              document={context.actor}
-              field="system.attributes.hp.tempmax"
-              value={context.system.attributes.hp.tempmax}
-              enableDeltaChanges
-              selectOnFocus={true}
-              data-dtype="Number"
-              inputmode="numeric"
-              placeholder="+{localize('DND5E.Max')}"
-              class="max-hp uninput centered"
-              aria-label={localize('DND5E.HitPointsTempMax')}
-              data-tooltip={'DND5E.HitPointsTempMax'}
-            />
+            <div class="max-hp-container">
+              <TextInputQuadrone
+                document={context.actor}
+                field="system.attributes.hp.tempmax"
+                value={context.system.attributes.hp.tempmax}
+                enableDeltaChanges
+                selectOnFocus={true}
+                data-dtype="Number"
+                inputmode="numeric"
+                placeholder="+{localize('DND5E.Max')}"
+                class="max-hp uninput centered"
+                aria-label={localize('DND5E.HitPointsTempMax')}
+                data-tooltip={'DND5E.HitPointsTempMax'}
+              />
+            </div>
 
             <button
               type="button"

--- a/src/sheets/quadrone/actor/npc-parts/Legendaries.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/Legendaries.svelte
@@ -52,18 +52,18 @@
 {#snippet lairActions()}
   {#if context.modernRules && context.unlocked}
     <!-- Checkbox - has lair -->
-    <div class="card-header flexrow">
       {#if showFiligree}
-        <h3>
-          {localize('DND5E.LAIR.HasLair')}
-        </h3>
+        <div class="card-header flexrow">
+          <h3>
+            {localize('DND5E.LAIR.HasLair')}
+          </h3>
+        </div>
       {:else}
         <h3 class="font-label-medium bordered">
           <i class="fa-solid fa-eye-evil color-icon-disabled"></i>
           {localize('DND5E.LAIR.HasLair')}
         </h3>
       {/if}
-    </div>
     <span class="card-content value">
       <label class="label hidden" for="lair-has-lair"
         >{localize('DND5E.LAIR.HasLair')}</label
@@ -79,18 +79,18 @@
     </span>
   {:else if context.modernRules && !context.unlocked && context.system.resources.lair.value}
     <!-- Switch - inside lair -->
-    <div class="card-header flexrow">
       {#if showFiligree}
-        <h3>
-          {localize('DND5E.LAIR.Inside')}
-        </h3>
+        <div class="card-header flexrow">
+          <h3>
+            {localize('DND5E.LAIR.Inside')}
+          </h3>
+        </div>
       {:else}
         <h3 class="font-label-medium bordered">
           <i class="fa-solid fa-eye-evil color-icon-disabled"></i>
           {localize('DND5E.LAIR.Inside')}
         </h3>
       {/if}
-    </div>
     <span class="card-content value">
       <label class="label hidden" for="lair-inside"
         >{localize('DND5E.LAIR.Inside')}</label
@@ -105,18 +105,18 @@
     </span>
   {:else if !context.modernRules}
     <!-- Lair initiative -->
-    <div class="card-header flexrow">
       {#if showFiligree}
-        <h3>
-          {localize('DND5E.LAIR.Action.Label')}
-        </h3>
+        <div class="card-header flexrow">
+          <h3>
+            {localize('DND5E.LAIR.Action.Label')}
+          </h3>
+        </div>
       {:else}
         <h3 class="font-label-medium bordered">
           <i class="fa-solid fa-eye-evil color-icon-disabled"></i>
           {localize('DND5E.LAIR.Action.Label')}
         </h3>
       {/if}
-    </div>
     <div class="card-content flexrow lair-initiative">
       <span class="font-label-medium color-text-lighter flexshrink">
         {localize('DND5E.Initiative')}

--- a/src/sheets/quadrone/actor/npc-parts/Legendaries.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/Legendaries.svelte
@@ -64,7 +64,7 @@
         </h3>
       {/if}
     </div>
-    <span class="value">
+    <span class="card-content value">
       <label class="label hidden" for="lair-has-lair"
         >{localize('DND5E.LAIR.HasLair')}</label
       >
@@ -91,7 +91,7 @@
         </h3>
       {/if}
     </div>
-    <span class="value">
+    <span class="card-content value">
       <label class="label hidden" for="lair-inside"
         >{localize('DND5E.LAIR.Inside')}</label
       >
@@ -117,7 +117,7 @@
         </h3>
       {/if}
     </div>
-    <div class="flexrow lair-initiative">
+    <div class="card-content flexrow lair-initiative">
       <span class="font-label-medium color-text-lighter flexshrink">
         {localize('DND5E.Initiative')}
       </span>

--- a/src/sheets/quadrone/actor/npc-parts/NpcScoreTrackerCard.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/NpcScoreTrackerCard.svelte
@@ -47,18 +47,18 @@
         {label}
       </h3>
     </div>
-    <div class="flexrow">
+    <div class="card-content flexrow">
       {#if valuePath}
         <button
           type="button"
-          class="flexshrink decrementer"
+          class="button button-icon-only button-borderless flexshrink decrementer"
           disabled={value <= min}
           onclick={() => change(valuePath, -1)}
         >
           <i class="fa-solid fa-hexagon-minus"></i>
         </button>
       {/if}
-      <span class="uses">
+      <span class="uses flexrow">
         {#if valuePath}
           <NumberInputQuadrone
             document={actor}
@@ -75,7 +75,7 @@
             >{value}</span
           >
         {/if}
-        <span class="separator color-text-lightest">/</span>
+        <span class="separator color-text-lightest flexshrink">/</span>
         {#if maxPath && unlocked}
           <NumberInputQuadrone
             document={actor}
@@ -96,7 +96,7 @@
       {#if valuePath}
         <button
           type="button"
-          class="flexshrink decrementer"
+          class="button button-icon-only button-borderless flexshrink decrementer"
           disabled={!isNil(max) && value >= max}
           onclick={() => change(valuePath, 1)}
         >

--- a/src/sheets/quadrone/actor/tabs/NpcStatblockTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/NpcStatblockTab.svelte
@@ -44,11 +44,6 @@
           prop: legendariesProp,
           default: false,
         },
-      ],
-    } satisfies SectionOptionGroup,
-    {
-      title: '',
-      settings: [
         {
           type: 'boolean',
           label: 'TIDY5E.Utilities.IncludeSpellbookInNpcStatblockTab',

--- a/src/sheets/quadrone/actor/tabs/NpcStatblockTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/NpcStatblockTab.svelte
@@ -83,7 +83,7 @@
 <ActionBar bind:searchCriteria {sections} {tabId} {tabOptionGroups} />
 
 {#if context.showLegendariesOnStatblockTab && (context.showLegendaryActions || context.showLegendaryResistances || context.showLairTracker)}
-  <div class="legendaries flexrow">
+  <div class="legendaries cards-container flexrow">
     <Legendaries />
   </div>
 {/if}

--- a/src/sheets/quadrone/item/parts/ItemStartingEquipment.svelte
+++ b/src/sheets/quadrone/item/parts/ItemStartingEquipment.svelte
@@ -38,7 +38,7 @@
     </div>
   </div>
   <div class="form-group">
-    <label></label>
+    <label for="{appId}-starting-equipment"></label>
     <div class="form-fields">
       <div class="editor-rendered-content starting-equipment-list" id="{appId}-starting-equipment">
         {@html coalesce(

--- a/src/sheets/quadrone/item/tabs/ItemFeatDetailsTab.svelte
+++ b/src/sheets/quadrone/item/tabs/ItemFeatDetailsTab.svelte
@@ -130,7 +130,7 @@
   </div>
 
   <div class="form-group">
-    <label id="prerequisites-repeatable-{appId}">
+    <label for="prerequisites-repeatable-{appId}">
       {localize('DND5E.Prerequisites.FIELDS.prerequisites.repeatable.label')}
     </label>
     <div class="form-fields">
@@ -143,6 +143,7 @@
           disabledChecked={context.system.prerequisites.repeatable}
           disabled={!context.unlocked}
         />
+        &nbsp;
       </label>
     </div>
     <p class="hint">

--- a/src/todo.md
+++ b/src/todo.md
@@ -14,6 +14,8 @@
     - [x] Figure out solution for HP > 999
     - [x] Needs testing: Validate character sheet header styles are still working as expected
   - [ ] Make loyalty tracker match legendary trackers
+- [ ] PC and NPC Sheets
+  - [ ] Update class/subclass/background/species rows to View on double-click and Edit on middle-click
 
 #### Abilities Simplification Initiative
 

--- a/src/todo.md
+++ b/src/todo.md
@@ -11,7 +11,7 @@
     - [ ] Display background/subclass/etc in Statblock tab
     - [ ] Class styling in sidebar (copy from PC sheet Traits tab)
     - [ ] Show alignment/species/size in sidebar in Edit Mode, subtitle only in play mode
-    - [ ] Figure out solution for HP > 999
+    - [x] Figure out solution for HP > 999
     - [x] Needs testing: Validate character sheet header styles are still working as expected
   - [ ] Make loyalty tracker match legendary trackers
 


### PR DESCRIPTION
- Fixed some small alignment NPC header issues from fields/buttons
- NPC max HP field and overrides styled
- Inline cards for legendary actions styled up and prepped to hold...other item types 👀
- Transparent image background fixes for Letlev's issue; now properly only adds gold background for SVGs
- Fixed some form behavior to better handle lists of checkboxes/radios
- Fixed form fields to do a more greedy grab of mouse actions

I think we're down to just the additional sidebar/subtitle fields listed in the todos! Styles are all feeling solid