### PR TITLE
fix(ui): format weight and add units

### DIFF
--- a/src/sheets/classic/actor/EncumbranceBar.svelte
+++ b/src/sheets/classic/actor/EncumbranceBar.svelte
@@ -9,6 +9,14 @@
   let { encumbrance }: Props = $props();
 
   const localize = FoundryAdapter.localize;
+
+  function formatWeight(value: number): string {
+    const rounded = Math.round((value ?? 0) * 100) / 100;
+    return rounded.toFixed(2).replace(/\.0+$/, '').replace(/\.$/, '');
+  }
+
+  let readableValue = $derived(formatWeight(encumbrance.value ?? 0));
+  let unitsAbbreviation = $derived(FoundryAdapter.getWeightUnit());
 </script>
 
 <div
@@ -24,9 +32,10 @@
 >
   <span class="encumbrance-bar" style="width:{encumbrance.pct}%"
   ></span>
-  <span class="encumbrance-label"
-    >{encumbrance.value} / {encumbrance.max}</span
-  >
+  <span class="encumbrance-label">
+    {readableValue} / {encumbrance.max}
+    <span class="color-text-lightest">{unitsAbbreviation}</span>
+  </span>
   <i class="encumbrance-breakpoint encumbrance-low arrow-up"></i>
   <i class="encumbrance-breakpoint encumbrance-low arrow-down"></i>
   <i class="encumbrance-breakpoint encumbrance-high arrow-up"></i>

--- a/src/sheets/quadrone/actor/parts/ActorEncumbranceBar.svelte
+++ b/src/sheets/quadrone/actor/parts/ActorEncumbranceBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { ActorAttributeEncumbrance } from 'src/foundry/dnd5e.types';
   import { getSheetContext } from 'src/sheets/sheet-context.svelte';
+  import { FoundryAdapter } from 'src/foundry/foundry-adapter';
   import WeightDistributionTooltip from 'src/tooltips/WeightDistributionTooltip.svelte';
   import type { ActorSheetQuadroneContext } from 'src/types/types';
 
@@ -20,13 +21,19 @@
         : `low`,
   );
 
-  let readableValue = $derived((encumbrance.value ?? 0).toFixed(1));
+  function formatWeight(value: number): string {
+    const rounded = Math.round((value ?? 0) * 100) / 100;
+    return rounded.toFixed(2).replace(/\.0+$/, '').replace(/\.$/, '');
+  }
+
+  let readableValue = $derived(formatWeight(encumbrance.value ?? 0));
 
   let encumbranceMaxText = $derived(
     encumbrance.max === Infinity ? '∞' : encumbrance.max,
   );
 
   let weightDistributionTooltip: WeightDistributionTooltip;
+  let unitsAbbreviation = $derived(FoundryAdapter.getWeightUnit());
 </script>
 
 <WeightDistributionTooltip
@@ -58,7 +65,7 @@
     <span class="value font-weight-label">{readableValue}</span>
     <span class="separator">/</span>
     <span class="max color-text-default">{encumbranceMaxText}</span>
-    <!-- <span class="units color-text-lightest">{unitsAbbreviation}</span> -->
+    <span class="units color-text-lightest">{unitsAbbreviation}</span>
   </div>
 
   <i class="breakpoint encumbrance-low arrow-up" role="presentation"></i>

--- a/src/sheets/quadrone/container/ContainerSheet.svelte
+++ b/src/sheets/quadrone/container/ContainerSheet.svelte
@@ -31,6 +31,11 @@
       units: context.capacity.units ?? '',
     });
   });
+
+  function formatWeight(value: number | undefined): string {
+    const rounded = Math.round((value ?? 0) * 100) / 100;
+    return rounded.toFixed(2).replace(/\.0+$/, '').replace(/\.$/, '');
+  }
 </script>
 
 <ItemNameHeaderOrchestrator {itemNameEl} />
@@ -106,9 +111,10 @@
       <i class="fa-solid fa-scale-unbalanced item-capacity-icon text-label-icon"
       ></i>
       <div class="item-capacity-counter">
-        <span class="capacity-value text-data">{context.capacity.value}</span>
+        <span class="capacity-value text-data">{formatWeight(context.capacity.value)}</span>
         <div class="separator">/</div>
-        <span class="capacity-max text-data">{context.capacity.max}</span>
+        <span class="capacity-max text-data">{formatWeight(context.capacity.max)}</span>
+        <span class="color-text-lighter">{context.capacity.units}</span>
       </div>
     </div>
 

--- a/src/sheets/quadrone/container/parts/CapacityTracker.svelte
+++ b/src/sheets/quadrone/container/parts/CapacityTracker.svelte
@@ -13,7 +13,10 @@
 
   let readableValue = $derived(
     container.system.capacity.type === CONSTANTS.ITEM_CAPACITY_TYPE_WEIGHT
-      ? (capacity.value ?? 0).toFixed(1)
+      ? (() => {
+          const rounded = Math.round((capacity.value ?? 0) * 100) / 100;
+          return rounded.toFixed(2).replace(/\.0+$/, '').replace(/\.$/, '');
+        })()
       : Math.ceil(capacity.value ?? 0).toString(),
   );
 

--- a/src/sheets/quadrone/item/parts/header/ItemWeightSummary.svelte
+++ b/src/sheets/quadrone/item/parts/header/ItemWeightSummary.svelte
@@ -1,12 +1,23 @@
 <script lang="ts">
   import { getItemSheetContextQuadrone } from 'src/sheets/sheet-context.svelte';
+  import { FoundryAdapter } from 'src/foundry/foundry-adapter';
 
   let context = $derived(getItemSheetContextQuadrone());
+
+  function formatWeight(value: number | undefined): string {
+    const rounded = Math.round((value ?? 0) * 100) / 100;
+    return rounded.toFixed(2).replace(/\.0+$/, '').replace(/\.$/, '');
+  }
+
+  let unitsAbbreviation = $derived(FoundryAdapter.getWeightUnit());
 </script>
 
 <div class="item-weight">
   <i class="fas fa-weight-hanging item-weight-icon text-label-icon"></i>
-  <span class="item-weight-value text-data">
-    {context.system.weight?.value}
+  <span class="item-weight-value">
+    <span class="color-text-default font-weight-label">
+      {formatWeight(context.system.weight?.value)}
+    </span>
+    <span class="item-weight-units color-text-lighter">{unitsAbbreviation}</span>
   </span>
 </div>

--- a/src/tooltips/WeightDistributionTooltip.svelte
+++ b/src/tooltips/WeightDistributionTooltip.svelte
@@ -12,7 +12,14 @@
 
   let { sheetDocument, fullWeight, currencyWeight }: Props = $props();
 
-  let itemsWeight = $derived((fullWeight - currencyWeight).toNearest(0.1));
+  let itemsWeight = $derived((fullWeight - currencyWeight).toNearest(0.01));
+
+  let unitsAbbreviation = $derived(FoundryAdapter.getWeightUnit());
+
+  function formatWeight(value: number): string {
+    const rounded = Math.round((value ?? 0) * 100) / 100;
+    return rounded.toFixed(2).replace(/\.0+$/, '').replace(/\.$/, '');
+  }
 
   let tooltip: HTMLElement;
 
@@ -45,14 +52,20 @@
           <i class="fa-solid fa-sack"></i>
           <span class="truncate">{localize('DND5E.Items')}</span>
         </span>
-        <span class="value">{itemsWeight}</span>
+        <span class="value">
+          {formatWeight(itemsWeight)}
+          <span class="units color-text-lighter">{unitsAbbreviation}</span>
+        </span>
       </li>
       <li>
         <span class="label">
           <i class="fa-solid fa-coins"></i>
           <span class="truncate">{localize('DND5E.Currency')}</span>
         </span>
-        <span class="value">{currencyWeight}</span>
+        <span class="value">
+          {formatWeight(currencyWeight)}
+          <span class="units color-text-lighter">{unitsAbbreviation}</span>
+        </span>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
Hey! Great module!
Small fix:

* Add units to the weight panels of character / items / tools / etc sheets
* Limit to ≤2 decimals in character inventory summary (before it could be 43.333333333)


<img width="887" height="817" alt="Screenshot 2025-08-24 at 20 35 12" src="https://github.com/user-attachments/assets/2e4d0bea-b2b8-4ed3-aa30-8f1788e92011" />
<img width="569" height="590" alt="Screenshot 2025-08-24 at 20 35 35" src="https://github.com/user-attachments/assets/b383e90c-cba4-419a-ba9a-c2085630908d" />


