### PR TITLE
Group sheet refinement

### DIFF
--- a/src/foundry/foundry-adapter.ts
+++ b/src/foundry/foundry-adapter.ts
@@ -462,10 +462,10 @@ export const FoundryAdapter = {
   },
   getProficiencyIconClass(level: number) {
     const icons: Record<number, string> = {
-      0: 'far fa-circle',
-      0.5: 'fas fa-adjust',
-      1: 'fas fa-check',
-      2: 'fas fa-check-double',
+      0: 'far fa-circle color-text-gold',
+      0.5: 'fas fa-circle-half-stroke color-text-gold-emphasis',
+      1: 'fas fa-circle color-text-gold-emphasis',
+      2: 'fas fa-circle-star color-text-gold-emphasis',
     };
     return icons[level] || icons[0];
   },

--- a/src/scss/quadrone/actors.scss
+++ b/src/scss/quadrone/actors.scss
@@ -179,7 +179,10 @@
         overflow-y: auto;
         padding: var(--t5e-size-3x) var(--t5e-size-4x) var(--t5e-size-3x) var(--t5e-size-4x);
         position: relative;
-        // container-type: inline-size;
+
+        &.inventory {
+          padding-top: 0;
+        }
       }
     }
   }
@@ -979,10 +982,6 @@
       >span {
         flex: 0;
         text-wrap: nowrap;
-      }
-
-      >.divider-dot:last-child {
-        display: none;
       }
 
       .dc {
@@ -2570,30 +2569,19 @@
 
   // TODO: @kgar still need to move inventory footer to flex positioned outside rest of content. Here was some of the padding changes
   .window-content .main-content>.tidy-tab.inventory {
-    //   padding: 0;
-
-    //   >* {
-    //     margin-left: var(--t5e-size-4x);
-    //     margin-right: var(--t5e-size-4x);
-    //   }
-
-    //   >:first-child {
-    //     margin-top: var(--t5e-size-3x);
-    //   }
-
-    //   >:last-child {
-    //     margin: 0 var(--t5e-size-3x) var(--t5e-size-3x);
-    //     padding: var(--t5e-size-1x);
-    //   }
 
     row-gap: 0;
     padding-inline-end: 0;
+  }
+
+  .tidy-tab.inventory {
 
     .inventory-content {
       display: flex;
       flex-direction: column;
       flex: 1 1 0;
       overflow: auto;
+      padding-block-start: var(--t5e-size-3x);
       padding-inline-end: var(--t5e-size-4x);
       row-gap: var(--t5e-size-3x);
     }

--- a/src/scss/quadrone/components/meters.scss
+++ b/src/scss/quadrone/components/meters.scss
@@ -93,7 +93,7 @@
     &.medium {
       --bar-background: linear-gradient(to right,
           var(--t5e-color-palette-orange-40) 0%,
-          var(--t5e-color-palette-orange-70) 100%);
+          var(--t5e-color-palette-orange-55) 100%);
       --bar-border-color: var(--t5e-color-palette-orange-40);
     }
 

--- a/src/scss/quadrone/dialogs.scss
+++ b/src/scss/quadrone/dialogs.scss
@@ -26,6 +26,7 @@
       flex-direction: column;
       flex: 1;
       min-height: 0;
+      padding: 0 1rem 1rem;
 
       h1 {
         font: var(--t5e-font-title-medium);
@@ -66,6 +67,14 @@
         flex: 1;
         text-wrap: none;
       }
+    }
+  }
+
+  &.special-traits,
+  &.tab-configuration,
+  &.tidy-journal-entry {
+    .window-content {
+      padding: 0 1rem 1rem;
     }
   }
 }

--- a/src/scss/quadrone/group.scss
+++ b/src/scss/quadrone/group.scss
@@ -141,6 +141,19 @@
     }
   }
 
+  .separated-list {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    >* {
+      align-items: center;
+      display: flex;
+      flex-direction: row;
+      gap: 0.25rem;
+    }
+  }
+
   /* Specific tab overrides */
   .window-content .main-content>.tidy-tab {
     flex-direction: row;
@@ -161,7 +174,13 @@
       display: flex;
       flex: 1;
       overflow-y: auto;
-      padding: var(--t5e-size-3x) var(--t5e-size-4x) var(--t5e-size-8x) var(--t5e-size-3x);
+      padding-left: var(--t5e-size-3x);
+    }
+
+    .group-members-content {
+      padding-top: var(--t5e-size-3x);
+      padding-right: var(--t5e-size-4x);
+      padding-bottom: var(--t5e-size-8x);
     }
   }
 
@@ -405,6 +424,10 @@
     }
 
     &.inventory {
+      .groups-tab-content {
+        padding-bottom: var(--t5e-size-3x);
+      }
+
       .sidebar {
         padding-top: var(--t5e-size-4x);
       }
@@ -415,10 +438,6 @@
 
         &:hover {
           cursor: pointer;
-        }
-
-        .actor-currency {
-          gap: 0.125rem;
         }
 
         .progress {

--- a/src/scss/quadrone/tooltips.scss
+++ b/src/scss/quadrone/tooltips.scss
@@ -2,30 +2,59 @@
   min-height: unset;
   min-width: unset;
 
+  &:has(.document-list-summary-tooltip) {
+    padding: var(--t5e-size-1x) var(--t5e-size-3x) var(--t5e-size-3x);
+  }
+
   .document-list-summary-tooltip {
-    padding-bottom: var(--t5e-size-1x);
 
     h3 {
+      color: var(--t5e-color-text-default);
+      font: var(--t5e-font-title-small);
       font-size: var(--font-size-24);
       text-align: center;
       margin-bottom: 0;
     }
 
+    hr {
+      background-image: linear-gradient(to right, transparent, var(--t5e-color-gold) 40%, var(--t5e-color-gold) 60%, transparent);
+      height: 0.0625rem;
+      margin: 0.375rem 0 0.625rem;
+    }
+
     ul {
-      margin: 0;
+      margin: 0 0.5rem 0 0;
       padding: 0;
       text-align: left;
 
-      > li + li {
+      >li {
+        align-items: center;
+      }
+
+      >li+li {
         margin-top: 0.5rem;
+      }
+
+      .text-align-right {
+        text-align: right;
       }
     }
 
-    > .weight-distribution {
-      > li {
+    >.weight-distribution {
+      >li {
         display: flex;
         gap: 1rem;
       }
+    }
+
+    .highlighted {
+      color: var(--t5e-color-yellow);
+    }
+
+    i {
+      text-shadow: 0 0 0.25rem rgba(0, 0, 0, 0.24);
+      font-size: 0.75rem;
+      margin-right: 0.25rem;
     }
 
     .image-and-name {
@@ -44,38 +73,63 @@
       background-position: 50% 0;
       border-radius: 0.0625rem;
       border: 0.0625rem solid var(--t5e-color-gold);
+
+      &.round {
+        border-radius: 100%;
+      }
+
+      &.token {
+        border: none;
+      }
+
+      &.transparent {
+        border: none;
+        position: relative;
+
+        &::before {
+          content: '';
+          border-radius: 100%;
+          border: 0.0625rem solid var(--t5e-color-palette-gold-62);
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          z-index: -1;
+        }
+      }
+    }
+
+    .item-name {
+      margin-left: 0.375rem;
     }
   }
 
   .group-trait-grid {
-    // TODO hightouch halp
     display: grid;
     grid-template-columns: 1.5rem 10rem 2.25rem;
     gap: 0.25rem;
-
-    i {
-      font-size: 0.75rem;
-    }
   }
 
   .group-tool-grid {
-    // TODO hightouch halp
     display: grid;
     grid-template-columns: 1.5rem 10rem 2.25rem 2rem;
     gap: 0.25rem;
-
-    i {
-      font-size: 0.75rem;
-    }
   }
 
   .group-skill-grid {
     display: grid;
-    grid-template-columns: 1.5rem 10rem 2.25rem 2.25rem 2rem;
+    grid-template-columns: 1.5rem 9rem 2.25rem 2.25rem 2.5rem;
     gap: 0.25rem;
+  }
 
-    i {
-      font-size: 0.75rem;
+  .group-tooltip-header {
+    margin: -0.125rem 0 -0.375rem;
+
+    >* {
+      text-wrap: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 

--- a/src/sheets/quadrone/actor/group-parts/GroupMemberNameColumn.svelte
+++ b/src/sheets/quadrone/actor/group-parts/GroupMemberNameColumn.svelte
@@ -91,15 +91,23 @@
     </h4>
     {#if member.actor.type === CONSTANTS.SHEET_TYPE_CHARACTER}
       {@const classes = Object.values<Item5e>(member.actor.classes)}
-
-      {#each classes as thisClass}
-        <span class="font-label-medium color-text-gold-emphasis"
-          >{thisClass.name}</span
-        >
-        <span class="font-data-medium color-text-default"
-          >{thisClass.system.levels}</span
-        >
-      {/each}
+      {#if classes.length > 0}
+        <div class="separated-list">
+          {#each classes as thisClass, index}
+            <div class="class-names">
+              <span class="font-label-medium color-text-gold-emphasis"
+                >{thisClass.name}</span
+              >
+              <span class="font-data-medium color-text-default"
+                >{thisClass.system.levels}</span
+              >
+            </div>
+            {#if index < classes.length - 1}
+              <div class="divider-dot"></div>
+            {/if}
+          {/each}
+        </div>
+      {/if}
     {:else if member.actor.type === CONSTANTS.SHEET_TYPE_NPC}
       {@const formattedCr = dnd5e.utils.formatCR(
         member.actor.system.details.cr,
@@ -119,23 +127,31 @@
 
       {@const classes = Object.values<Item5e>(member.actor.classes)}
 
-      <span class="flexrow">
-        {#each classes as thisClass}
-          <span class="font-label-medium color-text-gold-emphasis"
-            >{thisClass.name}</span
-          >
-          <span class="font-data-medium color-text-default"
-            >{thisClass.system.levels}</span
-          >
-          <div class="divider-dot"></div>
+      {#if classes.length > 0}
+      <span class="separated-list">
+        {#each classes as thisClass, index}
+          <div class="class-names">
+            <span class="font-label-medium color-text-gold-emphasis"
+              >{thisClass.name}</span
+            >
+            <span class="font-data-medium color-text-default"
+              >{thisClass.system.levels}</span
+            >
+            {#if index < classes.length - 1}
+              <div class="divider-dot"></div>
+            {/if}
+          </div>
         {/each}
 
-        <span class="cr">
-          <span class="font-label-medium color-text-gold-emphasis"
-            >{localize('DND5E.AbbreviationCR')}</span
-          >
-          <span class="font-data-medium color-text-default">{formattedCr}</span>
-        </span>
+        <div class="divider-dot"></div>
+        <div>
+          <span class="cr">
+            <span class="font-label-medium color-text-gold-emphasis"
+              >{localize('DND5E.AbbreviationCR')}</span
+            >
+            <span class="font-data-medium color-text-default">{formattedCr}</span>
+          </span>
+        </div>
         <div class="divider-dot"></div>
         <span class="size">
           <span class="font-label-medium color-text-gold-emphasis">{size}</span>
@@ -153,6 +169,7 @@
           </span>
         {/if}
       </span>
+      {/if}
     {:else if member.actor.type === CONSTANTS.SHEET_TYPE_VEHICLE}
       {@const vehicleType =
         CONFIG.DND5E.vehicleTypes[member.actor.system.vehicleType] ??

--- a/src/sheets/quadrone/actor/group-parts/GroupSubtitle.svelte
+++ b/src/sheets/quadrone/actor/group-parts/GroupSubtitle.svelte
@@ -47,7 +47,7 @@
 {/snippet}
 
 <!-- Group subtitle, member info -->
-<div class="actor-subtitle flexrow" data-tidy-sheet-part="subtitle-row">
+<div class="actor-subtitle separated-list" data-tidy-sheet-part="subtitle-row">
   {#if !charactersOnly && context.members.character.members.length > 0}
     <span class="members">
       <span class="color-text-gold font-label-medium"
@@ -110,11 +110,11 @@
 </div>
 
 <div
-  class="actor-subtitle flexrow group-speeds"
+  class="actor-subtitle separated-list group-speeds"
   data-tidy-sheet-part="subtitle-row"
 >
   {#if !!context.travel.currentPace}
-    <div class="span flexrow travel-pace">
+    <div class="span separated-list travel-pace">
       <button
         class="button button-borderless button-icon-only"
         onclick={() => context.sheet.changePace(-1)}
@@ -144,22 +144,17 @@
             : 'fa-solid'} fa-forward"
         ></i>
       </button>
-    </div>
-    <span class="travel-pace">
-      <span class="font-label-medium color-text-gold">
-        {localize('DND5E.Travel.Label')}
-      </span>
-      <span class="label font-label-medium color-text-default flexshrink">
-        {context.travel.currentPace.config.label}
-      </span>
-    </span>
+      <div>
+        <span class="font-label-medium color-text-gold">
+          {localize('DND5E.Travel.Label')}
+        </span>
+        <span class="label font-label-medium color-text-default flexshrink">
+          {context.travel.currentPace.config.label}
+        </span>
+      </div>
+  </div>
   {/if}
-  <!-- {#each speeds as speed, i}
-  {#if i > 0}
-    <div class="divider-dot"></div>
-  {/if}
-  {@render speedSenseSummary(speed, ['speed', 'main-speed'])}
-{/each} -->
+  {#if context.actor.system.attributes.movement.paces.land > 0}
   <div class="divider-dot"></div>
   <span class="speed">
     <span class="color-text-gold font-label-medium"
@@ -172,6 +167,8 @@
       >{context.travel.units.label}</span
     >
   </span>
+  {/if}
+  {#if context.actor.system.attributes.movement.paces.air > 0}
   <div class="divider-dot"></div>
   <span class="speed">
     <span class="color-text-gold font-label-medium"
@@ -184,6 +181,8 @@
       >{context.travel.units.label}</span
     >
   </span>
+  {/if}
+  {#if context.actor.system.attributes.movement.paces.water > 0}
   <div class="divider-dot"></div>
   <span class="speed">
     <span class="color-text-gold font-label-medium"
@@ -196,6 +195,7 @@
       >{context.travel.units.label}</span
     >
   </span>
+  {/if}
   {#if context.unlocked}
     <button
       aria-label={localize('DND5E.MovementConfig')}

--- a/src/sheets/quadrone/actor/tabs/GroupInventoryTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/GroupInventoryTab.svelte
@@ -119,17 +119,20 @@
         </h4>
         {#if member.actor.type === CONSTANTS.SHEET_TYPE_CHARACTER || member.actor.type === CONSTANTS.SHEET_TYPE_NPC}
           <!-- TODO: Add currency -->
-          <span class="actor-currency flexrow">
-            <span class="font-label-medium color-text-default flexshrink"
-              >{member.gold}</span
-            >
-            <span class="font-body-medium color-text-lighter flexshrink"
-              >{member.goldAbbreviation}</span
-            >
-          </span>
+          <div class="separated-list">
+            <span class="actor-currency">
+              <span class="font-label-medium color-text-default flexshrink"
+                >{member.gold}</span
+              >
+              <span class="font-body-medium color-text-lighter flexshrink"
+                >{member.goldAbbreviation}</span
+              >
+            </span>
+          </div>
           <ActorEncumbranceBar actor={member.actor} />
         {:else if member.actor.type === CONSTANTS.SHEET_TYPE_VEHICLE}
-          <span class="actor-cargo flexrow">
+        <div class="separated-list">
+          <span class="actor-cargo separated-list">
             <span class="font-body-medium color-text-lighter"
               >{localize('DND5E.VehicleCargo')}</span
             >
@@ -141,30 +144,33 @@
               >{member.encumbrance.max}</span
             >
           </span>
+        </div>
         {/if}
       </div>
     </div>
   {/each}
 </aside>
-<div class="groups-tab-content inventory-content">
-  <InventoryActionBar bind:searchCriteria sections={inventory} {tabId} />
+<div class="groups-tab-content flexcol">
+  <div class="inventory-content">
+    <InventoryActionBar bind:searchCriteria sections={inventory} {tabId} />
 
-  {#if context.showContainerPanel && !!context.containerPanelItems.length}
-    <ContainerPanel
+    {#if context.showContainerPanel && !!context.containerPanelItems.length}
+      <ContainerPanel
+        {searchCriteria}
+        containerPanelItems={context.containerPanelItems}
+      />
+    {/if}
+
+    <InventoryTables
+      sections={inventory}
+      editable={context.editable}
+      itemContext={context.itemContext}
+      {inlineToggleService}
       {searchCriteria}
-      containerPanelItems={context.containerPanelItems}
+      sheetDocument={context.actor}
+      root={true}
     />
-  {/if}
-
-  <InventoryTables
-    sections={inventory}
-    editable={context.editable}
-    itemContext={context.itemContext}
-    {inlineToggleService}
-    {searchCriteria}
-    sheetDocument={context.actor}
-    root={true}
-  />
+  </div>
 
   <ActorInventoryFooter useAttunement={false} />
 </div>

--- a/src/tooltips/GroupLanguageTooltip.svelte
+++ b/src/tooltips/GroupLanguageTooltip.svelte
@@ -37,7 +37,7 @@
 
 <div class="hidden">
   <div bind:this={tooltip} class="document-list-summary-tooltip">
-    <h3>{language}</h3>
+    <h3 class="font-title-medium color-text-default">{language}</h3>
     <hr />
     <ul>
       {#each members as member}

--- a/src/tooltips/GroupSkillTooltip.svelte
+++ b/src/tooltips/GroupSkillTooltip.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
   import type { GroupSkill } from 'src/types/group.types';
-  import { formatAsModifier } from 'src/utils/formatting';
+  import { formatAsModifier, getModifierData } from 'src/utils/formatting';
   import { tick } from 'svelte';
   import { Tooltip } from './Tooltip';
   import { getThemeV2 } from 'src/theme/theme';
+
+  const localize = FoundryAdapter.localize;
 
   interface Props {
     sheetDocument: any;
@@ -47,27 +49,37 @@
 
 <div class="hidden">
   <div bind:this={tooltip} class="document-list-summary-tooltip">
-    <h3>{skill.label}</h3>
+    <h3 class="font-title-medium color-text-default">{skill.label}</h3>
     <hr />
     <ul>
+      <li class="group-skill-grid group-tooltip-header">
+        <div class=""></div>
+        <div class=""></div>
+        <div class="text-align-right font-label-small color-text-lightest">{localize('DND5E.AbilityModifierShort')}</div>
+        <div class="text-align-right font-label-small color-text-lightest">{localize('DND5E.Passive')}</div> 
+        <div class="text-align-right font-label-small color-text-lightest">{localize('DND5E.Proficiency')}</div>
+      </li>
       {#each skill.members as member}
         {@const score = member.system.skills[skill.key]?.total}
+        {@const modifier = getModifierData(score)}
         <li class="group-skill-grid">
+          <!-- TODO add token shape to class list  -->
           <div
-            class="item-image"
+            class="item-image TOKEN-SHAPE"
             style="background-image: url('{member.img}')"
           ></div>
           <div class="item-name truncate">{member.name}</div>
-          <div class="text-align-center">
-            {formatAsModifier(score)}
-          </div>
-          <div class="text-align-center">
-            ({member.system.skills[skill.key]?.passive})
-          </div>
-          <div class="text-align-center">
+          <div class="text-align-right">
             {#if score === highestScore}
-              <i class="fa-solid fa-trophy"></i>
+              <i class="fa-solid fa-award color-text-gold-emphasis highlighted" style="color: {member.highlightColor}"></i>
             {/if}
+            <span class="font-body-medium color-text-lighter">{modifier.sign}</span>
+            <span class="font-label-medium color-text-default">{modifier.value}</span>
+          </div>
+          <div class="text-align-right">
+            <span class="font-label-medium color-text-lighter">{member.system.skills[skill.key]?.passive}</span>
+          </div>
+          <div class="text-align-right">
             <i
               class="{FoundryAdapter.getProficiencyIconClass(
                 member.system.skills[skill.key]?.proficient,

--- a/src/tooltips/GroupToolTooltip.svelte
+++ b/src/tooltips/GroupToolTooltip.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
-  import { formatAsModifier } from 'src/utils/formatting';
+  import { getModifierData } from 'src/utils/formatting';
   import { tick } from 'svelte';
   import { Tooltip } from './Tooltip';
   import { getThemeV2 } from 'src/theme/theme';
   import type { Actor5e } from 'src/types/types';
+
+  const localize = FoundryAdapter.localize;
 
   type GroupTool = {
     key: string;
@@ -53,25 +55,34 @@
 
 <div class="hidden">
   <div bind:this={tooltip} class="document-list-summary-tooltip">
-    <h3>{tool.label}</h3>
+    <h3 class="font-title-medium color-text-default">{tool.label}</h3>
     <hr />
     <ul>
+      <li class="group-tool-grid group-tooltip-header">
+        <div class=""></div>
+        <div class=""></div>
+        <div class="text-align-right font-label-small color-text-lightest">{localize('DND5E.Passive')}</div> 
+        <div class="text-align-right font-label-small color-text-lightest">{localize('DND5E.Proficiency')}</div>
+      </li>
       {#each tool.members as member}
         {@const score = member.system.tools[tool.key]?.total}
+        {@const modifier = getModifierData(score)}
         <li class="group-tool-grid">
+          <!-- TODO add token shape to class list  -->
           <div
-            class="item-image"
+            class="item-image TOKEN-SHAPE"
             style="background-image: url('{member.img}')"
           ></div>
           <div class="item-name truncate">{member.name}</div>
-          <div class="text-align-center">
-            {formatAsModifier(score)}
-          </div>
-          <div class="text-align-center">
+          <div class="text-align-right">
             {#if score === highestScore}
-              <i class="fa-solid fa-trophy"></i>
+              <i class="fa-solid fa-award highlighted"></i>
               <!-- TODO: Temp placeholder to demonstrate the highest score holder -->
             {/if}
+            <span class="font-body-medium color-text-lighter">{modifier.sign}</span>
+            <span class="font-label-medium color-text-default">{modifier.value}</span>
+          </div>
+          <div class="text-align-right">
             <i
               class="{FoundryAdapter.getProficiencyIconClass(
                 member.system.tools[tool.key]?.value,

--- a/src/tooltips/GroupTraitTooltip.svelte
+++ b/src/tooltips/GroupTraitTooltip.svelte
@@ -46,21 +46,22 @@
 
 <div class="hidden">
   <div bind:this={tooltip} class="document-list-summary-tooltip">
-    <h3>{trait.label}</h3>
+    <h3 class="font-title-medium color-text-default">{trait.label}</h3>
     <hr />
     <ul>
       {#each trait.members as member}
         <li class="group-trait-grid">
+          <!-- TODO add token shape to class list  -->
           <div
-            class="item-image"
+            class="item-image TOKEN-SHAPE"
             style="background-image: url('{member.actor.img}')"
           ></div>
           <div class="item-name truncate">{member.actor.name}</div>
           {#if member.value}
-            <div class="text-align-center">
-              <span>{member.value}</span>
+            <div class="text-align-right">
+              <span class="font-label-medium color-text-default">{member.value}</span>
               {#if member.units}
-                <span>{member.units}</span>
+                <span class="font-body-medium color-text-lighter">{member.units}</span>
               {/if}
             </div>
           {/if}


### PR DESCRIPTION
- Styled group sidebar tooltips with updated headers, labels, proficiency, and top trait styles
- Updated group Skill proficiency icons to match Quadrone styles
- Fixed inventory tab scrolling behavior to properly sit flush with the sheet
- Fixed some actor subtitle styling in Group sheets
- Fixed Group sheet inventory footer layout
- Updated Group sheet header to hide speeds = 0