### PR TITLE
quick fix - core theme bug

### DIFF
--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -24,7 +24,7 @@ export function getThemeV2(doc?: any) {
 
   if (!theme) {
     const { colorScheme } = game.settings.get('core', 'uiConfig');
-    theme = colorScheme.application;
+    theme = colorScheme.applications;
   }
 
   if (!theme) {


### PR DESCRIPTION
Fixed bug where the prescribed application color scheme was not being read properly and was defaulting to `prefers-color-scheme` inappropriately.