### PR TITLE
UI Overhaul and the Return of Pickled Pete

### DIFF
--- a/src/foundry/foundry-adapter.ts
+++ b/src/foundry/foundry-adapter.ts
@@ -253,7 +253,7 @@ export const FoundryAdapter = {
     const dataModel = CONFIG.Item.dataModels[type];
     const singleton = dataModel?.metadata.singleton ?? false;
     if (singleton && actor.itemTypes[type].length) {
-      const error = FoundryAdapter.localize('DND5E.ActorWarningSingleton', {
+      const error = FoundryAdapter.localize('DND5E.ACTOR.Warning.Singleton', {
         itemType: type,
         actorType: actor.type,
       });

--- a/src/mixins/Tidy5eActorSheetBaseMixin.ts
+++ b/src/mixins/Tidy5eActorSheetBaseMixin.ts
@@ -345,7 +345,7 @@ export function Tidy5eActorSheetBaseMixin(BaseApplication: any) {
         const singleton = dataModel?.metadata.singleton ?? false;
         if (singleton && this.actor.itemTypes[itemData.type].length) {
           ui.notifications.error(
-            game.i18n.format('DND5E.ActorWarningSingleton', {
+            game.i18n.format('DND5E.ACTOR.Warning.Singleton', {
               itemType: game.i18n.localize(
                 CONFIG.Item.typeLabels[
                   itemData.type as keyof typeof CONFIG.Item.typeLabels

--- a/src/sheets/classic/Tidy5eActorSheetClassicV2Base.svelte.ts
+++ b/src/sheets/classic/Tidy5eActorSheetClassicV2Base.svelte.ts
@@ -1161,7 +1161,7 @@ export function Tidy5eActorSheetClassicV2Base<
         const singleton = dataModel?.metadata.singleton ?? false;
         if (singleton && this.actor.itemTypes[itemData.type].length) {
           ui.notifications.error(
-            game.i18n.format('DND5E.ActorWarningSingleton', {
+            game.i18n.format('DND5E.ACTOR.Warning.Singleton', {
               itemType: game.i18n.localize(
                 CONFIG.Item.typeLabels[itemData.type]
               ),

--- a/src/sheets/quadrone/Tidy5eCharacterSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eCharacterSheetQuadrone.svelte.ts
@@ -10,20 +10,17 @@ import type {
   Actor5e,
   ActorInventoryTypes,
   ActorSheetQuadroneContext,
-  CharacterClassEntryContext,
   CharacterItemContext,
   CharacterItemPartitions,
   CharacterSheetQuadroneContext,
   CharacterSpeedSenseContext,
   ActorSpeedSenseEntryContext,
   ChosenFacilityContext,
-  CreatureTypeContext,
   ExpandedItemData,
   ExpandedItemIdToLocationsMap,
   FacilityOccupantContext,
   FavoriteContextEntry,
   LocationToSearchTextMap,
-  SpellcastingClassContext,
   InspirationSource,
   FeatureSection,
 } from 'src/types/types';
@@ -375,77 +372,6 @@ export class Tidy5eCharacterSheetQuadrone extends Tidy5eActorSheetQuadroneBase(
     }
 
     return inspirationSource;
-  }
-
-  _getClassesAndOrphanedSubclasses(): {
-    classes: CharacterClassEntryContext[];
-    orphanedSubclasses: Item5e[];
-  } {
-    const subclasses: Item5e[] = Object.values(this.actor.subclasses);
-    const classes = Object.values(this.actor.classes)
-      .map<CharacterClassEntryContext>((cls: Item5e) => {
-        const maxLevelDelta =
-          CONFIG.DND5E.maxLevel - this.actor.system.details.level;
-
-        const spellcasting = cls.system.spellcasting
-          ? {
-              dc: cls.system.spellcasting.save,
-              ability: (
-                CONFIG.DND5E.abilities[cls.system.spellcasting.ability]
-                  ?.abbreviation ?? cls.system.spellcasting.ability
-              )?.toLocaleUpperCase(),
-            }
-          : undefined;
-
-        const subclass = subclasses.findSplice(
-          (s: Item5e) => s.system.classIdentifier === cls.identifier
-        );
-
-        let needsSubclass = false;
-        if (!subclass) {
-          const subclassAdvancement = cls.advancement.byType.Subclass?.[0];
-          needsSubclass =
-            subclassAdvancement &&
-            subclassAdvancement.level <= cls.system.levels;
-        }
-
-        return {
-          name: cls.name,
-          levels: cls.system.levels,
-          isOriginalClass: cls.system.isOriginalClass,
-          spellcasting,
-          item: cls,
-          img: cls.img,
-          availableLevels: Array.fromRange(CONFIG.DND5E.maxLevel + 1)
-            .slice(1)
-            .map((level) => {
-              const delta = level - cls.system.levels;
-              return { level, delta, disabled: delta > maxLevelDelta };
-            }),
-          uuid: cls.uuid,
-          subclass,
-          needsSubclass,
-        };
-      })
-      .toSorted((left, right) => right.levels - left.levels);
-
-    return { classes, orphanedSubclasses: subclasses };
-  }
-
-  _getCreatureType(): CreatureTypeContext {
-    const { details } = this.actor.system;
-
-    return {
-      icon:
-        CONFIG.DND5E.creatureTypes[details.type.value]?.icon ??
-        'icons/svg/mystery-man.svg',
-      title:
-        details.type.value === 'custom'
-          ? details.type.custom
-          : CONFIG.DND5E.creatureTypes[details.type.value]?.label,
-      reference: CONFIG.DND5E.creatureTypes[details.type.value]?.reference,
-      subtitle: details.type.subtype,
-    };
   }
 
   /**
@@ -1286,59 +1212,5 @@ export class Tidy5eCharacterSheetQuadrone extends Tidy5eActorSheetQuadroneBase(
     value = value.filter((_: any, i: number) => i !== index);
 
     return facility.update({ [`${prop}.value`]: value });
-  }
-
-  /* -------------------------------------------- */
-  /*  Sheet Actions                               */
-  /* -------------------------------------------- */
-
-  /**
-   * Handle finding an available item of a given type.
-   */
-  async findItem(args: {
-    event: Event;
-    type: string;
-    classIdentifier?: string;
-    facilityType?: string;
-  }) {
-    const { event, classIdentifier, facilityType, type } = args;
-
-    const filters: Record<string, any> = {
-      locked: { types: new Set([type]) },
-    };
-
-    if (classIdentifier) {
-      filters.locked.additional = { class: { [classIdentifier]: 1 } };
-    }
-
-    if (type === 'class') {
-      const existingIdentifiers = new Set(Object.keys(this.actor.classes));
-      filters.locked.arbitrary = [
-        {
-          o: 'NOT',
-          v: { k: 'system.identifier', o: 'in', v: existingIdentifiers },
-        },
-      ];
-    }
-
-    if (type === 'facility' && facilityType) {
-      const otherType = facilityType === 'basic' ? 'special' : 'basic';
-      filters.locked.additional = {
-        type: { [facilityType]: 1, [otherType]: -1 },
-        level: { max: this.actor.system.details.level },
-      };
-    }
-
-    let result = await dnd5e.applications.CompendiumBrowser.selectOne({
-      filters,
-    });
-
-    if (result) {
-      this._onDropItemCreate(
-        game.items.fromCompendium(await fromUuid(result), { keepId: true }),
-        event,
-        'copy'
-      );
-    }
   }
 }

--- a/src/sheets/quadrone/Tidy5eNpcSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eNpcSheetQuadrone.svelte.ts
@@ -165,11 +165,22 @@ export class Tidy5eNpcSheetQuadrone extends Tidy5eActorSheetQuadroneBase(
       ? this.actor.token
       : this.actor.prototypeToken;
 
+    let background = this.actor.itemTypes.background[0];
+    let species = this.actor.itemTypes.race[0];
+
     const context: NpcSheetQuadroneContext = {
+      background: background
+        ? {
+            id: background.id,
+            img: background.img,
+            name: background.name,
+          }
+        : undefined,
       containerPanelItems: await Inventory.getContainerPanelItems(
         actorContext.items
       ),
       conditions: conditions,
+      creatureType: this._getCreatureType(),
       currencies,
       effects: enhancedEffectSections,
       enriched: {
@@ -236,6 +247,13 @@ export class Tidy5eNpcSheetQuadrone extends Tidy5eActorSheetQuadroneBase(
       showLoyaltyTracker:
         this.actor.system.traits.important &&
         game.settings.get('dnd5e', 'loyaltyScore'),
+      species: species
+        ? {
+            id: species.id,
+            img: species.img,
+            name: species.name,
+          }
+        : undefined,
       speeds: super._getMovementSpeeds(),
       spellbook: [],
       spellcasting: this._prepareSpellcastingContext(actorContext.rollData),
@@ -248,6 +266,7 @@ export class Tidy5eNpcSheetQuadrone extends Tidy5eActorSheetQuadroneBase(
       treasures: [],
       type: CONSTANTS.SHEET_TYPE_NPC,
       ...actorContext,
+      ...this._getClassesAndOrphanedSubclasses(),
     };
 
     context.skills = this._getSkillsToolsContext(context, 'skills');

--- a/src/sheets/quadrone/actor/character-parts/traits/CharacterTraits.svelte
+++ b/src/sheets/quadrone/actor/character-parts/traits/CharacterTraits.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
-  import SelectOptions from 'src/components/inputs/SelectOptions.svelte';
-  import SelectQuadrone from 'src/components/inputs/SelectQuadrone.svelte';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
   import { getCharacterSheetQuadroneContext } from 'src/sheets/sheet-context.svelte';
-  import CharacterTraitClasses from './CharacterTraitClasses.svelte';
-  import CharacterTraitSpecies from './CharacterTraitSpecies.svelte';
-  import CharacterTraitBackground from './CharacterTraitBackground.svelte';
+  import ActorTraitClasses from '../../parts/ActorTraitClasses.svelte';
+  import ActorTraitSpecies from '../../parts/ActorTraitSpecies.svelte';
+  import ActorTraitBackground from '../../parts/ActorTraitBackground.svelte';
   import ActorTraitConfigurableListEntry from '../../parts/ActorTraitConfigurableListEntry.svelte';
   import { SpecialTraitsApplication } from 'src/applications-quadrone/special-traits/SpecialTraitsApplication.svelte';
+  import ActorTraitSize from '../../parts/ActorTraitSize.svelte';
 
   let context = $derived(getCharacterSheetQuadroneContext());
 
@@ -38,42 +37,14 @@
   </div>
 
   <div class="list traits">
-    <CharacterTraitClasses />
+    <ActorTraitClasses />
 
-    <CharacterTraitSpecies />
+    <ActorTraitSpecies />
 
-    <CharacterTraitBackground />
+    <ActorTraitBackground />
 
     <!-- Size -->
-    <div class="list-entry">
-      <div class="list-label">
-        <h4 class="font-weight-label">
-          {localize('DND5E.Size')}
-        </h4>
-      </div>
-      <div class="list-content">
-        <div class="list-values">
-          {#if context.unlocked}
-            <SelectQuadrone
-              document={context.actor}
-              field="system.traits.size"
-              value={context.system.traits.size}
-            >
-              <SelectOptions
-                data={context.config.actorSizes}
-                labelProp="label"
-              />
-            </SelectQuadrone>
-          {:else}
-            <ul class="pills">
-              <li class="pill pill-medium">
-                {context.size.label}
-              </li>
-            </ul>
-          {/if}
-        </div>
-      </div>
-    </div>
+    <ActorTraitSize />
 
     <!-- Speed -->
     <ActorTraitConfigurableListEntry

--- a/src/sheets/quadrone/actor/npc-parts/LoyaltyTracker.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/LoyaltyTracker.svelte
@@ -21,5 +21,7 @@
     valuePath="system.attributes.loyalty.value"
     max={loyaltyMax}
     unlocked={context.unlocked}
+    showFiligree={false}
+    icon=""
   />
 {/if}

--- a/src/sheets/quadrone/actor/npc-parts/NpcScoreTrackerCard.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/NpcScoreTrackerCard.svelte
@@ -22,7 +22,7 @@
     actor,
     label,
     min = 0,
-    value,
+    value = 0,
     valuePath,
     valueTooltip,
     max,

--- a/src/sheets/quadrone/actor/npc-parts/NpcSubtitle.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/NpcSubtitle.svelte
@@ -5,6 +5,7 @@
   import type { ActorSpeedSenseEntryContext } from 'src/types/types';
   import type { ClassValue } from 'svelte/elements';
   import { getModifierData } from 'src/utils/formatting';
+  import { isNil } from 'src/utils/data';
 
   let context = $derived(getNpcSheetQuadroneContext());
 
@@ -63,6 +64,14 @@
       </span>
       <div class="divider-dot"></div>
     {/if}
+    {#if !isNil(context.creatureType?.title, '')}
+      <span class="size">
+        <span class="font-label-medium color-text-gold"
+          >{context.creatureType.title}</span
+        >
+      </span>
+      <div class="divider-dot"></div>
+    {/if}
     {#if context.system.details.creatureType?.title}
       <span class="creature-type">
         <span class="font-label-medium color-text-gold">
@@ -80,9 +89,11 @@
       </span>
       <div class="divider-dot"></div>
     {/if}
-    <span class="alignment">
-      <span class="font-label-medium color-text-gold">{alignment}</span>
-    </span>
+    {#if !isNil(alignment)}
+      <span class="alignment">
+        <span class="font-label-medium color-text-gold">{alignment}</span>
+      </span>
+    {/if}
     {#if context.enableXp}
       <div class="divider-dot"></div>
       <div class="xp-label flexrow">
@@ -119,14 +130,14 @@
               })}
             class="unbutton concentration-roll-button header-control"
           >
-          {#if context.isConcentrating}
-            <i
-              class="active-concentration-icon fas fa-arrow-rotate-left fa-spin fa-spin-reverse"
-              aria-label={localize('DND5E.Concentration')}
-            ></i>
-          {:else}
-            <!-- <i class="fas fa-head-side-brain color-text-gold"></i> -->
-          {/if}
+            {#if context.isConcentrating}
+              <i
+                class="active-concentration-icon fas fa-arrow-rotate-left fa-spin fa-spin-reverse"
+                aria-label={localize('DND5E.Concentration')}
+              ></i>
+            {:else}
+              <!-- <i class="fas fa-head-side-brain color-text-gold"></i> -->
+            {/if}
             <span class="label font-label-medium color-text-gold">
               {#if context.isConcentrating}
                 {localize('EFFECT.DND5E.StatusConcentrating')}

--- a/src/sheets/quadrone/actor/npc-parts/NpcTraits.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/NpcTraits.svelte
@@ -3,6 +3,7 @@
   import ActorTraitConfigurableListEntry from '../parts/ActorTraitConfigurableListEntry.svelte';
   import { getNpcSheetQuadroneContext } from 'src/sheets/sheet-context.svelte';
   import { SpecialTraitsApplication } from 'src/applications-quadrone/special-traits/SpecialTraitsApplication.svelte';
+  import ActorTraitSize from '../parts/ActorTraitSize.svelte';
 
   let context = $derived(getNpcSheetQuadroneContext());
 
@@ -17,6 +18,11 @@
 {/if} -->
 
 <div class="list traits">
+  <!-- Size -->
+  {#if context.unlocked}
+    <ActorTraitSize />
+  {/if}
+
   <!-- Speed -->
   <ActorTraitConfigurableListEntry
     label={localize('DND5E.Speed')}
@@ -119,32 +125,17 @@
     icon="fa-solid fa-gem"
   />
 
-    <!-- Special Traits -->
-    {#if context.unlocked}
+  <!-- Special Traits -->
+  {#if context.unlocked}
     <ActorTraitConfigurableListEntry
-    label={localize('DND5E.SpecialTraits')}
-    entries={[]}
-    configurationTooltip={localize('DND5E.SpecialTraits')}
-    onconfig={() =>
-      new SpecialTraitsApplication({ document: context.actor }).render({
-        force: true,
-      })}
-    icon="fa-solid fa-star"
-  />
+      label={localize('DND5E.SpecialTraits')}
+      entries={[]}
+      configurationTooltip={localize('DND5E.SpecialTraits')}
+      onconfig={() =>
+        new SpecialTraitsApplication({ document: context.actor }).render({
+          force: true,
+        })}
+      icon="fa-solid fa-star"
+    />
   {/if}
 </div>
-
-{#if context.unlocked}
-<!-- Special Traits -->
-<!-- <button
-  type="button"
-  class="button"
-  onclick={() =>
-    new SpecialTraitsApplication({ document: context.actor }).render({
-      force: true,
-    })}
->
-  <i class="fa-solid fa-star"></i>
-  {localize('DND5E.SpecialTraits')}
-</button> -->
-{/if}

--- a/src/sheets/quadrone/actor/parts/ActorTraitBackground.svelte
+++ b/src/sheets/quadrone/actor/parts/ActorTraitBackground.svelte
@@ -1,9 +1,18 @@
 <script lang="ts">
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { getCharacterSheetQuadroneContext } from 'src/sheets/sheet-context.svelte';
+  import { getSheetContext } from 'src/sheets/sheet-context.svelte';
+  import type {
+    CharacterSheetQuadroneContext,
+    NpcSheetQuadroneContext,
+  } from 'src/types/types';
 
-  let context = $derived(getCharacterSheetQuadroneContext());
+  let context =
+    $derived(
+      getSheetContext<
+        CharacterSheetQuadroneContext | NpcSheetQuadroneContext
+      >(),
+    );
 
   let background = $derived(context.background);
 

--- a/src/sheets/quadrone/actor/parts/ActorTraitSize.svelte
+++ b/src/sheets/quadrone/actor/parts/ActorTraitSize.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+    import SelectOptions from 'src/components/inputs/SelectOptions.svelte';
+    import SelectQuadrone from 'src/components/inputs/SelectQuadrone.svelte';
+  import { FoundryAdapter } from 'src/foundry/foundry-adapter';
+  import { getSheetContext } from 'src/sheets/sheet-context.svelte';
+  import type {
+    CharacterSheetQuadroneContext,
+    NpcSheetQuadroneContext,
+  } from 'src/types/types';
+
+  let context =
+    $derived(
+      getSheetContext<
+        CharacterSheetQuadroneContext | NpcSheetQuadroneContext
+      >(),
+    );
+
+  const localize = FoundryAdapter.localize;
+</script>
+
+<div class="list-entry">
+  <div class="list-label">
+    <h4 class="font-weight-label">
+      {localize('DND5E.Size')}
+    </h4>
+  </div>
+  <div class="list-content">
+    <div class="list-values">
+      {#if context.unlocked}
+        <SelectQuadrone
+          document={context.actor}
+          field="system.traits.size"
+          value={context.system.traits.size}
+        >
+          <SelectOptions data={context.config.actorSizes} labelProp="label" />
+        </SelectQuadrone>
+      {:else}
+        <ul class="pills">
+          <li class="pill pill-medium">
+            {context.size.label}
+          </li>
+        </ul>
+      {/if}
+    </div>
+  </div>
+</div>

--- a/src/sheets/quadrone/actor/parts/ActorTraitSpecies.svelte
+++ b/src/sheets/quadrone/actor/parts/ActorTraitSpecies.svelte
@@ -1,10 +1,25 @@
 <script lang="ts">
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { getCharacterSheetQuadroneContext } from 'src/sheets/sheet-context.svelte';
+  import { getSheetContext } from 'src/sheets/sheet-context.svelte';
+  import type {
+    CharacterSheetQuadroneContext,
+    NpcSheetQuadroneContext,
+  } from 'src/types/types';
   import { EventHelper } from 'src/utils/events';
 
-  let context = $derived(getCharacterSheetQuadroneContext());
+  interface Props {
+    includeCreatureTypeConfig?: boolean;
+  }
+
+  let { includeCreatureTypeConfig }: Props = $props();
+
+  let context =
+    $derived(
+      getSheetContext<
+        CharacterSheetQuadroneContext | NpcSheetQuadroneContext
+      >(),
+    );
 
   const localize = FoundryAdapter.localize;
 
@@ -54,7 +69,7 @@
           </span>
         {:else if context.unlocked}
           <button
-            aria-label="Add {localize('TYPES.Item.race')}"
+            aria-label={localize('DND5E.Species.Add')}
             type="button"
             class="button button-primary"
             data-tooltip="DND5E.Species.Add"
@@ -124,7 +139,7 @@
           </span>
         {/if}
       </div>
-      {#if context.unlocked && species}
+      {#if context.unlocked && (species || includeCreatureTypeConfig)}
         <div class="list-controls">
           <button
             aria-label="Edit {localize('DND5E.CreatureType')}"

--- a/src/sheets/quadrone/actor/tabs/NpcBiographyTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/NpcBiographyTab.svelte
@@ -18,6 +18,11 @@
 
   let bioFields: FlagBioField[] = $derived([
     {
+      field: 'system.details.alignment',
+      value: context.system.details.alignment,
+      text: 'DND5E.Alignment',
+    },
+    {
       field: TidyFlags.gender.prop,
       value: TidyFlags.gender.get(context.actor),
       text: 'DND5E.Gender',

--- a/src/sheets/quadrone/actor/tabs/NpcStatblockTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/NpcStatblockTab.svelte
@@ -17,6 +17,9 @@
   import StatblockTables from '../../shared/StatblockTables.svelte';
   import type { FeatureSection, SpellbookSection } from 'src/types/types';
   import UserPreferencesService from 'src/features/user-preferences/UserPreferencesService';
+  import ActorTraitClasses from '../parts/ActorTraitClasses.svelte';
+  import ActorTraitBackground from '../parts/ActorTraitBackground.svelte';
+  import ActorTraitSpecies from '../parts/ActorTraitSpecies.svelte';
 
   let context = $derived(getNpcSheetQuadroneContext());
 
@@ -95,3 +98,11 @@
   {searchCriteria}
   sheetDocument={context.actor}
 />
+
+<ActorTraitClasses />
+
+<ActorTraitBackground />
+
+{#if context.unlocked}
+  <ActorTraitSpecies includeCreatureTypeConfig />
+{/if}

--- a/src/todo.md
+++ b/src/todo.md
@@ -2,33 +2,9 @@
 
 ### The Short List
 
-- [x] Restore Character sheet responsive ability scores with a scripted approach. See Abilities Simplification Initiative (ASI)
-- [ ] NPC Sheet
-  - [x] Header - Wire up Max HP
-  - [x] Header - Wire up HP roll
-  - [ ] hightouch punch list from PR #1278
-    - [x] Legendaries in the statblock tab styling (see "Legendaries Tray" tasks)
-    - [ ] Display background/subclass/etc in Statblock tab
-    - [ ] Class styling in sidebar (copy from PC sheet Traits tab)
-    - [ ] Show alignment/species/size in sidebar in Edit Mode, subtitle only in play mode
-    - [x] Figure out solution for HP > 999
-    - [x] Needs testing: Validate character sheet header styles are still working as expected
-  - [ ] Make loyalty tracker match legendary trackers
 - [ ] PC and NPC Sheets
   - [ ] Update class/subclass/background/species rows to View on double-click and Edit on middle-click
-
-#### Abilities Simplification Initiative
-
-- [x] Track application position on the svelte mixin, and lock it to `_updatePosition`; this will be maintained for all use cases by app v2 <3
-- [x] Feed svelte context with reactive position ref
-- [x] Retrofit character.scss ability container styles to be
-  - [x] .ability.ability-smaller - the smaller abilities
-  - [x] .ability.ability-collapsed - the alternate view of abilities
-- [x] Update the abilities component to apply `.ability-smaller` at a specific sheet position width, then `.ability-collapsed` for the smallest configuration.
-  - [x] Determine what that width should be, via trial and error
-  - [x] Be sure to convert hard width to rems when making our calculations
-  - [x] Use a constant, multiplied by the number of visible abilities.
-
+- [ ] NPC: (important NPCs only) Add Hit Dice tracker to traits section of sidebar. It is readonly and simply shows value/max hit dice in the style of the traits rows.
 
 ### (Almost) Everything after the short list
 
@@ -213,6 +189,22 @@ Limited:
 
 ### To Do Graveyard
 
+- [x] Restore Character sheet responsive ability scores with a scripted approach. See Abilities Simplification Initiative (ASI)
+- [x] NPC Sheet
+  - [x] Header - Wire up Max HP
+  - [x] Header - Wire up HP roll
+  - [x] hightouch punch list from PR #1278
+    - [x] Legendaries in the statblock tab styling (see "Legendaries Tray" tasks)
+    - [x] Display background/subclass/etc in Statblock tab
+    - [x] ~~(confirm if needed) Class styling in sidebar (copy from PC sheet Traits tab)~~ Not needed. Already covered.
+    - [x] Show alignment in bio tab
+    - [x] Show species in sidebar in Edit Mode, subtitle only in play mode
+    - [x] Show size in sidebar in Edit Mode, subtitle only in play mode
+    - [x] Figure out solution for HP > 999
+    - [x] Needs testing: Validate character sheet header styles are still working as expected
+  - [x] Make loyalty tracker match legendary trackers
+
+
 
 #### Legendaries Tray
 
@@ -238,3 +230,15 @@ Limited:
   box-shadow: var(--t5e-drop-shadow-field);
 }
 ```
+
+#### Abilities Simplification Initiative
+
+- [x] Track application position on the svelte mixin, and lock it to `_updatePosition`; this will be maintained for all use cases by app v2 <3
+- [x] Feed svelte context with reactive position ref
+- [x] Retrofit character.scss ability container styles to be
+  - [x] .ability.ability-smaller - the smaller abilities
+  - [x] .ability.ability-collapsed - the alternate view of abilities
+- [x] Update the abilities component to apply `.ability-smaller` at a specific sheet position width, then `.ability-collapsed` for the smallest configuration.
+  - [x] Determine what that width should be, via trial and error
+  - [x] Be sure to convert hard width to rems when making our calculations
+  - [x] Use a constant, multiplied by the number of visible abilities.

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -403,8 +403,8 @@ export type CharacterSheetContext = {
   spellbook: SpellbookSection[];
   spellcastingInfo: SpellcastingInfo;
   spellSlotTrackerMode:
-  | typeof CONSTANTS.SPELL_SLOT_TRACKER_MODE_PIPS
-  | typeof CONSTANTS.SPELL_SLOT_TRACKER_MODE_VALUE_MAX;
+    | typeof CONSTANTS.SPELL_SLOT_TRACKER_MODE_PIPS
+    | typeof CONSTANTS.SPELL_SLOT_TRACKER_MODE_VALUE_MAX;
   traitEnrichedHtml: string;
   utilities: Utilities<CharacterSheetContext>;
 } & ActorSheetContextV1;
@@ -510,8 +510,8 @@ export type NpcSheetContext = {
   spellbook: SpellbookSection[];
   spellcastingInfo: SpellcastingInfo;
   spellSlotTrackerMode:
-  | typeof CONSTANTS.SPELL_SLOT_TRACKER_MODE_PIPS
-  | typeof CONSTANTS.SPELL_SLOT_TRACKER_MODE_VALUE_MAX;
+    | typeof CONSTANTS.SPELL_SLOT_TRACKER_MODE_PIPS
+    | typeof CONSTANTS.SPELL_SLOT_TRACKER_MODE_VALUE_MAX;
   traitEnrichedHtml: string;
   treasure: { label: string }[];
   utilities: Utilities<NpcSheetContext>;
@@ -567,15 +567,15 @@ export type MessageBus = { message: MessageBusMessage | undefined };
 
 export type MessageBusMessage =
   | {
-    tabId: string;
-    message: typeof CONSTANTS.MESSAGE_BUS_EXPAND_ALL;
-    options?: { includeInlineToggles?: boolean };
-  }
+      tabId: string;
+      message: typeof CONSTANTS.MESSAGE_BUS_EXPAND_ALL;
+      options?: { includeInlineToggles?: boolean };
+    }
   | {
-    tabId: string;
-    message: typeof CONSTANTS.MESSAGE_BUS_COLLAPSE_ALL;
-    options?: { includeInlineToggles?: boolean };
-  };
+      tabId: string;
+      message: typeof CONSTANTS.MESSAGE_BUS_COLLAPSE_ALL;
+      options?: { includeInlineToggles?: boolean };
+    };
 
 export type Utilities<TContext> = Record<
   string,
@@ -993,7 +993,7 @@ export type ActorSpeedSenseEntryContext = {
   units: string;
 } & ActorTraitContext;
 
-export type CharacterClassEntryContext = {
+export type ActorClassEntryContext = {
   uuid: string;
   name: string;
   img: string;
@@ -1125,7 +1125,7 @@ export type ActorTraitItemContext = {
 export type CharacterSheetQuadroneContext = {
   background?: ActorTraitItemContext;
   // TODO: Populate with context data as needed
-  classes: CharacterClassEntryContext[];
+  classes: ActorClassEntryContext[];
   conditions: Dnd5eActorCondition[];
   containerPanelItems: ContainerPanelItemContext[];
   creatureType: CreatureTypeContext;
@@ -1173,8 +1173,11 @@ export type CharacterSheetQuadroneContext = {
 
 export type NpcSheetQuadroneContext = {
   // TODO: Populate with context data as needed
+  background?: ActorTraitItemContext;
+  classes: ActorClassEntryContext[];
   conditions: Dnd5eActorCondition[];
   containerPanelItems: ContainerPanelItemContext[];
+  creatureType: CreatureTypeContext;
   currencies: CurrencyContext[];
   effects: ActiveEffectSection[];
   enriched: {
@@ -1188,6 +1191,7 @@ export type NpcSheetQuadroneContext = {
   features: FeatureSection[];
   habitats: { label: string }[];
   inventory: InventorySection[];
+  orphanedSubclasses: Item5e[];
   portrait: {
     src: string;
     shape: PortraitShape;
@@ -1204,6 +1208,7 @@ export type NpcSheetQuadroneContext = {
   showLegendariesOnStatblockTab: boolean;
   size: ActorSizeContext;
   skills: ActorSkillsToolsContext<SkillData>[];
+  species?: ActorTraitItemContext;
   speeds: ActorSpeedSenseEntryContext[];
   spellbook: SpellbookSection[];
   spellcasting: (SpellcastingClassContext | NpcSpellcastingContext)[];


### PR DESCRIPTION
NPC todos:
- [x] Display background/subclass/etc in Statblock tab
- [x] ~~(confirm if needed) Class styling in sidebar (copy from PC sheet Traits tab)~~ Not needed. Already covered.
- [x] Show alignment in bio tab
- [x] Show species in sidebar in Edit Mode, subtitle only in play mode
- [x] Show size in sidebar in Edit Mode, subtitle only in play mode
- [x] Make loyalty tracker match legendary trackers

Planned work for some additional missing items.

Generalized several components and context preparation functions so that NPCs and Characters can share.

Corrected Singleton warning loc key, as it has changed.

Added Creature Type to subtitle.