### PR TITLE
fix[#1342]: popout now works with theming

### DIFF
--- a/src/integration/modules/PopoutModuleIntegration.ts
+++ b/src/integration/modules/PopoutModuleIntegration.ts
@@ -1,16 +1,43 @@
 import type { Tidy5eSheetsApi } from 'src/api/Tidy5eSheetsApi';
 import type { ModuleIntegrationBase } from '../integration-classes';
 import type { ContextMenuPositionInfo } from 'src/context-menu/context-menu.types';
+import { ThemeQuadrone } from 'src/theme/theme-quadrone.svelte';
 
 declare var PopoutModule: any;
 
 export class PopoutModuleIntegration implements ModuleIntegrationBase {
+  poppedOut: Map<unknown, CSSStyleSheet> = new Map();
+
   get moduleId(): string {
     return 'popout';
   }
 
   init(api: Tidy5eSheetsApi): void {
-    //this.addPopOutHeaderButton(api); // Uncomment if PopOut! supports App V2
+    Hooks.on('PopOut:loaded', (app: unknown, node: HTMLHtmlElement) => {
+      if (api.isTidy5eSheet(app)) {
+        const popoutDocument = node.ownerDocument;
+        const popoutWindow = popoutDocument.defaultView;
+        if (!popoutWindow) return;
+
+        const copiedStylesheet = new popoutWindow.CSSStyleSheet();
+
+        this.poppedOut.set(app, copiedStylesheet);
+        ThemeQuadrone.subscribeStylesheet(copiedStylesheet);
+
+        popoutDocument.adoptedStyleSheets.push(copiedStylesheet);
+      }
+    });
+
+    const unsubscribe = (app: unknown) => {
+      const stylesheet = this.poppedOut.get(app);
+      if (stylesheet) {
+        this.poppedOut.delete(app);
+        ThemeQuadrone.unsubscribeStylesheet(stylesheet);
+      }
+    };
+
+    Hooks.on('PopOut:popin', unsubscribe);
+    Hooks.on('PopOut:close', unsubscribe);
   }
 
   private addPopOutHeaderButton(api: Tidy5eSheetsApi) {


### PR DESCRIPTION
Theming now works on popped out sheets. They're kept in sync as the theme changes (currently only possible with global settings changes as the context menu at the top breaks in popout view, this is a popout problem as it breaks in vanilla dnd5e sheets too)


fix #1342 