### PR TITLE
quick fix: roll table button icon styles

### DIFF
--- a/src/scss/quadrone/editors.scss
+++ b/src/scss/quadrone/editors.scss
@@ -121,6 +121,7 @@
         th {
           line-height: 1.25;
           padding: var(--t5e-size-halfx) var(--t5e-size-2x);
+          color: var(--t5e-color-palette-white);
         }
       }
 
@@ -153,7 +154,7 @@
           justify-content: center;
         }
 
-        button.fas {
+        :is(button, .button):is(.fas, .icon) {
           font-family: "Font Awesome 6 Pro";
           padding: 0 0 0.0625rem;
           min-height: var(--t5e-table-button-width);


### PR DESCRIPTION
Fixed: roll table buttons have a non-Font-Awesome font and don't receive the intended button styles for icon buttons.