### PR TITLE
NPC sheet trait style fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ foundry-data-path-config.json
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+.cursor/*
 .idea
 .DS_Store
 *.suo

--- a/src/components/table-quadrone/TidyItemTableRow.svelte
+++ b/src/components/table-quadrone/TidyItemTableRow.svelte
@@ -110,9 +110,11 @@
       : undefined,
   );
 
+  const diminished = $derived(item.system.identified === false);
+
   const itemColorClasses = $derived<ClassValue>([
     !isNil(item.system.rarity, '') ? 'rarity' : undefined,
-    item.system.rarity?.slugify(),
+    diminished ? 'diminished' : item.system.rarity?.slugify(),
     !isNil(config?.key) ? 'spell-method' : undefined,
     {
       [`method-${config?.key?.slugify()}`]: !isNil(config),

--- a/src/components/table-quadrone/table-buttons/EffectToggleButton.svelte
+++ b/src/components/table-quadrone/table-buttons/EffectToggleButton.svelte
@@ -47,7 +47,7 @@
   </a>
 {:else}
   <a
-    class="tidy-table-button"
+    class="tidy-table-button tidy-table-toggle"
     data-tooltip={title}
     onclick={() => effect.update({ disabled: !effect.disabled })}
   >

--- a/src/scss/quadrone/actors.scss
+++ b/src/scss/quadrone/actors.scss
@@ -2693,5 +2693,9 @@
         }
       }
     }
+
+    .traits.list .pill:is(.physical-bypass) {
+      border-color: var(--t5e-color-palette-orange-70);
+    }
   }
 }

--- a/src/scss/quadrone/actors.scss
+++ b/src/scss/quadrone/actors.scss
@@ -2392,6 +2392,10 @@
 
   // Encumbrance
   .meter.encumbrance {
+    .label {
+      cursor: auto;
+    }
+
     .breakpoint {
       display: block;
       position: absolute;

--- a/src/scss/quadrone/actors.scss
+++ b/src/scss/quadrone/actors.scss
@@ -1272,7 +1272,7 @@
       margin: -0.25rem 0 -0.25rem 0;
     }
 
-    .proficiency {
+    .proficiency-bonus {
       .label {
         margin-right: var(--t5e-size-halfx);
       }
@@ -1497,7 +1497,7 @@
 
   .ability-roll-button,
   .initiative-roll-button {
-    color: var(--t5e-color-text-gold);
+    color: var(--t5e-color-text-gold-emphasis);
     font: var(--t5e-font-label-medium);
     height: auto;
     line-height: normal;
@@ -1912,6 +1912,14 @@
       flex: 1;
       min-width: fit-content;
       flex-direction: row;
+
+      .input-group {
+        padding-inline-start: 0.5rem;
+      }
+
+      .currency {
+        display: none;
+      }
     }
 
     .footer-content-left {

--- a/src/scss/quadrone/actors.scss
+++ b/src/scss/quadrone/actors.scss
@@ -1043,7 +1043,7 @@
       &:hover,
       &:focus,
       &:active {
-        border-color: var(--t5e-color-palette-gold-89);
+        border: 0.125rem solid var(--t5e-color-palette-gold-89);
 
         i {
           color: var(--t5e-color-palette-gold-89);
@@ -1937,7 +1937,7 @@
     .window-title {
       visibility: visible;
     }
-    
+
     .configurable-source {
       display: none;
     }

--- a/src/scss/quadrone/apps.scss
+++ b/src/scss/quadrone/apps.scss
@@ -714,18 +714,21 @@
     &:where(.artifact) {
       --t5e-item-color: var(--t5e-color-rarity-artifact);
     }
+
+    &.diminished {
+      --t5e-item-color: var(--t5e-color-palette-grey-40);
+    }
   }
 
   :where(.spell-method:is(.cannot-prepare, .can-prepare.always)) {
     --t5e-icon-color: var(--t5e-method-color);
 
-    &:is(.tidy5e-sheet.theme-dark :where(.spell-method:is(.cannot-prepare, .can-prepare.always))) 
-    {
+    &:is(.tidy5e-sheet.theme-dark :where(.spell-method:is(.cannot-prepare, .can-prepare.always))) {
       --t5e-icon-color: oklch(from var(--t5e-method-color) calc(l * 1.5) calc(c * .88) h);
     }
   }
 
-  :where(.spell-method.can-prepare.unprepared)  {
+  :where(.spell-method.diminished) {
     --t5e-icon-color: var(--t5e-color-text-lighter);
   }
 
@@ -749,7 +752,7 @@
     --t5e-method-color: var(--t5e-color-spellcasting-spell);
   }
 
-  :where(.unidentified) {
+  :where(.diminished) {
     --t5e-item-color: var(--t5e-color-palette-grey-40);
   }
 

--- a/src/scss/quadrone/character.scss
+++ b/src/scss/quadrone/character.scss
@@ -307,7 +307,7 @@
 
   @mixin collapse-abilities {
     --collapse-bg-light: rgba(0, 0, 0, 0.20);
-    --collapse-bg-dark: rgba(0, 0, 0, 0.4);
+    --collapse-bg-dark: rgba(0, 0, 0, 0.56);
     --collapse-outline: 0.0625rem solid rgba(0, 0, 0, 0.16);
     --collapse-font-medium: 1.25rem;
     --collapse-font-large: 1.5rem;
@@ -335,7 +335,7 @@
 
 
     .ability:has(.proficient) {
-      outline-color: rgba(0, 0, 0, 0.40);
+      outline-color: rgba(0, 0, 0, 0.64);
     }
 
     .ability .bonus-container,

--- a/src/scss/quadrone/components/meters.scss
+++ b/src/scss/quadrone/components/meters.scss
@@ -25,18 +25,19 @@
   }
 
   .label {
-    inline-size: 100%;
-    block-size: 100%;
-    display: flex;
     align-items: center;
-    gap: 0.25rem;
-    position: relative;
+    block-size: 100%;
     color: var(--t5e-color-text-default);
+    cursor: pointer;
+    display: flex;
     font-size: 0.75rem;
     font-weight: 500;
+    gap: 0.25rem;
+    inline-size: 100%;
     line-height: normal;
     padding-inline-start: 0.5rem;
     padding-inline-end: 0.75rem;
+    position: relative;
 
     i {
       color: var(--t5e-color-text-lighter);
@@ -140,10 +141,6 @@
     --bar-background: linear-gradient(to right,
         var(--t5e-color-palette-gold-62) 0%,
         var(--t5e-color-palette-gold-75) 100%);
-  }
-
-  .label {
-    cursor: pointer;
   }
 
   input {

--- a/src/scss/quadrone/items.scss
+++ b/src/scss/quadrone/items.scss
@@ -282,7 +282,7 @@
       }
     }
 
-    .item-rarity-text.unidentified {
+    .item-rarity-text.diminished {
       --t5e-item-color: var(--t5e-color-text-default);
     }
 

--- a/src/scss/quadrone/npc.scss
+++ b/src/scss/quadrone/npc.scss
@@ -375,6 +375,10 @@
           }
         }
 
+        .button-config {
+          margin-bottom: -0.0625rem;
+        }
+
         &.empty {
 
           .list-label h4 i {
@@ -392,6 +396,33 @@
           min-height: auto;
           padding: 0.125rem 0.25rem 0.1875rem;
         }
+      }
+    }
+
+    .trait-size {
+      .select-button {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      /* The real select captures all interactions */
+      .select-button .native-select-overlay {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        opacity: 0;
+        /* keep it focusable and clickable */
+        cursor: pointer;
+        -webkit-appearance: menulist;
+        appearance: auto;
+      }
+
+      /* Decorative icon; remove pointer-events if it shouldn't intercept clicks */
+      .select-button .fa-cog {
+        pointer-events: none;
       }
     }
 

--- a/src/scss/quadrone/npc.scss
+++ b/src/scss/quadrone/npc.scss
@@ -475,6 +475,12 @@
       }
     }
 
+    .trait-hit-dice {
+      .hit-dice-container {
+        padding-right: 0.5rem;
+      }
+    }
+
     .skills {
       padding: 0;
       background: none;
@@ -487,6 +493,11 @@
 
         li {
           width: auto;
+
+          .passive,
+          .modifier {
+            padding-right: 0.25rem;
+          }
         }
       }
     }
@@ -504,6 +515,12 @@
           width: 1.5rem;
         }
       }
+    }
+  }
+
+  &.sheet-mode-edit .sidebar .npc-score-tracker {
+    .uses .max {
+      padding: 0 var(--t5e-size-2x);
     }
   }
 

--- a/src/scss/quadrone/npc.scss
+++ b/src/scss/quadrone/npc.scss
@@ -153,6 +153,8 @@
 
     input[type="text"]:not(:disabled):not(.uninput).h2.actor-name {
       font-size: var(--font-size-46);
+      max-height: var(--font-size-46);
+      // margin-bottom: 0.0625rem;
     }
 
     input[type="text"]:not(:disabled):not(.uninput) {
@@ -189,15 +191,62 @@
   }
 
   .actor-subtitle {
-    .xp-label {
-      align-content: center;
+
+    >* {
+      height: 1rem;
+    }
+
+    .xp-label,
+    .xp-container {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0;
+      flex: 0 1 fit-content;
       flex-wrap: nowrap;
-      gap: 0.25rem;
       max-height: 1rem;
     }
 
+    .xp-label {
+      gap: 0.25rem;
+    }
+
+    .xp-container .label {
+      margin-right: 0;
+    }
+
     .xp-value {
+      flex: 0 1 auto;
       max-width: 4.5rem;
+      min-width: 1ch;
+      width: auto;
+    }
+
+    .xp-value:is(:focus, :active) {
+      max-width: 4.5rem;
+    }
+
+    .xp-label-clickable {
+      cursor: pointer;
+      transition: all 0.1s ease;
+      border-radius: 0.125rem;
+
+      &:hover {
+        background-color: rgba(255, 255, 255, 0.1);
+
+        .label {
+          color: var(--t5e-color-text-light);
+        }
+      }
+
+      &:focus {
+        outline: 1px solid var(--t5e-color-accent);
+        background-color: rgba(255, 255, 255, 0.1);
+      }
+
+      &:active {
+        background-color: rgba(255, 255, 255, 0.2);
+      }
     }
 
     .concentration {
@@ -237,7 +286,7 @@
     gap: 0;
 
     &:has(.challenge-rating-input) .label {
-      margin: 0.0625rem 0 0;
+      margin: 0.0625rem 0 -0.0625rem;
     }
 
     >* {

--- a/src/scss/quadrone/npc.scss
+++ b/src/scss/quadrone/npc.scss
@@ -211,7 +211,7 @@
     }
   }
 
-  .proficiency {
+  .proficiency-bonus {
     line-height: 1rem;
     margin: 0 var(--t5e-size-2x) 0 var(--t5e-size-1x);
     align-self: flex-start;
@@ -515,19 +515,16 @@
     }
 
     .ability {
-      background: var(--t5e-component-card-darker);
+      background: var(--t5e-component-card-default);
     }
 
-    .ability:has(.proficient) {
-      background: var(--t5e-component-card-default);
+    .ability:has(.proficient),
+    .initiative-container {
+      background: var(--t5e-component-card-lighter);
       outline-color: var(--t5e-color-palette-gold-62);
     }
 
-    :is(.quadrone.npc.theme-dark .ability:has(.proficient)),
-    .initiative-container {
-      background: var(--collapse-bg-dark);
-      outline-color: var(--t5e-color-palette-grey-11);
-    }
+
 
     .ability .bonus-container,
     .ability .bonus-container.proficient,
@@ -755,8 +752,19 @@
 
     }
 
-    .sheet-header .actor-vitals-container .shield {
-      background-image: url(../../modules/tidy5e-sheet/images/badge_ac_npc_dark.svg);
+    .sheet-header {
+      .actor-vitals-container .shield {
+        background-image: url(../../modules/tidy5e-sheet/images/badge_ac_npc_dark.svg);
+      }
+
+      .abilities-container.ability-collapsed .abilities-container-inner {
+
+        .ability:has(.proficient),
+        .initiative-container {
+          background: var(--collapse-bg-dark);
+          outline-color: var(--t5e-color-palette-grey-11);
+        }
+      }
     }
   }
 

--- a/src/scss/quadrone/npc.scss
+++ b/src/scss/quadrone/npc.scss
@@ -494,9 +494,12 @@
       &:has(.character-traits) {
         .tidy-table-container {
           padding-block-end: 0;
+          flex: 0 1 auto;
         }
 
         .character-traits {
+          padding-bottom: var(--t5e-size-4x);
+
           .tidy-table-header-row {
             h3 {
               padding: 0 0 0.125rem 0.5rem;

--- a/src/scss/quadrone/tables.scss
+++ b/src/scss/quadrone/tables.scss
@@ -49,6 +49,11 @@
       --t5e-table-header-background-right: var(--t5e-method-color, var(--t5e-theme-color-darker));
     }
 
+    &.diminished {
+      --t5e-table-header-background-left: var(--t5e-color-palette-grey-21);
+      --t5e-table-header-background-right: var(--t5e-color-palette-grey-34);
+    }
+
     :is(.tidy-table-cell, .tidy-table-header-cell) {
       margin-top: var(--t5e-size-1x);
       margin-bottom: var(--t5e-size-1x);
@@ -564,9 +569,14 @@
       width: var(--t5e-size-6x);
     }
 
+    .tidy-table-toggle {
+      i {
+        font-size: var(--font-size-16);
+      }
+    }
+
     .tidy-table-button:hover i {
       background: rgba(0, 0, 0, 0.12);
-
     }
   }
 

--- a/src/scss/quadrone/tables.scss
+++ b/src/scss/quadrone/tables.scss
@@ -216,8 +216,13 @@
 
     &.rarity {
 
-      .common {
-        --t5e-item-color: var(--t5e-color-palette-gold-56);
+      &.common {
+        // TODO: Add method for hiding common rarity colors.
+        // --t5e-item-color: var(--t5e-color-text-gold-emphasis);
+      }
+
+      &.diminished {
+        // --t5e-item-color: var(--t5e-color-palette-grey-40);
       }
 
       .highlight {
@@ -265,7 +270,7 @@
 
     // TODO: Finish other unidentified styles. Classes aren't applied yet.
     // Make sure this is last.
-    &.unidentified {
+    &.diminished {
       color: var(--t5e-color-text-lighter);
       background: transparent;
 
@@ -771,7 +776,7 @@
         --icon-fill: var(--t5e-color-text-gold-emphasis);
       }
 
-      &.unprepared {
+      &.diminished {
         color: var(--t5e-color-text-lightest);
 
         .item-name,
@@ -791,8 +796,7 @@
       }
     }
 
-    &.spell-method:not(.unprepared) {
-
+    &.spell-method:not(.diminished) {
 
       background: linear-gradient(to right,
           var(--t5e-color-palette-grey-100) 10%,
@@ -960,7 +964,7 @@
       // }
 
       /* If a spell is prepared, use full background gradient. */
-      &.spell-method:not(.unprepared) {
+      &.spell-method:not(.diminished) {
         background: linear-gradient(to right,
             var(--t5e-component-card-default) 5%,
             transparent 64%);

--- a/src/sheets/quadrone/Tidy5eNpcSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eNpcSheetQuadrone.svelte.ts
@@ -246,7 +246,7 @@ export class Tidy5eNpcSheetQuadrone extends Tidy5eActorSheetQuadroneBase(
       showLegendariesOnStatblockTab:
         userPreferences.showLegendariesOnNpcStatblock === true,
       showLoyaltyTracker:
-        this.actor.system.traits.important &&
+        // this.actor.system.traits.important &&
         game.settings.get('dnd5e', 'loyaltyScore'),
       species: species
         ? {

--- a/src/sheets/quadrone/actor/CharacterSheet.svelte
+++ b/src/sheets/quadrone/actor/CharacterSheet.svelte
@@ -136,7 +136,7 @@
               {context.system.details.level ?? 0}
             </span>
             <div
-              class="proficiency flexrow"
+              class="proficiency-bonus flexrow"
               data-tooltip="DND5E.ProficiencyBonus"
             >
               <span class="label font-label-medium color-text-gold">

--- a/src/sheets/quadrone/actor/npc-parts/Legendaries.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/Legendaries.svelte
@@ -11,6 +11,8 @@
 
   const localize = FoundryAdapter.localize;
 
+  let appId = $derived(context.document.id);
+
   let {
     showFiligree = true,
   }: {
@@ -59,17 +61,19 @@
           </h3>
         </div>
       {:else}
-        <h3 class="font-label-medium bordered">
-          <i class="fa-solid fa-eye-evil color-icon-disabled"></i>
-          {localize('DND5E.LAIR.HasLair')}
-        </h3>
+        <label for="{appId}-lair-has-lair">
+          <h3 class="font-label-medium bordered">
+            <i class="fa-solid fa-eye-evil color-icon-disabled"></i>
+            {localize('DND5E.LAIR.HasLair')}
+          </h3>
+        </label>
       {/if}
     <span class="card-content value">
       <label class="label hidden" for="lair-has-lair"
         >{localize('DND5E.LAIR.HasLair')}</label
       >
       <FieldToggle
-        id="lair-has-lair"
+        id="{appId}-lair-has-lair"
         checked={context.system.resources.lair.value}
         onchange={(ev) =>
           context.actor.update({
@@ -86,16 +90,17 @@
           </h3>
         </div>
       {:else}
-        <h3 class="font-label-medium bordered">
+        <label for="{appId}-lair-inside" class="h3 font-label-medium bordered">
           <i class="fa-solid fa-eye-evil color-icon-disabled"></i>
           {localize('DND5E.LAIR.Inside')}
-        </h3>
+        </label>
       {/if}
     <span class="card-content value">
       <label class="label hidden" for="lair-inside"
         >{localize('DND5E.LAIR.Inside')}</label
       >
       <FieldToggle
+        id="{appId}-lair-inside"
         checked={context.system.resources.lair.inside}
         onchange={(ev) =>
           context.actor.update({
@@ -112,16 +117,17 @@
           </h3>
         </div>
       {:else}
-        <h3 class="font-label-medium bordered">
+        <label for="{appId}-lair-action" class="h3 font-label-medium bordered">
           <i class="fa-solid fa-eye-evil color-icon-disabled"></i>
           {localize('DND5E.LAIR.Action.Label')}
-        </h3>
+        </label>
       {/if}
     <div class="card-content flexrow lair-initiative">
       <span class="font-label-medium color-text-lighter flexshrink">
         {localize('DND5E.Initiative')}
       </span>
       <TextInputQuadrone
+        id="{appId}-lair-action"
         document={context.actor}
         field="system.resources.lair.initiative"
         value={context.system.resources.lair.initiative ?? ''}

--- a/src/sheets/quadrone/actor/npc-parts/Legendaries.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/Legendaries.svelte
@@ -69,9 +69,6 @@
         </label>
       {/if}
     <span class="card-content value">
-      <label class="label hidden" for="lair-has-lair"
-        >{localize('DND5E.LAIR.HasLair')}</label
-      >
       <FieldToggle
         id="{appId}-lair-has-lair"
         checked={context.system.resources.lair.value}
@@ -117,10 +114,10 @@
           </h3>
         </div>
       {:else}
-        <label for="{appId}-lair-action" class="h3 font-label-medium bordered">
+        <h3 class="font-label-medium bordered">
           <i class="fa-solid fa-eye-evil color-icon-disabled"></i>
           {localize('DND5E.LAIR.Action.Label')}
-        </label>
+        </h3>
       {/if}
     <div class="card-content flexrow lair-initiative">
       <span class="font-label-medium color-text-lighter flexshrink">

--- a/src/sheets/quadrone/actor/npc-parts/LoyaltyTracker.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/LoyaltyTracker.svelte
@@ -13,7 +13,7 @@
   );
 </script>
 
-{#if context.showLoyaltyTracker}
+{#if context.showLoyaltyTracker && (context.unlocked || (!context.unlocked && loyaltyValue !== null))}
   <NpcScoreTrackerCard
     actor={context.actor}
     label={localize('DND5E.Loyalty')}
@@ -22,6 +22,6 @@
     max={loyaltyMax}
     unlocked={context.unlocked}
     showFiligree={false}
-    icon=""
+    icon="fa-solid fa-dog"
   />
 {/if}

--- a/src/sheets/quadrone/actor/npc-parts/NpcSubtitle.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/NpcSubtitle.svelte
@@ -164,7 +164,7 @@
       </div>
     {/if}
   </div>
-  <div class="proficiency flexrow" data-tooltip="DND5E.ProficiencyBonus">
+  <div class="proficiency-bonus flexrow" data-tooltip="DND5E.ProficiencyBonus">
     <span class="label font-label-medium color-text-gold">
       {localize('DND5E.Proficiency')}
     </span>

--- a/src/sheets/quadrone/actor/npc-parts/NpcTraits.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/NpcTraits.svelte
@@ -4,8 +4,8 @@
   import { getNpcSheetQuadroneContext } from 'src/sheets/sheet-context.svelte';
   import { SpecialTraitsApplication } from 'src/applications-quadrone/special-traits/SpecialTraitsApplication.svelte';
   import ActorTraitSize from '../parts/ActorTraitSize.svelte';
-  import NpcTraitSpecies from './traits/NpcTraitSpecies.svelte';
   import NpcTraitCreatureType from './traits/NpcTraitCreatureType.svelte';
+  import NpcTraitSize from './traits/NpcTraitSize.svelte';
   let context = $derived(getNpcSheetQuadroneContext());
 
   const localize = FoundryAdapter.localize;
@@ -57,7 +57,7 @@
 
   <!-- Size -->
   {#if context.unlocked}
-    <ActorTraitSize />
+    <NpcTraitSize />
   {/if}
 
   <!-- Creature Type -->

--- a/src/sheets/quadrone/actor/npc-parts/NpcTraits.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/NpcTraits.svelte
@@ -4,23 +4,11 @@
   import { getNpcSheetQuadroneContext } from 'src/sheets/sheet-context.svelte';
   import { SpecialTraitsApplication } from 'src/applications-quadrone/special-traits/SpecialTraitsApplication.svelte';
   import ActorTraitSize from '../parts/ActorTraitSize.svelte';
-  import { isNil } from 'src/utils/data';
-  import type { ActorTraitContext } from 'src/types/types';
   import NpcTraitSpecies from './traits/NpcTraitSpecies.svelte';
-
+  import NpcTraitCreatureType from './traits/NpcTraitCreatureType.svelte';
   let context = $derived(getNpcSheetQuadroneContext());
 
   const localize = FoundryAdapter.localize;
-
-  let creatureTypeEntries = $derived.by(() => {
-    let result: ActorTraitContext[] = [];
-
-    if (!isNil(context.creatureType?.title, '')) {
-      result.push({ label: context.creatureType?.title });
-    }
-
-    return result;
-  });
 </script>
 
 <!-- {#if context.unlocked}
@@ -47,23 +35,6 @@
     </div>
   {/if}
 
-  <!-- Size -->
-  {#if context.unlocked}
-    <ActorTraitSize />
-  {/if}
-
-  <!-- Species -->
-  <NpcTraitSpecies />
-
-  <!-- Creature Type -->
-  <ActorTraitConfigurableListEntry
-    configButtonLocation="label"
-    label={localize('DND5E.CreatureType')}
-    entries={creatureTypeEntries}
-    onconfig={() => FoundryAdapter.renderCreatureTypeConfig(context.actor)}
-    icon=""
-  />
-
   <!-- Speed -->
   <ActorTraitConfigurableListEntry
     configButtonLocation="label"
@@ -83,6 +54,14 @@
       FoundryAdapter.renderMovementSensesConfig(context.actor, 'senses')}
     icon="fa-solid fa-eye"
   />
+
+  <!-- Size -->
+  {#if context.unlocked}
+    <ActorTraitSize />
+  {/if}
+
+  <!-- Creature Type -->
+  <NpcTraitCreatureType />
 
   <!-- Resistances -->
   <ActorTraitConfigurableListEntry

--- a/src/sheets/quadrone/actor/npc-parts/NpcTraits.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/NpcTraits.svelte
@@ -3,33 +3,26 @@
   import ActorTraitConfigurableListEntry from '../parts/ActorTraitConfigurableListEntry.svelte';
   import { getNpcSheetQuadroneContext } from 'src/sheets/sheet-context.svelte';
   import { SpecialTraitsApplication } from 'src/applications-quadrone/special-traits/SpecialTraitsApplication.svelte';
-  import ActorTraitSize from '../parts/ActorTraitSize.svelte';
   import NpcTraitCreatureType from './traits/NpcTraitCreatureType.svelte';
   import NpcTraitSize from './traits/NpcTraitSize.svelte';
+
   let context = $derived(getNpcSheetQuadroneContext());
 
   const localize = FoundryAdapter.localize;
 </script>
 
-<!-- {#if context.unlocked}
-<div class="title-container">
-  <h3 class="font-title-small">{localize('DND5E.Traits')}</h3>
-  <tidy-gold-header-underline></tidy-gold-header-underline>
-</div>
-{/if} -->
-
 <div class="list traits">
-  {#if context.actor.system.traits.important}
-    <div class="list-entry">
+  {#if context.actor.system.traits.important || context.classes.length > 0}
+    <div class="list-entry trait-hit-dice">
       <div class="list-label flexrow">
         <h4 class="font-weight-label">
           <i class="fa-solid fa-dice"></i>
           {localize('DND5E.HitDice')}
         </h4>
-        <div class="flexshrink">
-          <span class="value">{context.system.attributes.hd.value}</span>
-          <span class="divider">/</span>
-          <span class="max">{context.system.attributes.hd.max}</span>
+        <div class="flexshrink hit-dice-container">
+          <span class="value font-label-medium">{context.system.attributes.hd.value}</span>
+          <span class="divider font-body-medium color-text-lightest">/</span>
+          <span class="max font-label-medium">{context.system.attributes.hd.max}</span>
         </div>
       </div>
     </div>

--- a/src/sheets/quadrone/actor/npc-parts/traits/NpcTraitCreatureType.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/traits/NpcTraitCreatureType.svelte
@@ -31,7 +31,7 @@
   <div class="list-entry">
     <div class="list-label flexrow">
       <h4 class="font-weight-label">
-        <i class="fa-solid fa-user-alien"></i>
+        <i class="fa-solid fa-paw"></i>
         {localize('DND5E.CreatureType')}
       </h4>
       {#if context.unlocked}

--- a/src/sheets/quadrone/actor/npc-parts/traits/NpcTraitCreatureType.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/traits/NpcTraitCreatureType.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import { CONSTANTS } from 'src/constants';
+  import { FoundryAdapter } from 'src/foundry/foundry-adapter';
+  import { getCharacterSheetQuadroneContext } from 'src/sheets/sheet-context.svelte';
+  import ActorTraitPills from 'src/sheets/quadrone/actor/parts/ActorTraitPills.svelte';
+  import { EventHelper } from 'src/utils/events';
+  import { isNil } from 'src/utils/data';
+  import type { ActorTraitContext } from 'src/types/types';
+
+  let context = $derived(getCharacterSheetQuadroneContext());
+
+  const localize = FoundryAdapter.localize;
+
+  let species = $derived(context.creatureType);
+  let onconfig = () => FoundryAdapter.renderCreatureTypeConfig(context.actor);
+
+  let creatureTypeEntries = $derived.by(() => {
+    let result: ActorTraitContext[] = [];
+
+    if (!isNil(context.creatureType?.title, '')) {
+      result.push({ label: context.creatureType?.title });
+    }
+
+    return result;
+  });
+
+</script>
+
+{#if context.unlocked}
+  <!-- Species -->
+  <div class="list-entry">
+    <div class="list-label flexrow">
+      <h4 class="font-weight-label">
+        <i class="fa-solid fa-user-alien"></i>
+        {localize('DND5E.CreatureType')}
+      </h4>
+      {#if context.unlocked}
+        <button
+          aria-label={localize('DND5E.CreatureType.Add')}
+          type="button"
+          class="button button-borderless button-icon-only button-config flexshrink"
+          data-tooltip={localize('DND5E.CreatureType.Add')}
+          onclick={onconfig}
+        >
+          <i class="fa-solid fa-cog"></i>
+        </button>
+      {/if}
+    </div>
+    <div class="list-content">
+      <div class="list-values trait-item">
+        <ActorTraitPills values={creatureTypeEntries} />
+      </div>
+    </div>
+  </div>
+{/if}

--- a/src/sheets/quadrone/actor/npc-parts/traits/NpcTraitSize.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/traits/NpcTraitSize.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+    import SelectOptions from 'src/components/inputs/SelectOptions.svelte';
+    import SelectQuadrone from 'src/components/inputs/SelectQuadrone.svelte';
+  import { FoundryAdapter } from 'src/foundry/foundry-adapter';
+  import { getSheetContext } from 'src/sheets/sheet-context.svelte';
+  import type {
+    CharacterSheetQuadroneContext,
+    NpcSheetQuadroneContext,
+  } from 'src/types/types';
+  import ActorTraitPills from 'src/sheets/quadrone/actor/parts/ActorTraitPills.svelte';
+
+  let context =
+    $derived(
+      getSheetContext<
+        CharacterSheetQuadroneContext | NpcSheetQuadroneContext
+      >(),
+    );
+
+  let appId = $derived(context.document.id);
+
+  const localize = FoundryAdapter.localize;
+</script>
+
+{#if context.unlocked}
+  <div class={['list-entry trait-size']}>
+    <div class="list-label flexrow">
+      <h4 class="font-weight-label">
+        <i class="fas fa-ruler-combined"></i>
+        {localize('DND5E.Size')}
+      </h4>
+      {#if context.unlocked}
+        <label 
+          class="select-button button button-borderless button-icon-only button-config flexshrink" 
+          for="{appId}-npc-size"
+          aria-label={localize('DND5E.Size')}>
+          <SelectQuadrone
+            class="native-select-overlay"
+            id="{appId}-npc-size"
+            document={context.actor}
+            field="system.traits.size"
+            value={context.system.traits.size}
+          >
+            <SelectOptions data={context.config.actorSizes} labelProp="label" />
+          </SelectQuadrone>
+          <i class="fa-solid fa-cog" aria-hidden="true"></i>
+        </label>
+      {/if}
+    </div>
+    <div class="list-content">
+      <div class="list-values">
+        {#if context.system.traits.size && context.config.actorSizes[context.system.traits.size]}
+          <ActorTraitPills
+            values={[
+              {
+                key: 'size',
+                label: context.config.actorSizes[context.system.traits.size].label,
+              },
+            ]}
+          />
+        {/if}
+      </div>
+    </div>
+  </div>
+{/if}

--- a/src/sheets/quadrone/actor/parts/ActorTraitSize.svelte
+++ b/src/sheets/quadrone/actor/parts/ActorTraitSize.svelte
@@ -20,7 +20,7 @@
   const localize = FoundryAdapter.localize;
 </script>
 
-<div class="list-entry">
+<div class="list-entry trait-size">
   <div class="list-label">
     <label for="{appId}-npc-size" class="h4 font-weight-label">
       <i class="fas fa-ruler-combined"></i>

--- a/src/sheets/quadrone/actor/parts/ActorTraitSize.svelte
+++ b/src/sheets/quadrone/actor/parts/ActorTraitSize.svelte
@@ -15,20 +15,23 @@
       >(),
     );
 
+  let appId = $derived(context.document.id);
+
   const localize = FoundryAdapter.localize;
 </script>
 
 <div class="list-entry">
   <div class="list-label">
-    <h4 class="font-weight-label">
+    <label for="{appId}-npc-size" class="h4 font-weight-label">
       <i class="fas fa-ruler-combined"></i>
       {localize('DND5E.Size')}
-    </h4>
+    </label>
   </div>
   <div class="list-content">
     <div class="list-values">
       {#if context.unlocked}
         <SelectQuadrone
+          id="{appId}-npc-size"
           document={context.actor}
           field="system.traits.size"
           value={context.system.traits.size}

--- a/src/sheets/quadrone/actor/tabs/NpcStatblockTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/NpcStatblockTab.svelte
@@ -20,6 +20,7 @@
   import UserPreferencesService from 'src/features/user-preferences/UserPreferencesService';
   import ActorTraitClasses from '../parts/ActorTraitClasses.svelte';
   import ActorTraitBackground from '../parts/ActorTraitBackground.svelte';
+  import NpcTraitSpecies from '../npc-parts/traits/NpcTraitSpecies.svelte';
 
   const localize = FoundryAdapter.localize;
 
@@ -101,13 +102,15 @@
   sheetDocument={context.actor}
 />
 
-<div class="tidy-table character-traits">
-  <div class="tidy-table-header-row theme-dark">
-    <h3>{localize('TIDY5E.CharacterTraits.Title')}</h3>
+{#if context.unlocked || context.background || context.species || context.classes.length > 0}
+  <div class="tidy-table character-traits">
+    <div class="tidy-table-header-row theme-dark">
+      <h3>{localize('TIDY5E.CharacterTraits.Title')}</h3>
+    </div>
+    <div class="list traits">
+      <ActorTraitClasses />
+      <ActorTraitBackground />
+      <NpcTraitSpecies />
+    </div>
   </div>
-  <div class="list traits">
-    <ActorTraitClasses />
-
-    <ActorTraitBackground />
-  </div>
-</div>
+{/if}

--- a/src/sheets/quadrone/shared/EffectsTables.svelte
+++ b/src/sheets/quadrone/shared/EffectsTables.svelte
@@ -49,12 +49,16 @@
   {@const hiddenColumns = EffectColumnRuntime.determineHiddenColumns(
     inlineWidth,
     columns,
-    10
+    10,
   )}
   {#if section.show}
     <TidyTable key={section.key}>
       {#snippet header()}
-        <TidyTableHeaderRow class="theme-dark">
+        <TidyTableHeaderRow
+          class="theme-dark {section.type === 'suppressed' || section.disabled
+            ? 'diminished'
+            : ''}"
+        >
           <TidyTableHeaderCell primary={true} class="header-label-cell">
             <h3>
               {localize(section.label)}

--- a/src/sheets/quadrone/shared/InventoryTables.svelte
+++ b/src/sheets/quadrone/shared/InventoryTables.svelte
@@ -177,12 +177,11 @@
             }))}
             {#each itemEntries as { item, ctx }, i (item.id)}
               {@const expanded = !!containerToggleMap.get(tabId)?.has(item.id)}
-              {@const unidentified = item.system.identified === false}
 
               <TidyItemTableRow
                 {item}
                 hidden={!searchResults.show(item.uuid)}
-                rowClass={[{ expanded, unidentified }]}
+                rowClass={[{ expanded }]}
                 contextMenu={{
                   type: CONSTANTS.CONTEXT_MENU_TYPE_ITEMS,
                   uuid: item.uuid,

--- a/src/sheets/quadrone/shared/ItemRollButton.svelte
+++ b/src/sheets/quadrone/shared/ItemRollButton.svelte
@@ -1,8 +1,4 @@
 <script lang="ts">
-  import type { ItemDescription } from 'src/types/item.types';
-  import CollapsibleEditorSection from './CollapsibleEditorSection.svelte';
-  import SheetEditorV2 from 'src/components/editor/SheetEditorV2.svelte';
-
   interface Props {
     image: string;
     name: string;

--- a/src/sheets/quadrone/shared/ItemRollButton.svelte
+++ b/src/sheets/quadrone/shared/ItemRollButton.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import type { ItemDescription } from 'src/types/item.types';
+  import CollapsibleEditorSection from './CollapsibleEditorSection.svelte';
+  import SheetEditorV2 from 'src/components/editor/SheetEditorV2.svelte';
+
+  interface Props {
+    image: string;
+    name: string;
+    onclick: (ev: MouseEvent) => void;
+    roll?: boolean;
+  }
+
+  let {
+    image,
+    name,
+    onclick,
+    roll = true,
+  }: Props = $props();
+
+  let diminished = $state(false);
+  let disabled = $state(false);
+  
+</script>
+
+{#if !disabled}
+  <a
+    class={['tidy-table-row-use-button', diminished && 'diminished']}
+    onclick={onclick}
+    onkeydown={(ev) => (ev.key === 'Enter' || ev.key === ' ') && onclick(ev as unknown as MouseEvent)}
+    aria-label={name}
+    tabindex="0"
+    role="button"
+  >
+    <img class="item-image" alt={name} src={image} />
+    <span class="roll-prompt">
+      <i class="fa {roll ? 'fa-dice-d20' : 'fa-file-magnifying-glass'}"></i>
+    </span>
+  </a>
+{:else}
+
+{/if}

--- a/src/sheets/quadrone/shared/SpellTable.svelte
+++ b/src/sheets/quadrone/shared/SpellTable.svelte
@@ -158,7 +158,7 @@
               item.system.canPrepare &&
               item.system.prepared ===
                 CONFIG.DND5E.spellPreparationStates.always.value,
-            unprepared:
+            diminished:
               !item.system.linkedActivity &&
               item.system.canPrepare &&
               item.system.prepared ===

--- a/src/todo.md
+++ b/src/todo.md
@@ -116,27 +116,27 @@
   - [x] Add Bastion facility roll icon on hover
   - [ ] Add Character tab roll icon on hover
 - [x] Figure out what's up with multiclassed spellbook footer padding missing
-- [ ] NPC Header
+- [x] NPC Header
   - [x] Rest buttons - when mouse down, the button borders change size and cause the buttons to shift
-- [ ] Light mode, collapsed view (enable Honor and Sanity)
-  - [ ] Init is very dark
-  - [ ] Ability proficiency decoration is a bit hard to notice
+- [x] Light mode, collapsed view (enable Honor and Sanity)
+  - [x] Init is very dark
+  - [x] Ability proficiency decoration is a bit hard to notice
 - [ ] NPC Subtitle
-  - [x] Do we need to mention Classes / Subclasses? Recommending no for now
-  - [x] Do we need to mention Background? Recommending no for now
+  - [x] Do we need to mention Classes / Subclasses? **Note: Recommending no for now**
+  - [x] Do we need to mention Background? **Note: Recommending no for now**
   - [x] Concentration button is vertically offset from the rest of the subtitle slightly
   - [ ] XP width broken when wrapping in Edit Mode
 - [x] NPC Sidebar
   - [x] Species section doesn't have an icon (I couldn't decide on one)
   - [x] Creature Type doesn't have an icon (I couldn't decide on one)
   - [x] Loyalty tracker doesn't have an icon (I couldn't decide on one)
-- [ ] Edit Mode
-  - [ ] Value input is wider than legendary trackers' value inputs
+- [x] Edit Mode
+  - [x] Value input is wider than legendary trackers' value inputs. **Note: on purpose**
 - [ ] Statblock tab
   - [ ] Section add buttons: they can only ever add a Feature to the Features section, unless we also opt to add a default Activity with action economy, which is not really a good option. I don't know if there's a solution for this, but I wanted to point the behavior out.
-- [ ] Pinned Filters
-  - [ ] At smallest width with sidebar open, all buttons are hidden, but the button group border itself is still visible. Wasn't sure if intentional.
-  - [ ] Given an NPC with a class and background and all sections collapsed, the character traits UI kinda floats a little awkwardly above the bottom of the sheet
+- [x] Pinned Filters
+  - [x] At smallest width with sidebar open, all buttons are hidden, but the button group border itself is still visible. Wasn't sure if intentional.
+  - [x] Given an NPC with a class and background and all sections collapsed, the character traits UI kinda floats a little awkwardly above the bottom of the sheet
 - [ ] Inventory tab
   - [ ] The encumbrance bar has a cursor pointer on its label. This is the same for all meters. Is there a specific use case it should be limited to?
 

--- a/src/todo.md
+++ b/src/todo.md
@@ -122,11 +122,11 @@
 - [x] Light mode, collapsed view (enable Honor and Sanity)
   - [x] Init is very dark
   - [x] Ability proficiency decoration is a bit hard to notice
-- [ ] NPC Subtitle
+- [x] NPC Subtitle
   - [x] Do we need to mention Classes / Subclasses? **Note: Recommending no for now**
   - [x] Do we need to mention Background? **Note: Recommending no for now**
   - [x] Concentration button is vertically offset from the rest of the subtitle slightly
-  - [ ] XP width broken when wrapping in Edit Mode
+  - [x] XP width broken when wrapping in Edit Mode
 - [x] NPC Sidebar
   - [x] Species section doesn't have an icon (I couldn't decide on one)
   - [x] Creature Type doesn't have an icon (I couldn't decide on one)
@@ -138,8 +138,8 @@
 - [x] Pinned Filters
   - [x] At smallest width with sidebar open, all buttons are hidden, but the button group border itself is still visible. Wasn't sure if intentional.
   - [x] Given an NPC with a class and background and all sections collapsed, the character traits UI kinda floats a little awkwardly above the bottom of the sheet
-- [ ] Inventory tab
-  - [ ] The encumbrance bar has a cursor pointer on its label. This is the same for all meters. Is there a specific use case it should be limited to?
+- [x] Inventory tab
+  - [x] The encumbrance bar has a cursor pointer on its label. This is the same for all meters. Is there a specific use case it should be limited to?
 
 ### Huh?
 

--- a/src/todo.md
+++ b/src/todo.md
@@ -122,9 +122,9 @@
   - [ ] Init is very dark
   - [ ] Ability proficiency decoration is a bit hard to notice
 - [ ] NPC Subtitle
-  - [ ] Do we need to mention Classes / Subclasses?
-  - [ ] Do we need to mention Background?
-  - [ ] Concentration button is vertically offset from the rest of the subtitle slightly
+  - [x] Do we need to mention Classes / Subclasses? Recommending no for now
+  - [x] Do we need to mention Background? Recommending no for now
+  - [x] Concentration button is vertically offset from the rest of the subtitle slightly
   - [ ] XP width broken when wrapping in Edit Mode
 - [x] NPC Sidebar
   - [x] Species section doesn't have an icon (I couldn't decide on one)

--- a/src/todo.md
+++ b/src/todo.md
@@ -123,18 +123,19 @@
   - [x] Init is very dark
   - [x] Ability proficiency decoration is a bit hard to notice
 - [x] NPC Subtitle
-  - [x] Do we need to mention Classes / Subclasses? **Note: Recommending no for now**
-  - [x] Do we need to mention Background? **Note: Recommending no for now**
+  - [x] ~~Do we need to mention Classes / Subclasses?~~ **Note: Recommending no for now**
+  - [x] ~~Do we need to mention Background?~~ **Note: Recommending no for now**
   - [x] Concentration button is vertically offset from the rest of the subtitle slightly
   - [x] XP width broken when wrapping in Edit Mode
 - [x] NPC Sidebar
   - [x] Species section doesn't have an icon (I couldn't decide on one)
   - [x] Creature Type doesn't have an icon (I couldn't decide on one)
   - [x] Loyalty tracker doesn't have an icon (I couldn't decide on one)
+  - [x] Finish styling hit die
 - [x] Edit Mode
   - [x] Value input is wider than legendary trackers' value inputs. **Note: on purpose**
-- [ ] Statblock tab
-  - [ ] Section add buttons: they can only ever add a Feature to the Features section, unless we also opt to add a default Activity with action economy, which is not really a good option. I don't know if there's a solution for this, but I wanted to point the behavior out.
+- [x] ~~Statblock tab~~
+  - [x] ~~Section add buttons: they can only ever add a Feature to the Features section, unless we also opt to add a default Activity with action economy, which is not really a good option. I don't know if there's a solution for this, but I wanted to point the behavior out.~~
 - [x] Pinned Filters
   - [x] At smallest width with sidebar open, all buttons are hidden, but the button group border itself is still visible. Wasn't sure if intentional.
   - [x] Given an NPC with a class and background and all sections collapsed, the character traits UI kinda floats a little awkwardly above the bottom of the sheet

--- a/src/todo.md
+++ b/src/todo.md
@@ -101,9 +101,9 @@
 ## hightouch To Do
 
 - [x] NPC Header subtitle - Concentration of 2 digits wraps badly, needs flex-wrap no-wrap
-- [ ] kgar idea: unify unprepared spell, unidentified inventory item, and suppressed effect table row styles into a class we can place on a table row to achieve the same look and feel across any of the table rows.
+- [x] kgar idea: unify unprepared spell, unidentified inventory item, and suppressed effect table row styles into a class we can place on a table row to achieve the same look and feel across any of the table rows.
 - [ ] kgar question: should we apply any alt header color for the suppressed effect section?
-- [ ] Non-square portraits need some CSS help: <https://github.com/kgar/foundry-vtt-tidy-5e-sheets/issues/1218#issuecomment-3067321940>
+- [x] Non-square portraits need some CSS help: <https://github.com/kgar/foundry-vtt-tidy-5e-sheets/issues/1218#issuecomment-3067321940>
 - [x] Test Korean language on Mac
 - [ ] Item sheet context menu styles - hide initial grouping line if present.
 - [ ] Request from Tyler: provide performance settings in Tidy that can disable animations and other similarly taxing CSS.
@@ -113,11 +113,11 @@
 - [ ] Item sheet sidebar background image (low)
 - [ ] Make a generic roll button component
   - [ ] Fix Slot favorite roll icon not appearing
-  - [ ] Add Bastion facility roll icon on hover
+  - [x] Add Bastion facility roll icon on hover
   - [ ] Add Character tab roll icon on hover
-- [ ] Figure out what's up with multiclassed spellbook footer padding missing
+- [x] Figure out what's up with multiclassed spellbook footer padding missing
 - [ ] NPC Header
-  - [ ] Rest buttons - when mouse down, the button borders change size and cause the buttons to shift
+  - [x] Rest buttons - when mouse down, the button borders change size and cause the buttons to shift
 - [ ] Light mode, collapsed view (enable Honor and Sanity)
   - [ ] Init is very dark
   - [ ] Ability proficiency decoration is a bit hard to notice
@@ -125,6 +125,7 @@
   - [ ] Do we need to mention Classes / Subclasses?
   - [ ] Do we need to mention Background?
   - [ ] Concentration button is vertically offset from the rest of the subtitle slightly
+  - [ ] XP width broken when wrapping in Edit Mode
 - [ ] NPC Sidebar
   - [ ] Species section doesn't have an icon (I couldn't decide on one)
   - [ ] Creature Type doesn't have an icon (I couldn't decide on one)

--- a/src/todo.md
+++ b/src/todo.md
@@ -102,10 +102,10 @@
 
 - [x] NPC Header subtitle - Concentration of 2 digits wraps badly, needs flex-wrap no-wrap
 - [x] kgar idea: unify unprepared spell, unidentified inventory item, and suppressed effect table row styles into a class we can place on a table row to achieve the same look and feel across any of the table rows.
-- [ ] kgar question: should we apply any alt header color for the suppressed effect section?
+- [x] kgar question: should we apply any alt header color for the suppressed effect section?
 - [x] Non-square portraits need some CSS help: <https://github.com/kgar/foundry-vtt-tidy-5e-sheets/issues/1218#issuecomment-3067321940>
 - [x] Test Korean language on Mac
-- [ ] Item sheet context menu styles - hide initial grouping line if present.
+- [x] Item sheet context menu styles - hide initial grouping line if present.
 - [ ] Request from Tyler: provide performance settings in Tidy that can disable animations and other similarly taxing CSS.
   - [ ] both - identify the things that can be disabled to appreciably improve perf
   - [ ] kgar - establish client (or user) setting(s) for disabling animations, shadows, etc.
@@ -126,10 +126,10 @@
   - [ ] Do we need to mention Background?
   - [ ] Concentration button is vertically offset from the rest of the subtitle slightly
   - [ ] XP width broken when wrapping in Edit Mode
-- [ ] NPC Sidebar
-  - [ ] Species section doesn't have an icon (I couldn't decide on one)
-  - [ ] Creature Type doesn't have an icon (I couldn't decide on one)
-  - [ ] Loyalty tracker doesn't have an icon (I couldn't decide on one)
+- [x] NPC Sidebar
+  - [x] Species section doesn't have an icon (I couldn't decide on one)
+  - [x] Creature Type doesn't have an icon (I couldn't decide on one)
+  - [x] Loyalty tracker doesn't have an icon (I couldn't decide on one)
 - [ ] Edit Mode
   - [ ] Value input is wider than legendary trackers' value inputs
 - [ ] Statblock tab

--- a/src/todo.md
+++ b/src/todo.md
@@ -23,10 +23,10 @@
   - [ ] Identify all resize observers which can be removed.
   - [ ] Propagate it to all locations where relevant. Namely, each instance of TabContent should track its inline width. This pays dividends.
   - [ ] Consider optimizing nested container inline width management at this time; apply spacer calculations to the final total for each level of nesting. It doesn't have to be perfect.
-- [ ] disable all roll buttons when in observer or locked compendium view. Leverage the `canUse` helper. https://discord.com/channels/@me/1243307347682529423/1397418208813650091
+- [ ] disable all roll buttons when in observer or locked compendium view. Leverage the `canUse` helper. <https://discord.com/channels/@me/1243307347682529423/1397418208813650091>
   - [ ] Fully remove the short/long rest buttons in the header
   - [ ] ...
-- [ ] Need to refactor: Resize Observation and Column Loadout. There are so many places in a given tab where resize observers are needed for inline activities that it imposes a noticeable perforamnce hit. Also, with every adjustment, column loadout is redone and re-ordered, which is unnecessary. At much as possible needs to be moved to 
+- [ ] Need to refactor: Resize Observation and Column Loadout. There are so many places in a given tab where resize observers are needed for inline activities that it imposes a noticeable perforamnce hit. Also, with every adjustment, column loadout is redone and re-ordered, which is unnecessary. At much as possible needs to be moved to
 - [ ] Suggestion: Hide the Add to Sheet Tab button when the sheet tab is hidden.
   - [ ] Actor Sheet base - add abstract function `getSelectedTabIds()`; all callers must return the effective list of selected tab IDs. If the flag is nil, then return the default tab ID list. This will side-step any need for major refactors
     - [ ] Then add `isUsingActionsTab()`, which leverages `getSelectedTabIds()` and returns whether the actions tab ID is included.
@@ -98,14 +98,13 @@
 - [ ] Like with the getSheetContext() functions, make other common ones, like getMessageBus() and getTabId(). At this point, should they be housed in a containing static class or exported object constant?
 - [ ] Wonky formulas like `0 + 2 + 1d4 + 0 / 2` are clearly able to be simplified when reading them with human eyes. Is there a way with standard Foundry/dnd5e APIs to resolve all deterministic parts and make the formula look like `2 + 1d4`, or even better, `1d4 + 2`?
 
-
 ## hightouch To Do
 
-- [ ] NPC Header subtitle - Concentration of 2 digits wraps badly, needs flex-wrap no-wrap
+- [x] NPC Header subtitle - Concentration of 2 digits wraps badly, needs flex-wrap no-wrap
 - [ ] kgar idea: unify unprepared spell, unidentified inventory item, and suppressed effect table row styles into a class we can place on a table row to achieve the same look and feel across any of the table rows.
 - [ ] kgar question: should we apply any alt header color for the suppressed effect section?
 - [ ] Non-square portraits need some CSS help: <https://github.com/kgar/foundry-vtt-tidy-5e-sheets/issues/1218#issuecomment-3067321940>
-- [ ] Test Korean language on Mac
+- [x] Test Korean language on Mac
 - [ ] Item sheet context menu styles - hide initial grouping line if present.
 - [ ] Request from Tyler: provide performance settings in Tidy that can disable animations and other similarly taxing CSS.
   - [ ] both - identify the things that can be disabled to appreciably improve perf
@@ -117,6 +116,28 @@
   - [ ] Add Bastion facility roll icon on hover
   - [ ] Add Character tab roll icon on hover
 - [ ] Figure out what's up with multiclassed spellbook footer padding missing
+- [ ] NPC Header
+  - [ ] Rest buttons - when mouse down, the button borders change size and cause the buttons to shift
+- [ ] Light mode, collapsed view (enable Honor and Sanity)
+  - [ ] Init is very dark
+  - [ ] Ability proficiency decoration is a bit hard to notice
+- [ ] NPC Subtitle
+  - [ ] Do we need to mention Classes / Subclasses?
+  - [ ] Do we need to mention Background?
+  - [ ] Concentration button is vertically offset from the rest of the subtitle slightly
+- [ ] NPC Sidebar
+  - [ ] Species section doesn't have an icon (I couldn't decide on one)
+  - [ ] Creature Type doesn't have an icon (I couldn't decide on one)
+  - [ ] Loyalty tracker doesn't have an icon (I couldn't decide on one)
+- [ ] Edit Mode
+  - [ ] Value input is wider than legendary trackers' value inputs
+- [ ] Statblock tab
+  - [ ] Section add buttons: they can only ever add a Feature to the Features section, unless we also opt to add a default Activity with action economy, which is not really a good option. I don't know if there's a solution for this, but I wanted to point the behavior out.
+- [ ] Pinned Filters
+  - [ ] At smallest width with sidebar open, all buttons are hidden, but the button group border itself is still visible. Wasn't sure if intentional.
+  - [ ] Given an NPC with a class and background and all sections collapsed, the character traits UI kinda floats a little awkwardly above the bottom of the sheet
+- [ ] Inventory tab
+  - [ ] The encumbrance bar has a cursor pointer on its label. This is the same for all meters. Is there a specific use case it should be limited to?
 
 ### Huh?
 
@@ -194,6 +215,4 @@ Limited:
 
 - Identical to Observer
 
-
 ### To Do Graveyard
-


### PR DESCRIPTION
- Updated todos, still need to look at light mode sidebar trait label colors
- Reorganized Character Traits and NPC Traits to have a clearer distinction between the sidebar and Statblock tabs
- Updated Size to use a dropdown on the gear icon to better fit in to sidebar
- Migrated grey/unidentified/unprepared to use a common `.diminished` class
- Fixed collapsed ability styles on NPC and Character sheets
- Small fix to damage bypass colors in dark mode