### PR TITLE
Quick fixes

### DIFF
--- a/src/components/info-card/Cards/SpellItemCard.svelte
+++ b/src/components/info-card/Cards/SpellItemCard.svelte
@@ -30,7 +30,7 @@
 
   let preparationMap = FoundryAdapter.getSpellPreparationStatesMap();
 
-  let method = $derived(CONFIG.DND5E.spellcasting[item.system.method]);
+  let method = $derived(FoundryAdapter.getSpellMethodConfig(item));
 
   let leftSubtitle = $derived(
     [
@@ -55,7 +55,7 @@
         <span>{leftSubtitle ?? ''}</span>
         {#if owner}
           {@const rightSubtitle = [
-            CONFIG.DND5E.spellcasting[item.system.method]?.getLabel({
+            FoundryAdapter.getSpellMethodConfig(item)?.getLabel({
               level: method?.slots ? item.system.level || 0 : 1,
               format: 'short',
             }),

--- a/src/components/table-quadrone/TidyItemTableRow.svelte
+++ b/src/components/table-quadrone/TidyItemTableRow.svelte
@@ -104,15 +104,18 @@
     }
   }
 
+  const config = $derived(
+    item.type === CONSTANTS.ITEM_TYPE_SPELL
+      ? FoundryAdapter.getSpellMethodConfig(item)
+      : undefined,
+  );
+
   const itemColorClasses = $derived<ClassValue>([
     !isNil(item.system.rarity, '') ? 'rarity' : undefined,
     item.system.rarity?.slugify(),
-    !isNil(item.system.method) ? 'spell-method' : undefined,
+    !isNil(config?.key) ? 'spell-method' : undefined,
     {
-      [`method-${item.system.method?.slugify()}`]: !isNil(
-        item.system.method,
-        '',
-      ),
+      [`method-${config?.key?.slugify()}`]: !isNil(config),
     },
     'equipped' in item.system && item.system.equipped ? 'equipped' : undefined,
   ]);

--- a/src/components/table-quadrone/table-buttons/SpellButton.svelte
+++ b/src/components/table-quadrone/table-buttons/SpellButton.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
   import { isNil } from 'src/utils/data';
   import type { ClassValue } from 'svelte/elements';
@@ -10,8 +9,8 @@
 
   let { doc }: Props = $props();
 
-  let method = $derived(doc.system.method ?? '');
-  let config = $derived(CONFIG.DND5E.spellcasting[method]);
+  let config = $derived(FoundryAdapter.getSpellMethodConfig(doc));
+  let method = $derived(config.key);
 
   let iconClasses: ClassValue = $derived([
     'spell-row-icon',

--- a/src/foundry/foundry-adapter.ts
+++ b/src/foundry/foundry-adapter.ts
@@ -364,6 +364,7 @@ export const FoundryAdapter = {
   },
   getSpellRowClasses(spell: any): string {
     const classes: string[] = [];
+    const method = FoundryAdapter.getSpellMethodConfig(spell).key;
 
     if (spell.system.canPrepare) {
       classes.push('can-prepare');
@@ -391,23 +392,23 @@ export const FoundryAdapter = {
       classes.push('always');
     }
 
-    if (spell.system.method === CONSTANTS.SPELL_PREPARATION_METHOD_SPELL) {
+    if (method === CONSTANTS.SPELL_PREPARATION_METHOD_SPELL) {
       classes.push('method-spell');
     }
 
-    if (spell.system.method === CONSTANTS.SPELL_PREPARATION_METHOD_PACT) {
+    if (method === CONSTANTS.SPELL_PREPARATION_METHOD_PACT) {
       classes.push('method-pact');
     }
 
-    if (spell.system.method === CONSTANTS.SPELL_PREPARATION_METHOD_ATWILL) {
+    if (method === CONSTANTS.SPELL_PREPARATION_METHOD_ATWILL) {
       classes.push('method-atwill');
     }
 
-    if (spell.system.method === CONSTANTS.SPELL_PREPARATION_METHOD_RITUAL) {
+    if (method === CONSTANTS.SPELL_PREPARATION_METHOD_RITUAL) {
       classes.push('method-ritual');
     }
 
-    if (spell.system.method === CONSTANTS.SPELL_PREPARATION_METHOD_INNATE) {
+    if (method === CONSTANTS.SPELL_PREPARATION_METHOD_INNATE) {
       classes.push('method-innate');
     }
 
@@ -1505,10 +1506,20 @@ export const FoundryAdapter = {
       return prev;
     }, {});
   },
+  getSpellMethodConfig(item: Item5e) {
+    return (
+      CONFIG.DND5E.spellcasting[item.system.method] ??
+      CONFIG.DND5E.spellcasting.innate
+    );
+  },
   getSpellIcon(item: Item5e): ClassValue {
+    const config = FoundryAdapter.getSpellMethodConfig(item);
+
+    const method = config.key;
+
     let classes: ClassValue = [];
 
-    if (item.system.canPrepare) {
+    if (config.prepares) {
       classes.push('can-prepare');
       classes.push(
         item.system.prepared ===
@@ -1523,7 +1534,7 @@ export const FoundryAdapter = {
       classes.push('cannot-prepare', 'fa-solid');
     }
 
-    switch (item.system.method) {
+    switch (method) {
       case CONSTANTS.SPELL_PREPARATION_METHOD_SPELL:
         classes.push('fa-book');
         break;

--- a/src/runtime/item/default-item-sorts.ts
+++ b/src/runtime/item/default-item-sorts.ts
@@ -68,7 +68,9 @@ export const defaultItemSortSchemes = {
       ) ||
       (a.system.level ?? 0) - (b.system.level ?? 0) ||
       binarize(b.system.prepared) - binarize(a.system.prepared) ||
-      (a.system.method ?? '').compare(b.system.method ?? '') ||
+      (a.system.method ?? CONSTANTS.SPELL_PREPARATION_METHOD_INNATE).compare(
+        b.system.method ?? CONSTANTS.SPELL_PREPARATION_METHOD_INNATE
+      ) ||
       a.name.localeCompare(b.name, game.i18n.lang),
   },
   [CONSTANTS.ITEM_SORT_METHOD_KEY_EQUIPPED]: {

--- a/src/sheets/quadrone/item/parts/Sidebar.svelte
+++ b/src/sheets/quadrone/item/parts/Sidebar.svelte
@@ -61,11 +61,13 @@
 
   // Spell Preparation
 
+  let config = $derived(FoundryAdapter.getSpellMethodConfig(context.item));
+
   let spellPreparationText = $derived(
-    context.system.method &&
-      context.system.method !== CONSTANTS.SPELL_PREPARATION_METHOD_SPELL
-      ? (CONFIG.DND5E.spellcasting[context.system.method]?.label ??
-          context.system.method)
+    config.key &&
+      config.key !== CONSTANTS.SPELL_PREPARATION_METHOD_SPELL
+      ? (CONFIG.DND5E.spellcasting[config.key]?.label ??
+          config.key)
       : '',
   );
 
@@ -88,8 +90,8 @@
     context.system.identified === false ? 'disabled' : undefined,
     !isNil(rarity, '') ? 'rarity' : undefined,
     coalesce(rarity?.slugify(), 'none'),
-    !isNil(context.system.method) ? 'spell-method' : undefined,
-    'method-' + context.system.method?.slugify(),
+    !isNil(config.key) ? 'spell-method' : undefined,
+    'method-' + config.key?.slugify(),
   ]);
 
   let saveContext = $derived(ItemContext.getItemSaveContext(context.item));

--- a/src/sheets/quadrone/item/tabs/ItemSpellDetailsTab.svelte
+++ b/src/sheets/quadrone/item/tabs/ItemSpellDetailsTab.svelte
@@ -167,7 +167,9 @@
             field="system.method"
             value={context.source.method}
             disabled={!context.unlocked}
+            blankValue={undefined}
           >
+            <option value={undefined}></option>
             <SelectOptions
               data={context.spellcastingMethods}
               labelProp="label"

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -9,6 +9,7 @@ import { CONSTANTS } from 'src/constants';
 import type { Item5e } from 'src/types/item.types';
 import { coalesce } from 'src/utils/formatting';
 import { isNil } from 'src/utils/data';
+import { FoundryAdapter } from 'src/foundry/foundry-adapter';
 
 const tidyStyleTagId = 'tidy5e-sheet-theme';
 
@@ -172,26 +173,28 @@ export function getInventoryItemThemeBackground(item: Item5e) {
 }
 
 export function getSpellItemThemeBackground(spell: Item5e) {
+  const config = FoundryAdapter.getSpellMethodConfig(spell);
+
   if (
-    spell.system.method === CONSTANTS.SPELL_PREPARATION_METHOD_INNATE
+    config.key === CONSTANTS.SPELL_PREPARATION_METHOD_INNATE
   ) {
     return '--t5e-innate-background';
   }
 
   if (
-    spell.system.method === CONSTANTS.SPELL_PREPARATION_METHOD_RITUAL
+    config.key === CONSTANTS.SPELL_PREPARATION_METHOD_RITUAL
   ) {
     return '--t5e-ritual-only-background';
   }
 
   if (
-    spell.system.method === CONSTANTS.SPELL_PREPARATION_METHOD_ATWILL
+    config.key === CONSTANTS.SPELL_PREPARATION_METHOD_ATWILL
   ) {
     return '--t5e-atwill-background';
   }
 
   if (
-    spell.system.method === CONSTANTS.SPELL_PREPARATION_METHOD_PACT
+    config.key === CONSTANTS.SPELL_PREPARATION_METHOD_PACT
   ) {
     return '--t5e-pact-background';
   }

--- a/src/utils/SpellUtils.ts
+++ b/src/utils/SpellUtils.ts
@@ -41,7 +41,6 @@ export class SpellUtils {
         SpellUtils.isUnlimitedAtWill(item) ||
         SpellUtils.isUnlimitedInnate(item) ||
         ItemUtils.hasSufficientLimitedUses(item) ||
-        SpellUtils.isPactMagic(item) ||
         SpellUtils.isRitualSpellForRitualCaster(item))
     );
   }
@@ -74,7 +73,10 @@ export class SpellUtils {
 
   /** Is an At-Will spell. */
   static isAtWill(item: any): boolean {
-    return item.system.method === CONSTANTS.SPELL_PREPARATION_METHOD_ATWILL;
+    return (
+      FoundryAdapter.getSpellMethodConfig(item).key ===
+      CONSTANTS.SPELL_PREPARATION_METHOD_ATWILL
+    );
   }
 
   /** Is an Innate spell with no limit on uses. */
@@ -84,12 +86,18 @@ export class SpellUtils {
 
   /** Is an Innate spell. */
   static isInnate(item: any): boolean {
-    return item.system.method === CONSTANTS.SPELL_PREPARATION_METHOD_INNATE;
+    return (
+      FoundryAdapter.getSpellMethodConfig(item).key ===
+      CONSTANTS.SPELL_PREPARATION_METHOD_INNATE
+    );
   }
 
   /** Is pact magic. */
   static isPactMagic(item: Item5e) {
-    return item.system.method === CONSTANTS.SPELL_PREPARATION_METHOD_PACT;
+    return (
+      FoundryAdapter.getSpellMethodConfig(item).key ===
+      CONSTANTS.SPELL_PREPARATION_METHOD_PACT
+    );
   }
 
   /** Is a spell that requires preparation and is prepared. */


### PR DESCRIPTION
Fixed: When a spell's method is undefined, the spellbook crashes. It is now updated to default to innate, as the system intends.

Fixed: Can Cast filter was still treating Pact spells as always castable instead of checking their preparedness.