### PR TITLE
feat: modify tab component mounting to allow bridging to other runtimes

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "exports":{
+    "./context": {
+      "types": "./src/api/PublicTypes.ts"
+    },
+    "./api": {
+      "types": "./src/api/Tidy5eSheetsApi.ts"
+    }
+  },
   "scripts": {
     "prepare-dev": "node prepare-dist-for-dev.js",
     "dev": "npm run prepare-dev && vite",

--- a/src/api/PublicTypes.ts
+++ b/src/api/PublicTypes.ts
@@ -1,0 +1,42 @@
+import type { InlineToggleService } from 'src/features/expand-collapse/InlineToggleService.svelte';
+import type { ItemFilterService } from 'src/features/filtering/ItemFilterService.svelte';
+import type { Ref } from 'src/features/reactivity/reactivity.types';
+import type { ActorSheetContextV1 } from 'src/types/types';
+import type { Readable } from 'svelte/store';
+
+/**
+ * Helper for type hinting values for subscribers provided by context
+ * Note: This isn't a comprehensive list and is subject to change
+ */
+export type ActorSheetContextRaw = {
+  /**
+   * Values from the Tidy5e sheet
+   */
+  context: ActorSheetContextV1;
+  /**
+   * Location of the tab
+   */
+  location: string;
+  /**
+   * id of the current tab
+   */
+  tabId: string;
+  inlineToggleService: InlineToggleService;
+  itemFilterService: ItemFilterService;
+  /**
+   * listener for a tab selected
+   */
+  onTabSelected(tabId: string): void;
+  /**
+   * Reference of the element the tab is contained in
+   */
+  tabContentElementRef: Ref<HTMLDivElement>;
+};
+
+/**
+ * Helper for type hinting getContext
+ * Note: This isn't a comprehensive list and is subject to change
+ */
+export type ActorSheetContext = {
+  [K in keyof ActorSheetContextRaw]: Readable<ActorSheetContextRaw[K]>;
+};

--- a/src/api/svelte/TidySvelteApi.ts
+++ b/src/api/svelte/TidySvelteApi.ts
@@ -1,9 +1,9 @@
 import { getContext, setContext, mount, unmount } from 'svelte';
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
-
 export const TidySvelteApi = {
   /**
    * Svelte resources which are directly tied to Tidy's svelte version / runtime.
+   * @deprecated potentially?
    */
   framework: {
     /**

--- a/src/api/tab/SvelteTab.ts
+++ b/src/api/tab/SvelteTab.ts
@@ -1,4 +1,4 @@
-import type { Component } from 'svelte';
+import type { Component, mount, unmount } from 'svelte';
 import type { OnRenderTabParams } from 'src/types/types';
 import type { RenderScheme } from '../api.types';
 import { CustomTabBase, type CustomTabTitle } from './CustomTabBase';
@@ -37,7 +37,11 @@ export class SvelteTab extends CustomTabBase {
   /**
    * A reference to the `.svelte` component.
    */
-  component?: Component = undefined;
+  component?:
+    | Component
+    | { component: Component }
+    | { component: Component; mount: typeof mount; unmount: typeof unmount } =
+    undefined;
   title: CustomTabTitle = '';
   iconClass?: string | undefined;
   tabId: string = '';

--- a/src/components/tabs/TabContent.svelte
+++ b/src/components/tabs/TabContent.svelte
@@ -7,7 +7,6 @@
   import { getSheetContext } from 'src/sheets/sheet-context.svelte';
   import type { ClassValue } from 'svelte/elements';
   import type { Ref } from 'src/features/reactivity/reactivity.types';
-  import { map } from 'src/utils/iterables';
   import { readonly, writable, type Readable } from 'svelte/store';
 
   interface Props {

--- a/src/components/tabs/TabContent.svelte
+++ b/src/components/tabs/TabContent.svelte
@@ -7,7 +7,7 @@
   import { getSheetContext } from 'src/sheets/sheet-context.svelte';
   import type { ClassValue } from 'svelte/elements';
   import type { Ref } from 'src/features/reactivity/reactivity.types';
-  import { readonly, writable, type Readable } from 'svelte/store';
+  import { readonly, writable } from 'svelte/store';
 
   interface Props {
     tab: Tab;
@@ -71,17 +71,7 @@
             $effect(() => {
               store.set(val);
             });
-            // We technically want this to only be readable from outside so we'll create a pseudo readable
-            const readonlyStore = {
-              // don't forget to like and
-              subscribe(
-                this: void,
-                ...args: Parameters<Readable<unknown>['subscribe']>
-              ) {
-                return store.subscribe(...args);
-              },
-            } satisfies Readable<unknown>;
-            return [key, readonlyStore];
+            return [key,  readonly(store)];
           }),
         );
         svelteTabComponent = _mount(component, {

--- a/src/components/tabs/TabContent.svelte
+++ b/src/components/tabs/TabContent.svelte
@@ -7,6 +7,8 @@
   import { getSheetContext } from 'src/sheets/sheet-context.svelte';
   import type { ClassValue } from 'svelte/elements';
   import type { Ref } from 'src/features/reactivity/reactivity.types';
+  import { map } from 'src/utils/iterables';
+  import { readonly, writable, type Readable } from 'svelte/store';
 
   interface Props {
     tab: Tab;
@@ -35,14 +37,63 @@
       const props = tab.content.getProps?.(context) ?? {};
       const tabComponentContext =
         tab.content.getContext?.(allContexts) ?? allContexts;
-      const svelteTabComponent = mount(tab.content.component, {
-        target: tidyTab.value,
-        context: tabComponentContext,
-        props: props,
-      });
+
+      const component =
+        typeof tab.content.component === 'function'
+          ? tab.content.component
+          : tab.content.component.component;
+      // We allow the user to provide their own mount function from their own svelte runtime
+      const { mount: _mount, unmount: _unmount } =
+        'mount' in tab.content.component
+          ? tab.content.component
+          : { mount, unmount };
+
+      const isExternalMount = mount !== _mount;
+      // Both need to be external or internal, else we got problems
+      const isValidMountPair = isExternalMount === (unmount !== _unmount);
+
+      if (!isValidMountPair)
+        throw new Error('Both mount and unmount must be provided if one is');
+
+      let svelteTabComponent: {};
+      if (!isExternalMount) {
+        svelteTabComponent = _mount(component, {
+          target: tidyTab.value,
+          context: tabComponentContext,
+          props: props,
+        });
+      } else {
+        // If we're using their mount, we need to do change how we handle the context so that they can hook into our reactivity
+        const safeTabComponentContext = new Map(
+          tabComponentContext.entries().map(([key, val]) => {
+            // stores are framework agnostic, which is what we need for cross runtime interactivity
+            const store = writable(val);
+            // This is where the magic happens, causes all subscribers to be triggered
+            $effect(() => {
+              store.set(val);
+            });
+            // We technically want this to only be readable from outside so we'll create a pseudo readable
+            const readonlyStore = {
+              // don't forget to like and
+              subscribe(
+                this: void,
+                ...args: Parameters<Readable<unknown>['subscribe']>
+              ) {
+                return store.subscribe(...args);
+              },
+            } satisfies Readable<unknown>;
+            return [key, readonlyStore];
+          }),
+        );
+        svelteTabComponent = _mount(component, {
+          target: tidyTab.value,
+          context: safeTabComponentContext,
+          props: props,
+        });
+      }
 
       return () => {
-        unmount(svelteTabComponent);
+        _unmount(svelteTabComponent);
       };
     } catch (e) {
       error('Failed to render svelte tab', false, e);

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,4 +1,4 @@
-import type { Component } from 'svelte';
+import type { Component, mount, unmount } from 'svelte';
 import type {
   ContainerContents,
   CurrencyContext,
@@ -40,7 +40,10 @@ export type TokenDocument = any;
 
 export type SvelteTabContent = {
   type: 'svelte';
-  component: Component<any>;
+  component:
+    | Component<any>
+    | { component: Component }
+    | { component: Component; mount: typeof mount; unmount: typeof unmount };
   cssClass?: string;
   getProps?: (data: any) => Record<string, any>;
   getContext?: (context: Map<any, any>) => Map<any, any>;


### PR DESCRIPTION
Modifies the Svelte Tab handler to accept an object that allows other modules to provide their own mount and unmount functions so that it can use it instead to mount the component within itself, handing over everything to their own runtime. 

In addition to this, the it updates the context to use Stores which are framework agnostic as they rely on subscribers functions for their interactivity. Hypothetically, you could use the same/similar technique to provide reactivity to other components. 

I've preserved the old potential value of Component so it's compatible with the old way.

This might mean we should deprecate/remove the svelte api as it appears that the better way to go about it is to let people use their own runtime for svelte for now.

## How it looks from a user's perspective

```svelte
<script lang="ts">
// Can just use their own getContext
import { getContext } from 'svelte'
// for ease of use, we can use derived
import { derived } from 'svelte/store'

const context = getContext('context')

// sheet would be another store
let sheet = derived(context, ($context) => $context.data.sheet)
let isEditMode = derived(
  context,
  ($context: any) => $context.data.unlocked
);
</script>

<div>
Sheet is editable: { $isEditMode }
</div>
```