### PR TITLE
Quick fix: Config button location on traits entries

### DIFF
--- a/src/sheets/quadrone/actor/character-parts/traits/CharacterTraits.svelte
+++ b/src/sheets/quadrone/actor/character-parts/traits/CharacterTraits.svelte
@@ -48,6 +48,7 @@
 
     <!-- Speed -->
     <ActorTraitConfigurableListEntry
+      configButtonLocation="end"
       label={localize('DND5E.Speed')}
       entries={context.speeds.traitEntries}
       onconfig={() =>
@@ -57,6 +58,7 @@
 
     <!-- Senses -->
     <ActorTraitConfigurableListEntry
+      configButtonLocation="end"
       label={localize('DND5E.Senses')}
       entries={context.senses.traitEntries}
       onconfig={() =>
@@ -66,6 +68,7 @@
 
     <!-- Resistances -->
     <ActorTraitConfigurableListEntry
+      configButtonLocation="end"
       label={localize('DND5E.Resistances')}
       entries={context.traits.dr}
       onconfig={() => FoundryAdapter.openDamagesConfig(context.actor, 'dr')}
@@ -79,6 +82,7 @@
 
     <!-- Damage Immunities -->
     <ActorTraitConfigurableListEntry
+      configButtonLocation="end"
       label={localize('DND5E.TraitDIPlural.other')}
       entries={context.traits.di}
       onconfig={() => FoundryAdapter.openDamagesConfig(context.actor, 'di')}
@@ -92,6 +96,7 @@
 
     <!-- Condition Immunities -->
     <ActorTraitConfigurableListEntry
+      configButtonLocation="end"
       label={localize('DND5E.TraitCIPlural.other')}
       entries={context.traits.ci}
       onconfig={() => FoundryAdapter.renderTraitsConfig(context.actor, 'ci')}
@@ -101,6 +106,7 @@
 
     <!-- Vulnerabilities -->
     <ActorTraitConfigurableListEntry
+      configButtonLocation="end"
       label={localize('DND5E.Vulnerabilities')}
       entries={context.traits.dv}
       onconfig={() => FoundryAdapter.openDamagesConfig(context.actor, 'dv')}
@@ -114,6 +120,7 @@
 
     <!-- Damage Modification -->
     <ActorTraitConfigurableListEntry
+      configButtonLocation="end"
       label={localize('DND5E.DamageModification.Label')}
       entries={context.traits.dm}
       onconfig={() => FoundryAdapter.openDamagesConfig(context.actor, 'dm')}
@@ -126,6 +133,7 @@
 
     <!-- Armor -->
     <ActorTraitConfigurableListEntry
+      configButtonLocation="end"
       label={localize('DND5E.Armor')}
       entries={context.traits.armor}
       onconfig={() => FoundryAdapter.renderTraitsConfig(context.actor, 'armor')}
@@ -134,6 +142,7 @@
 
     <!-- Weapons -->
     <ActorTraitConfigurableListEntry
+      configButtonLocation="end"
       label={localize('TYPES.Item.weaponPl')}
       entries={context.traits.weapon}
       onconfig={() => FoundryAdapter.renderWeaponsConfig(context.actor)}
@@ -142,6 +151,7 @@
 
     <!-- Languages -->
     <ActorTraitConfigurableListEntry
+      configButtonLocation="end"
       label={localize('DND5E.Languages')}
       entries={context.traits.languages}
       onconfig={() => FoundryAdapter.renderLanguagesConfig(context.actor)}
@@ -150,6 +160,7 @@
 
     {#each context.customActorTraits as trait}
       <ActorTraitConfigurableListEntry
+        configButtonLocation="end"
         label={localize(trait.title)}
         entries={[]}
         onconfig={(ev) =>

--- a/src/sheets/quadrone/actor/npc-parts/NpcTraits.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/NpcTraits.svelte
@@ -57,6 +57,7 @@
 
   <!-- Creature Type -->
   <ActorTraitConfigurableListEntry
+    configButtonLocation="label"
     label={localize('DND5E.CreatureType')}
     entries={creatureTypeEntries}
     onconfig={() => FoundryAdapter.renderCreatureTypeConfig(context.actor)}
@@ -65,6 +66,7 @@
 
   <!-- Speed -->
   <ActorTraitConfigurableListEntry
+    configButtonLocation="label"
     label={localize('DND5E.Speed')}
     entries={context.speeds}
     onconfig={() =>
@@ -74,6 +76,7 @@
 
   <!-- Senses -->
   <ActorTraitConfigurableListEntry
+    configButtonLocation="label"
     label={localize('DND5E.Senses')}
     entries={context.senses}
     onconfig={() =>
@@ -83,6 +86,7 @@
 
   <!-- Resistances -->
   <ActorTraitConfigurableListEntry
+    configButtonLocation="label"
     label={localize('DND5E.Resistances')}
     entries={context.traits.dr}
     onconfig={() => FoundryAdapter.openDamagesConfig(context.actor, 'dr')}
@@ -96,6 +100,7 @@
 
   <!-- Damage Immunities -->
   <ActorTraitConfigurableListEntry
+    configButtonLocation="label"
     label={localize('DND5E.TraitDIPlural.other')}
     entries={context.traits.di}
     onconfig={() => FoundryAdapter.openDamagesConfig(context.actor, 'di')}
@@ -109,6 +114,7 @@
 
   <!-- Condition Immunities -->
   <ActorTraitConfigurableListEntry
+    configButtonLocation="label"
     label={localize('DND5E.TraitCIPlural.other')}
     entries={context.traits.ci}
     onconfig={() => FoundryAdapter.renderTraitsConfig(context.actor, 'ci')}
@@ -118,6 +124,7 @@
 
   <!-- Vulnerabilities -->
   <ActorTraitConfigurableListEntry
+    configButtonLocation="label"
     label={localize('DND5E.Vulnerabilities')}
     entries={context.traits.dv}
     onconfig={() => FoundryAdapter.openDamagesConfig(context.actor, 'dv')}
@@ -131,6 +138,7 @@
 
   <!-- Damage Modification -->
   <ActorTraitConfigurableListEntry
+    configButtonLocation="label"
     label={localize('DND5E.DamageModification.Label')}
     entries={context.traits.dm}
     onconfig={() => FoundryAdapter.openDamagesConfig(context.actor, 'dm')}
@@ -143,6 +151,7 @@
 
   <!-- Habitat -->
   <ActorTraitConfigurableListEntry
+    configButtonLocation="label"
     label={localize('DND5E.Habitat.Configuration.Label')}
     entries={context.habitats}
     configurationTooltip={localize('DND5E.Habitat.Configuration.Title')}
@@ -155,6 +164,7 @@
 
   <!-- Treasure -->
   <ActorTraitConfigurableListEntry
+    configButtonLocation="label"
     label={localize('DND5E.Treasure.Configuration.Label')}
     entries={context.treasures}
     configurationTooltip={localize('DND5E.Treasure.Configuration.Title')}
@@ -168,6 +178,7 @@
   <!-- Special Traits -->
   {#if context.unlocked}
     <ActorTraitConfigurableListEntry
+      configButtonLocation="label"
       label={localize('DND5E.SpecialTraits')}
       entries={[]}
       configurationTooltip={localize('DND5E.SpecialTraits')}

--- a/src/sheets/quadrone/actor/parts/ActorTraitConfigurableListEntry.svelte
+++ b/src/sheets/quadrone/actor/parts/ActorTraitConfigurableListEntry.svelte
@@ -22,6 +22,7 @@
       pillClass: string;
       iconClass: string;
     };
+    configButtonLocation: 'label' | 'end';
   }
 
   let {
@@ -34,6 +35,7 @@
     alwaysShow,
     isCustomTrait,
     aggregateIcons,
+    configButtonLocation,
   }: Props = $props();
 
   let context = $derived(getCharacterSheetQuadroneContext());
@@ -54,7 +56,7 @@
         <i class={icon}></i>
         {label}
       </h4>
-      {#if context.unlocked}
+      {#if context.unlocked && configButtonLocation == 'label'}
         <button
           aria-label={configurationLabel}
           type="button"
@@ -82,6 +84,17 @@
           </button>
         {/if} -->
       </div>
+      {#if context.unlocked && configButtonLocation == 'end'}
+        <button
+          aria-label={configurationLabel}
+          type="button"
+          class="button button-borderless button-icon-only button-config flexshrink"
+          data-tooltip={configurationTooltip ?? configurationLabel}
+          onclick={(ev) => onconfig(ev)}
+        >
+          <i class="fa-solid fa-cog"></i>
+        </button>
+      {/if}
     </div>
   </div>
 {/if}


### PR DESCRIPTION
Updated ActorTraitConfigurableListEntry to allow specifying the desired position of the config button. Updated PCs to put the button at the end, and NPCs within the label.