### PR TITLE
fix[#1325]: replace favorite buttons with role="button"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3462,21 +3462,6 @@
         }
       }
     },
-    "node_modules/svelte-check/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3462,6 +3462,21 @@
         }
       }
     },
+    "node_modules/svelte-check/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",

--- a/src/scss/quadrone/character-parts/favorites.scss
+++ b/src/scss/quadrone/character-parts/favorites.scss
@@ -107,6 +107,8 @@
 
       .favorite-button {
         display: flex;
+        flex-direction: row;
+        overflow: visible;
         flex: 5;
         padding-inline-start: 0;
         padding-inline-end: 0;

--- a/src/sheets/quadrone/actor/character-parts/favorites/FavoriteSkillTool.svelte
+++ b/src/sheets/quadrone/actor/character-parts/favorites/FavoriteSkillTool.svelte
@@ -27,7 +27,7 @@
   );
 
   async function handleOnUse(
-    event: MouseEvent & { currentTarget: EventTarget & HTMLButtonElement },
+    event: MouseEvent & { currentTarget: EventTarget & HTMLDivElement },
     _favorite: SkillToolFavoriteContextEntry,
   ) {
     if (favorite.type === 'skill') {

--- a/src/sheets/quadrone/actor/character-parts/favorites/parts/FavoriteRollButton.svelte
+++ b/src/sheets/quadrone/actor/character-parts/favorites/parts/FavoriteRollButton.svelte
@@ -1,3 +1,7 @@
+<script lang="ts" module>
+const PSEUDO_BTN_CLICK_KEYS =new Set([' ', 'Enter'])
+</script>
+
 <script lang="ts" generics="TFavorite extends FavoriteContextEntry">
   import { getCharacterSheetQuadroneContext } from 'src/sheets/sheet-context.svelte';
   import type { FavoriteContextEntry } from 'src/types/types';
@@ -7,7 +11,7 @@
     favorite: TFavorite;
     img: string | undefined;
     onUse?: (
-      event: MouseEvent & { currentTarget: EventTarget & HTMLButtonElement },
+      event: MouseEvent & { currentTarget: EventTarget & HTMLDivElement },
       favorite: TFavorite,
     ) => Promise<any>;
     title: string;
@@ -29,7 +33,7 @@
   let context = $derived(getCharacterSheetQuadroneContext());
 
   function handleClick(
-    event: MouseEvent & { currentTarget: EventTarget & HTMLButtonElement },
+    event: MouseEvent & { currentTarget: EventTarget & HTMLDivElement },
   ) {
     if (!context.editable) {
       return;
@@ -46,14 +50,29 @@
       ? `${name} <br /> ${theSubtitle?.innerText.replaceAll('\n', ' • ') ?? ''}`
       : undefined,
   );
+
+  function handleKeyDown(
+    e: KeyboardEvent & { currentTarget: EventTarget & HTMLDivElement },
+  ) {
+    if (!context.editable) {
+      return;
+    }
+
+    if (PSEUDO_BTN_CLICK_KEYS.has(e.key)) return;
+
+    e.currentTarget?.click();
+  }
 </script>
 
-<button
-  type="button"
+<!-- We're not using a button here as firefox has a bug with dragging buttons -->
+<div
+  role="button"
   class="button button-borderless favorite-button"
   onclick={handleClick}
+  onkeydown={handleKeyDown}
+  tabindex="0"
   data-tooltip={tooltip}
-  disabled={!context.editable}
+  aria-disabled={!context.editable}
 >
   <span
     class={[
@@ -85,4 +104,4 @@
       </span>
     </div>
   </div>
-</button>
+</div>

--- a/src/sheets/quadrone/actor/character-parts/favorites/parts/FavoriteRollButton.svelte
+++ b/src/sheets/quadrone/actor/character-parts/favorites/parts/FavoriteRollButton.svelte
@@ -58,8 +58,9 @@ const PSEUDO_BTN_CLICK_KEYS =new Set([' ', 'Enter'])
       return;
     }
 
-    if (PSEUDO_BTN_CLICK_KEYS.has(e.key)) return;
+    if (!PSEUDO_BTN_CLICK_KEYS.has(e.key)) return;
 
+    e.preventDefault()
     e.currentTarget?.click();
   }
 </script>

--- a/src/sheets/quadrone/actor/character-parts/favorites/parts/FavoriteRollButton.svelte
+++ b/src/sheets/quadrone/actor/character-parts/favorites/parts/FavoriteRollButton.svelte
@@ -74,6 +74,7 @@ const PSEUDO_BTN_CLICK_KEYS =new Set([' ', 'Enter'])
   tabindex="0"
   data-tooltip={tooltip}
   aria-disabled={!context.editable}
+  data-keyboard-focus
 >
   <span
     class={[


### PR DESCRIPTION
I attempted to use follow this solution https://bugzilla.mozilla.org/show_bug.cgi?id=568313#c23 but it appears it only works if the button itself is draggable, instead, I've gone with the `role="button"` route.

fixes #1325 

Tested on Mac: Chromium (Vivaldi) and Firefox. Doesn't work on Safari, although that's parity with original