### PR TITLE
MCDM Class Bundle first pass

### DIFF
--- a/src/api/Tidy5eSheetsApi.ts
+++ b/src/api/Tidy5eSheetsApi.ts
@@ -14,6 +14,8 @@ import type {
   SupportedContent,
   ItemTabRegistrationOptions,
   HeaderControlRegistrationParams,
+  TabIdDocumentItemTypesParams,
+  TabIdDocumentItemTypesOptions,
 } from './api.types';
 import ApiConstants from './ApiConstants';
 import { HtmlContent } from './content/HtmlContent';
@@ -31,6 +33,7 @@ import { NpcSheetQuadroneRuntime } from 'src/runtime/actor/NpcSheetQuadroneRunti
 import { VehicleSheetQuadroneRuntime } from 'src/runtime/actor/VehicleSheetQuadroneRuntime.svelte';
 import VehicleSheetClassicRuntime from 'src/runtime/actor/VehicleSheetClassicRuntime.svelte';
 import { TidySvelteApi } from './svelte/TidySvelteApi';
+import { TabDocumentItemTypesRuntime } from 'src/runtime/item/TabDocumentItemTypesRuntime';
 
 /**
  * The Tidy 5e Sheets API. The API becomes available after the hook `tidy5e-sheet.ready` is called.
@@ -1333,5 +1336,26 @@ export class Tidy5eSheetsApi {
    */
   useHandlebarsRendering(html: string): string {
     return `<div style="display: contents;" ${CONSTANTS.HTML_DYNAMIC_RENDERING_ATTRIBUTE}>${html}</div>`;
+  }
+
+  /**
+   * Registers additional mappings of tab ID to item types, controlling available options when clicking a "create"
+   * button for a given tab.
+   * 
+   * @param params  params for registration (`tabId` and an array of `documentItemTypes`)
+   * @param options options for registration (currently `mode`: 'merge' or 'override')
+   * 
+   * @example Allowing creation of Spells on some newly-registered tab with ID `'my-new-tab'`
+   * ```js
+   * Hooks.on('tidy5e-sheet.ready', (api) => {
+   *   api.registerTabIdDocumentItemTypes({ tabId: 'my-new-tab', documentItemTypes: ['spell'] });
+   * });
+   * ```
+   */
+  registerTabIdDocumentItemTypes(
+    params: TabIdDocumentItemTypesParams,
+    options?: TabIdDocumentItemTypesOptions
+  ) {
+    TabDocumentItemTypesRuntime.registerTypes(params, options);
   }
 }

--- a/src/api/api.types.ts
+++ b/src/api/api.types.ts
@@ -466,3 +466,13 @@ export type HeaderControlRegistrationParams = {
    */
   controls: CustomHeaderControlsEntry[];
 };
+
+export type TabIdDocumentItemTypesParams = {
+  tabId: string;
+  documentItemTypes: string[];
+};
+
+export type TabIdDocumentItemTypesOptions = {
+  mode: 'merge' | 'override';
+};
+

--- a/src/integration/integration.ts
+++ b/src/integration/integration.ts
@@ -8,6 +8,7 @@ import { error } from 'src/utils/logging';
 import { CustomCharacterSheetsModuleIntegration } from './modules/CustomCharacterSheetsModuleIntegration';
 import type { Tidy5eSheetsApi } from 'src/api/Tidy5eSheetsApi';
 import { DrakkenheimCoreModuleIntegration } from './modules/Drakkenheim/DrakkenheimCore';
+import { McdmClassBundleModuleIntegration } from './modules/McdmClassBundle/McdmClassBundle';
 import { TidyCustomSectionsInDefaultItemSheetIntegration } from './system/TidyCustomSectionsInDefaultItemSheetIntegration';
 import { ColorisThirdPartyIntegration } from './third-party/Coloris.svelte';
 import { DndTashasCauldronModuleIntegration } from './modules/DndTashasCauldron/DndTashasCauldron';
@@ -43,6 +44,7 @@ const moduleIntegrations: ModuleIntegrationBase[] = [
   new PopoutModuleIntegration(),
   new CustomCharacterSheetsModuleIntegration(),
   new DrakkenheimCoreModuleIntegration(),
+  new McdmClassBundleModuleIntegration(),
   new SebastianCrowesGuideToDrakkenheimModuleIntegration(),
   new MonstersOfDrakkenheimModuleIntegration(),
   new DndTashasCauldronModuleIntegration(),

--- a/src/integration/modules/McdmClassBundle/McdmClassBundle.ts
+++ b/src/integration/modules/McdmClassBundle/McdmClassBundle.ts
@@ -1,0 +1,152 @@
+import type { Tidy5eSheetsApi } from 'src/api';
+import type { ModuleIntegrationBase } from 'src/integration/integration-classes';
+import McdmPowersTab from './McdmPowersTab.svelte';
+import { FoundryAdapter } from 'src/foundry/foundry-adapter';
+import { MCDM_CLASS_BUNDLE_CONSTANTS } from './McdmClassBundleConstants';
+import type { CONFIG as OriginalConfig } from 'src/foundry/config.types';
+import { CONSTANTS } from 'src/constants';
+import { Tidy5eItemSheetQuadrone } from 'src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte';
+import { ItemSheetQuadroneRuntime } from 'src/runtime/item/ItemSheetQuadroneRuntime.svelte';
+import McdmPowerSheet from './McdmPowerSheet.svelte';
+import McdmPowerDetailsTab from './McdmPowerDetailsTab.svelte';
+import { TabDocumentItemTypesRuntime } from 'src/runtime/item/TabDocumentItemTypesRuntime';
+import { ItemFilterRuntime } from 'src/runtime/item/ItemFilterRuntime.svelte';
+import { defaultItemFilters } from 'src/runtime/item/default-item-filters';
+import type { ItemFilter } from 'src/runtime/item/item.types';
+import type { Item5e } from 'src/types/item.types';
+import type { TidySectionBase } from 'src/types/types';
+
+declare global {
+  interface CONFIG extends OriginalConfig {
+    MCDM: {
+      powerOrders: Record<number, string>;
+      specialties: Record<string, {
+        label: string;
+        icon: string;
+        fullKey: string;
+      }>;
+      strainTypes: Record<string, {
+        effects: {
+          label: string;
+          tooltip: string;
+        }[];
+        header: string;
+        label: string;
+      }>;
+    }
+  }
+}
+
+export type PowersSection = {
+  type: 'powers',
+  order?: number | string;
+  items: Item5e[];
+  uses?: number;
+  canCreate: boolean;
+} & TidySectionBase;
+
+export class McdmClassBundleModuleIntegration implements ModuleIntegrationBase {
+  get moduleId(): string {
+    return MCDM_CLASS_BUNDLE_CONSTANTS.MODULE_ID;
+  }
+
+  get powersTabId(): string {
+    return 'mcdm-powers-tab';
+  }
+
+  init(api: Tidy5eSheetsApi): void {
+    // Powers tab
+    import('./McdmPowersTab.scss');
+    const powersTab = new api.models.SvelteTab({
+      title: () => FoundryAdapter.localize('TYPES.Item.mcdm-class-bundle.powerPl'),
+      tabId: this.powersTabId,
+      component: McdmPowersTab,
+      iconClass: 'fa-solid fa-brain'
+    });
+    
+    api.registerCharacterTab(powersTab, {
+      layout: ['quadrone'],
+    });
+    api.registerNpcTab(powersTab, {
+      layout: ['quadrone']
+    });
+
+    // Power item sheet
+    const documentSheetConfig = foundry.applications.apps.DocumentSheetConfig;
+    documentSheetConfig.registerSheet(
+      Item,
+      CONSTANTS.DND5E_SYSTEM_ID,
+      Tidy5eItemSheetQuadrone,
+      {
+        types: [MCDM_CLASS_BUNDLE_CONSTANTS.POWER_ITEM_TYPE],
+        label: 'TIDY5E.Tidy5eItemSheetQuadrone',
+      }
+    )
+    ItemSheetQuadroneRuntime.registerItemSheet(
+      MCDM_CLASS_BUNDLE_CONSTANTS.POWER_ITEM_TYPE,
+      {
+        component: McdmPowerSheet,
+        defaultTabs: [
+          CONSTANTS.TAB_DESCRIPTION,
+          CONSTANTS.TAB_ITEM_DETAILS,
+          CONSTANTS.TAB_ITEM_ACTIVITIES,
+          CONSTANTS.TAB_EFFECTS,
+        ],
+      },
+      [
+        CONSTANTS.TAB_DESCRIPTION,
+        CONSTANTS.TAB_ITEM_ACTIVITIES,
+        CONSTANTS.TAB_EFFECTS,
+      ]
+    );
+    ItemSheetQuadroneRuntime.registerTab({
+      id: CONSTANTS.TAB_ITEM_DETAILS,
+      title: 'DND5E.Details',
+      content: {
+        component: McdmPowerDetailsTab,
+        type: 'svelte',
+      },
+      layout: 'quadrone',
+      types: new Set([MCDM_CLASS_BUNDLE_CONSTANTS.POWER_ITEM_TYPE]),
+    });
+    TabDocumentItemTypesRuntime.registerTypes({
+      tabId: this.powersTabId,
+      documentItemTypes: [MCDM_CLASS_BUNDLE_CONSTANTS.POWER_ITEM_TYPE]
+    });
+
+    const powerSpecialtyFilters = Object.entries(CONFIG.MCDM.specialties).map<ItemFilter>(
+      ([key, specialtyData]) =>
+        ({
+          name: key,
+          predicate: (item) => item.system.specialty === key,
+          text: specialtyData.label
+        })
+    );
+    const filterTabs = {
+      'DND5E.ItemActivationCost': [
+        {
+          ...defaultItemFilters.activationCostAction,
+          pinnedFilterClass: 'hide-under-400'
+        },
+        {
+          ...defaultItemFilters.activationCostBonus,
+          pinnedFilterClass: 'hide-under-400'
+        },
+        {
+          ...defaultItemFilters.activationCostReaction,
+          pinnedFilterClass: 'hide-under-400'
+        },
+        {
+          ...defaultItemFilters.concentration
+        }
+      ],
+      'MCDMCB.TALENT.POWERS.SPECIALTIES.Header': powerSpecialtyFilters
+    };
+    ItemFilterRuntime._documentTabFiltersQuadrone[CONSTANTS.SHEET_TYPE_CHARACTER][this.powersTabId] = filterTabs;
+    ItemFilterRuntime._documentTabFiltersQuadrone[CONSTANTS.SHEET_TYPE_NPC][this.powersTabId] = filterTabs;
+
+    const filterPins = new Set(filterTabs['DND5E.ItemActivationCost'].map(i => i.name));
+    ItemFilterRuntime.defaultFilterPinsQuadrone[CONSTANTS.SHEET_TYPE_CHARACTER][this.powersTabId] = filterPins;
+    ItemFilterRuntime.defaultFilterPinsQuadrone[CONSTANTS.SHEET_TYPE_NPC][this.powersTabId] = filterPins;
+  }
+}

--- a/src/integration/modules/McdmClassBundle/McdmClassBundle.ts
+++ b/src/integration/modules/McdmClassBundle/McdmClassBundle.ts
@@ -142,10 +142,13 @@ export class McdmClassBundleModuleIntegration implements ModuleIntegrationBase {
       ],
       'MCDMCB.TALENT.POWERS.SPECIALTIES.Header': powerSpecialtyFilters
     };
+
+    // TODO: expose this via API
     ItemFilterRuntime._documentTabFiltersQuadrone[CONSTANTS.SHEET_TYPE_CHARACTER][this.powersTabId] = filterTabs;
     ItemFilterRuntime._documentTabFiltersQuadrone[CONSTANTS.SHEET_TYPE_NPC][this.powersTabId] = filterTabs;
 
     const filterPins = new Set(filterTabs['DND5E.ItemActivationCost'].map(i => i.name));
+    // TODO: expose this via API
     ItemFilterRuntime.defaultFilterPinsQuadrone[CONSTANTS.SHEET_TYPE_CHARACTER][this.powersTabId] = filterPins;
     ItemFilterRuntime.defaultFilterPinsQuadrone[CONSTANTS.SHEET_TYPE_NPC][this.powersTabId] = filterPins;
   }

--- a/src/integration/modules/McdmClassBundle/McdmClassBundleConstants.ts
+++ b/src/integration/modules/McdmClassBundle/McdmClassBundleConstants.ts
@@ -1,0 +1,7 @@
+export const MCDM_CLASS_BUNDLE_CONSTANTS = {
+  MODULE_ID: 'mcdm-class-bundle',
+  MAX_STRAIN_FLAG_PROP: 'flags.dnd5e.strainMax',
+  CURR_STRAIN_FLAG_PROP: 'flags.mcdm-class-bundle.strain',
+  MAX_STRAIN_DEFAULT_FORMULA: '@classes.talent.levels + 4',
+  POWER_ITEM_TYPE: 'mcdm-class-bundle.power'
+}

--- a/src/integration/modules/McdmClassBundle/McdmPowerDetailsTab.svelte
+++ b/src/integration/modules/McdmClassBundle/McdmPowerDetailsTab.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+  import SelectOptions from 'src/components/inputs/SelectOptions.svelte';
+  import SelectQuadrone from 'src/components/inputs/SelectQuadrone.svelte';
+  import { FoundryAdapter } from 'src/foundry/foundry-adapter';
+  import FieldActivation from 'src/sheets/quadrone/item/parts/FieldActivation.svelte';
+  import FieldDuration from 'src/sheets/quadrone/item/parts/FieldDuration.svelte';
+  import FieldRange from 'src/sheets/quadrone/item/parts/FieldRange.svelte';
+  import FieldTargets from 'src/sheets/quadrone/item/parts/FieldTargets.svelte';
+  import FieldUses from 'src/sheets/quadrone/item/parts/FieldUses.svelte';
+  import ItemProperties from 'src/sheets/quadrone/item/parts/ItemProperties.svelte';
+  import { getItemSheetContextQuadrone } from 'src/sheets/sheet-context.svelte';
+
+  let context = $derived(getItemSheetContextQuadrone());
+
+  let appId = $derived(context.document.id);
+
+  let localize = FoundryAdapter.localize;
+
+</script>
+
+<fieldset>
+  <legend>
+    {localize('MCDMCB.TALENT.POWERS.SHEET.Details')}
+    <tidy-gold-header-underline></tidy-gold-header-underline>
+  </legend>
+
+  <!-- Power Order -->
+  <div class="form-group">
+    <label for="{appId}-order">{localize('MCDMCB.TALENT.POWERS.ORDERS.Label')}</label>
+    <div class="form-fields">
+      <SelectQuadrone
+        id="{appId}-order"
+        document={context.item}
+        field="system.order"
+        value={context.source.order}
+        disabled={!context.unlocked}
+      >
+        <SelectOptions data={CONFIG.MCDM.powerOrders}/>
+      </SelectQuadrone>
+    </div>
+  </div>
+
+  <!-- Power Specialty -->
+  <div class="form-group">
+    <label for="{appId}-specialty">{localize('MCDMCB.TALENT.POWERS.SPECIALTIES.Label')}</label>
+    <div class="form-fields">
+      <SelectQuadrone
+        id="{appId}-specialty"
+        document={context.item}
+        field="system.specialty"
+        value={context.source.specialty}
+        disabled={!context.unlocked}
+        blankValue=""
+      >
+        <SelectOptions data={CONFIG.MCDM.specialties} blank=""/>
+      </SelectQuadrone>
+    </div>
+  </div>
+
+  <!-- Power Properties -->
+  <div class="form-group spell-components stacked checkbox-grid">
+    <label for="">
+      {localize('DND5E.Properties')}
+    </label>
+    <div class="form-fields">
+      <ItemProperties />
+    </div>
+  </div>
+
+  <!-- Ability -->
+  {#if context.isEmbedded}
+    <div class="form-group">
+      <label for="{appId}-ability">{localize('MCDMCB.TALENT.POWERS.ManifestAbility')}</label>
+      <div class="form-fields">
+        <SelectQuadrone
+          id="{appId}-ability"
+          document={context.item}
+          field="system.ability"
+          value={context.source.ability}
+          disabled={!context.unlocked}
+          blankValue=""
+        >
+          <SelectOptions data={context.config.abilities} labelProp="label" blank={context.defaultAbility} />
+        </SelectQuadrone>
+      </div>
+    </div>
+  {/if}
+</fieldset>
+
+<fieldset>
+  <legend>
+    {localize('MCDMCB.TALENT.POWERS.SHEET.ManifestingHeader')}
+    <tidy-gold-header-underline></tidy-gold-header-underline>
+  </legend>
+
+  <FieldActivation />
+  <FieldRange />
+  <FieldDuration />
+</fieldset>
+
+<FieldTargets />
+
+<FieldUses />

--- a/src/integration/modules/McdmClassBundle/McdmPowerSheet.svelte
+++ b/src/integration/modules/McdmClassBundle/McdmPowerSheet.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+  import ItemNameHeaderOrchestrator from 'src/sheets/quadrone/item/parts/ItemNameHeaderOrchestrator.svelte';
+  import Sidebar from 'src/sheets/quadrone/item/parts/Sidebar.svelte';
+  import { FoundryAdapter } from 'src/foundry/foundry-adapter';
+  import { getItemSheetContextQuadrone } from 'src/sheets/sheet-context.svelte';
+  import Tabs from 'src/components/tabs/Tabs.svelte';
+  import TabContents from 'src/components/tabs/TabContents.svelte';
+  import { isNil } from 'src/utils/data';
+  import Dnd5eIcon from 'src/components/icon/Dnd5eIcon.svelte';
+  import ItemChargesSummary from 'src/sheets/quadrone/item/parts/header/ItemChargesSummary.svelte';
+  import ItemRechargeSummary from 'src/sheets/quadrone/item/parts/header/ItemRechargeSummary.svelte';
+  import ItemName from 'src/sheets/quadrone/item/parts/header/ItemName.svelte';
+
+  let context = $derived(getItemSheetContextQuadrone());
+
+  const localize = FoundryAdapter.localize;
+
+  let selectedTabId: string = $derived(context.currentTabId);
+
+  let itemNameEl: HTMLElement | undefined = $state();
+  
+    let powerSpecialtiesConfig = $derived(
+      CONFIG.MCDM.specialties[context.system.specialty],
+    );
+
+  let subtitle = $derived(
+    [context.labels.level, context.labels.school]
+      .filter((x) => !isNil(x))
+      .join(', '),
+  );
+
+  let itemHeaderSummaries = $derived.by(() => {
+    let result = [];
+    if (context.item.hasLimitedUses) {
+      result.push(chargesSummaryItem);
+    }
+
+    if (context.item.hasRecharge) {
+      result.push(rechargeSummaryItem);
+    }
+
+    return result;
+  });
+</script>
+
+<ItemNameHeaderOrchestrator {itemNameEl} />
+
+<Sidebar includeSidebarProperties={false}>
+  {#snippet belowStateSwitches()}
+    <div>
+      <h4>
+        {localize('TYPES.Item.mcdm-class-bundle.power')}
+      </h4>
+    </div>
+  {/snippet}
+</Sidebar>
+
+<main class="item-content">
+  <div class="sheet-header">
+    <div class="identity-info">
+      <div
+        bind:this={itemNameEl}
+        class="item-name-wrapper flex-row extra-small-gap align-items-center"
+      >
+        <ItemName />
+      </div>
+      <div class="subtitle">{subtitle}</div>
+    </div>
+    {#if !context.unlocked}
+      <div class="common-fields">
+        {#if powerSpecialtiesConfig}
+          <div
+            class="school"
+            aria-label={powerSpecialtiesConfig.label}
+            data-tooltip={powerSpecialtiesConfig.label}
+          >
+            <Dnd5eIcon src={powerSpecialtiesConfig.icon} />
+          </div>
+        {/if}
+      </div>
+    {/if}
+
+    {#if itemHeaderSummaries.length}
+      <div class="item-header-summary">
+        {#each itemHeaderSummaries as summaryItem}
+          {@render summaryItem()}
+        {/each}
+      </div>
+    {/if}
+  </div>
+
+  <!-- Tab Strip -->
+  <Tabs
+    bind:selectedTabId
+    tabs={context.tabs}
+    cssClass="item-tabs"
+    sheet={context.sheet}
+    tabContext={{ context, item: context.item }}
+  />
+
+  <hr class="golden-fade" />
+
+  <!-- Tab Contents -->
+  <TabContents tabs={context.tabs} {selectedTabId} />
+</main>
+
+{#snippet chargesSummaryItem()}
+  <ItemChargesSummary />
+{/snippet}
+{#snippet rechargeSummaryItem()}
+  <ItemRechargeSummary />
+{/snippet}

--- a/src/integration/modules/McdmClassBundle/McdmPowerSpecialtyColumn.svelte
+++ b/src/integration/modules/McdmClassBundle/McdmPowerSpecialtyColumn.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import type { ColumnCellProps } from 'src/runtime/types';
+  import Dnd5eIcon from 'src/components/icon/Dnd5eIcon.svelte';
+
+  let { rowDocument }: ColumnCellProps = $props();
+
+  let powerSpecialtiesConfig = $derived(
+    CONFIG.MCDM.specialties[rowDocument.system.specialty],
+  );
+</script>
+
+{#if powerSpecialtiesConfig?.icon}
+  <span class="power-specialty-icon" data-tooltip={powerSpecialtiesConfig.label}>
+    <Dnd5eIcon src={powerSpecialtiesConfig.icon} />
+  </span>
+{:else}
+  <span class="color-text-disabled">—</span>
+{/if}

--- a/src/integration/modules/McdmClassBundle/McdmPowersTab.scss
+++ b/src/integration/modules/McdmClassBundle/McdmPowersTab.scss
@@ -1,0 +1,60 @@
+.tidy5e-sheet:is(.quadrone) {
+  .tidy-table-row[data-tidy-item-type="mcdm-class-bundle.power"] {
+    .power-specialty-icon dnd5e-icon {
+      --icon-size: calc(1.375rem);
+      --icon-fill: var(--t5e-color-text-gold-emphasis);
+    }
+    .concentration-icon {
+      --icon-size: calc(1.375rem);
+      opacity: 0.75;
+      transform: translateY(0.175rem);
+    }
+  }
+  .tidy-mcdm-power-label {
+    align-items: center;
+  }
+  .tidy-table-cell.tidy-mcdm-strain-effects {
+    justify-content: start;
+    input[type=radio] {
+      margin-right: 0.5rem;
+      transform: none;
+      &:disabled + label {
+        color: var(--t5e-color-text-disabled);
+      }
+    }
+    label {
+      width: 100%;
+      text-align: start;
+      &.selected {
+        color: var(--t5e-color-text-gold);
+      }
+    }
+  }
+
+  .mcdm-powers-tab {
+    scrollbar-gutter: stable;
+    .strain-values {
+      .strain-value {
+        align-items: center;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        &::before {
+          background: transparent url("/systems/dnd5e/ui/lozenge.svg") no-repeat top / contain;
+          background-size: cover;
+          content: "";
+          height: 30px;
+          position: absolute;
+          width: 68px;
+          z-index: 0;
+        }
+        .value {
+          font-size: 1.5rem;
+          font-weight: bold;
+          line-height: 30px;
+          z-index: 1;
+        }
+      }
+    }
+  }
+}

--- a/src/integration/modules/McdmClassBundle/McdmPowersTab.svelte
+++ b/src/integration/modules/McdmClassBundle/McdmPowersTab.svelte
@@ -97,7 +97,7 @@
     const sheetPreferences = SheetPreferencesService.getByType(context.actor.type);
     const sortMode = sheetPreferences.tabs?.[tabId]?.sort ?? 'm';
     const sectionConfig = TidyFlags.sectionConfig.get(context.actor)?.[tabId];
-    const allSections: PowersSection[] = [...Object.entries(orderToPowersMap).map(([order, powers]) => ({
+    const allSections = Object.entries(orderToPowersMap).map<PowersSection>(([order, powers]) => ({
       key: `order${order}`,
       type: 'powers' as 'powers',
       order: sectionConfig?.[`order${order}`]?.order ?? order,
@@ -109,7 +109,7 @@
       canCreate: true,
       rowActions: TableRowActionsRuntime.getInventoryRowActions(context),
       show: sectionConfig?.[`order${order}`]?.show !== false
-    })), ...Object.entries(customSectionToPowersMap).map(([sectionKey, powers]) => ({
+    })).concat(Object.entries(customSectionToPowersMap).map(([sectionKey, powers]) => ({
       key: sectionKey,
       type: 'powers' as 'powers',
       order: sectionConfig?.[sectionKey]?.order ?? 1000,
@@ -121,7 +121,7 @@
       canCreate: true,
       rowActions: TableRowActionsRuntime.getInventoryRowActions(context),
       show: sectionConfig?.[sectionKey]?.show !== false
-    }))]
+    })))
     return SheetSections.sortKeyedSections(allSections, sectionConfig)
   });
 

--- a/src/integration/modules/McdmClassBundle/McdmPowersTab.svelte
+++ b/src/integration/modules/McdmClassBundle/McdmPowersTab.svelte
@@ -1,0 +1,223 @@
+<script lang="ts">
+  import { FoundryAdapter } from 'src/foundry/foundry-adapter';
+  import type {
+    ActorSheetQuadroneContext,
+  } from 'src/types/types';
+  import { MCDM_CLASS_BUNDLE_CONSTANTS } from './McdmClassBundleConstants';
+  import { getSheetContext } from 'src/sheets/sheet-context.svelte';
+  import { getContext } from 'svelte';
+  import { CONSTANTS } from 'src/constants';
+  import ActionBar from 'src/sheets/quadrone/shared/ActionBar.svelte';
+  import TableRowActionsRuntime from 'src/runtime/tables/TableRowActionsRuntime.svelte';
+  import McdmPowersTables from './McdmPowersTables.svelte';
+  import TidyTableHeaderRow from 'src/components/table-quadrone/TidyTableHeaderRow.svelte';
+  import TidyTableHeaderCell from 'src/components/table-quadrone/TidyTableHeaderCell.svelte';
+  import TidyTable from 'src/components/table-quadrone/TidyTable.svelte';
+  import TidyTableRow from 'src/components/table-quadrone/TidyTableRow.svelte';
+  import TidyTableCell from 'src/components/table-quadrone/TidyTableCell.svelte';
+  import { ItemUtils } from 'src/utils/ItemUtils';
+  import { SheetPreferencesService } from 'src/features/user-preferences/SheetPreferencesService';
+  import { TidyFlags } from 'src/api';
+  import { SheetSections } from 'src/features/sections/SheetSections';
+  import type { Item5e } from 'src/types/item.types';
+  import type { PowersSection } from './McdmClassBundle';
+
+  let context = 
+    $derived(
+      getSheetContext<ActorSheetQuadroneContext>(),
+    );
+
+  const localize = FoundryAdapter.localize;
+
+  let sectionsContainer: HTMLElement;
+  let dynamicColumnWidth: number = $state(0);
+
+  function onResize(entry: ResizeObserverEntry) {
+    const labelWidth = parseFloat(getComputedStyle(document.documentElement).fontSize) * 5;
+    dynamicColumnWidth = (entry.borderBoxSize[0].inlineSize - labelWidth) / (Object.keys(strainTypes).length ?? 3);
+  }
+
+  $effect(() => {
+    const observer = new ResizeObserver(([entry]) => onResize(entry));
+    observer.observe(sectionsContainer);
+
+    return () => {
+      observer.disconnect();
+    };
+  });
+
+  const strainTypes = CONFIG.MCDM.strainTypes;
+
+  let levels = Array.fromRange(9);
+
+  let tabId = getContext<string>(CONSTANTS.SVELTE_CONTEXT.TAB_ID);
+
+  let searchCriteria = $state('');
+
+  let maxStrainFormula = $derived(
+    FoundryAdapter.getProperty<string | undefined>(
+      context.actor,
+      MCDM_CLASS_BUNDLE_CONSTANTS.MAX_STRAIN_FLAG_PROP
+    ) || MCDM_CLASS_BUNDLE_CONSTANTS.MAX_STRAIN_DEFAULT_FORMULA
+  );
+
+  let maxStrain = $derived.by(() => {
+    try {
+      return Roll.create(maxStrainFormula, context.rollData).evaluateSync().total;
+    } catch {
+      ui.notifications.error('MCDMCB.TALENT.STRAIN.WARNING.NonDeterministicStrainFormula', {
+        format: {
+          name: context.actor.name
+        },
+        localize: true
+      });
+      return Roll.create(MCDM_CLASS_BUNDLE_CONSTANTS.MAX_STRAIN_DEFAULT_FORMULA, context.rollData).evaluateSync().total;
+    }
+  });
+
+  let currentStrain = $derived(
+    FoundryAdapter.getProperty<Record<string, number> | undefined>(
+      context.actor,
+      MCDM_CLASS_BUNDLE_CONSTANTS.CURR_STRAIN_FLAG_PROP
+    ) ?? { body: 0, mind: 0, soul: 0 }
+  );
+
+  let totalStrain = $derived(
+    Object.values(currentStrain).reduce((acc, i) => acc + i, 0)
+  );
+
+  let powerSections: PowersSection[] = $derived.by(() => {
+    const allPowers: Item5e[] = context.actor.itemTypes[MCDM_CLASS_BUNDLE_CONSTANTS.POWER_ITEM_TYPE];
+    const customSectionPowers = allPowers.filter((p) => TidyFlags.section.get(p));
+    const normalPowers = allPowers.filter((p) => !customSectionPowers.includes(p));
+    
+    const orderToPowersMap = Object.groupBy<any, any>(normalPowers, p => p.system.order);
+    const customSectionToPowersMap = Object.groupBy<any, any>(customSectionPowers, p => TidyFlags.section.get(p));
+    
+    const sheetPreferences = SheetPreferencesService.getByType(context.actor.type);
+    const sortMode = sheetPreferences.tabs?.[tabId]?.sort ?? 'm';
+    const sectionConfig = TidyFlags.sectionConfig.get(context.actor)?.[tabId];
+    const allSections: PowersSection[] = [...Object.entries(orderToPowersMap).map(([order, powers]) => ({
+      key: `order${order}`,
+      type: 'powers' as 'powers',
+      order: sectionConfig?.[`order${order}`]?.order ?? order,
+      dataset: {
+        ['system.order']: order
+      },
+      items: ItemUtils.getSortedItems(powers ?? [], sortMode),
+      label: `MCDMCB.TALENT.POWERS.ORDERS.${order}`,
+      canCreate: true,
+      rowActions: TableRowActionsRuntime.getInventoryRowActions(context),
+      show: sectionConfig?.[`order${order}`]?.show !== false
+    })), ...Object.entries(customSectionToPowersMap).map(([sectionKey, powers]) => ({
+      key: sectionKey,
+      type: 'powers' as 'powers',
+      order: sectionConfig?.[sectionKey]?.order ?? 1000,
+      dataset: {
+        [TidyFlags.section.prop]: sectionKey
+      },
+      items: ItemUtils.getSortedItems(powers ?? [], sortMode),
+      label: sectionKey,
+      canCreate: true,
+      rowActions: TableRowActionsRuntime.getInventoryRowActions(context),
+      show: sectionConfig?.[sectionKey]?.show !== false
+    }))]
+    return SheetSections.sortKeyedSections(allSections, sectionConfig)
+  });
+
+  function onChangeStrain(strainType: string, strainLevel: number) {
+    context.actor.update({
+      [`${MCDM_CLASS_BUNDLE_CONSTANTS.CURR_STRAIN_FLAG_PROP}.${strainType}`]: strainLevel
+    });
+  }
+
+  function onAddClicked() {
+    context.actor.sheet._addDocument({
+      tabId
+    });
+  }
+</script>
+
+<div class="strain-values flexrow">
+  <div class="strain-value">
+    <span class="value">{totalStrain}</span>
+    {localize('MCDMCB.TALENT.STRAIN.Total')}
+  </div>
+  <div class="strain-value">
+    <span class="value">{maxStrain}</span>
+    {localize('MCDMCB.TALENT.STRAIN.Max')}
+  </div>
+</div>
+<div class="tidy-strain-container" bind:this={sectionsContainer}>
+  <TidyTable key="strain-table">
+    {#snippet header(expanded)}
+      <TidyTableHeaderRow
+        class={[
+          'theme-dark'
+        ]}
+      >
+        <TidyTableHeaderCell columnWidth="5rem" primary={true} class="header-label-cell" data-tidy-column-key="strain-level">
+          <h3>{localize('MCDMCB.TALENT.STRAIN.Label')}</h3>
+        </TidyTableHeaderCell>
+        {#each Object.entries(strainTypes) as [strainKey, strainType]}
+          <TidyTableHeaderCell columnWidth="{dynamicColumnWidth}px" data-tidy-column-key={strainKey}>
+            {strainType.header}
+          </TidyTableHeaderCell>
+        {/each}
+      </TidyTableHeaderRow>
+    {/snippet}
+
+    {#snippet body()}
+      {#each levels as level}
+        <TidyTableRow>
+          {#snippet children()}
+            <TidyTableCell columnWidth="5rem" attributes={{ ['data-tidy-column-key']: 'strain-level' }}>
+              {level}
+            </TidyTableCell>
+            {#each Object.entries(strainTypes) as [strainKey, strainType]}
+              <TidyTableCell
+                columnWidth="{dynamicColumnWidth}px"
+                class='tidy-mcdm-strain-effects'
+                attributes={{
+                  ['data-tidy-column-key']: strainKey,
+                  ['data-tooltip']: strainType.effects[level].tooltip
+                }}
+              >
+                <input
+                  id="{strainKey}-{level}"
+                  type="radio"
+                  name="{strainKey}"
+                  data-dtype="Number"
+                  value={currentStrain[strainKey]}
+                  checked={currentStrain[strainKey] === level}
+                  disabled={maxStrain - totalStrain < level - currentStrain[strainKey]}
+                  onchange={() => {
+                    onChangeStrain(strainKey, level);
+                  }}
+                >
+                <label class={currentStrain[strainKey] >= level ? 'selected' : ''} for="{strainKey}-{level}">{strainType.effects[level].label}</label>
+              </TidyTableCell>
+            {/each}
+          {/snippet}
+        </TidyTableRow>
+      {/each}
+    {/snippet}
+  </TidyTable>
+</div>
+<ActionBar bind:searchCriteria sections={powerSections} {tabId} />
+<McdmPowersTables sections={powerSections} {searchCriteria} {context} {tabId}/>
+<div class={['sheet-footer flexrow']}>
+  <div></div>
+  {#if context.editable}
+    <div class="sheet-footer-right flexshrink">
+      <a
+        data-tooltip="DND5E.ItemCreate"
+        class="button button-icon-only button-primary item-create"
+        class:disabled={!context.editable}
+        onclick={onAddClicked}
+      >
+        <i class="fas fa-plus"></i>
+      </a>
+    </div>
+  {/if}
+</div>

--- a/src/integration/modules/McdmClassBundle/McdmPowersTab.svelte
+++ b/src/integration/modules/McdmClassBundle/McdmPowersTab.svelte
@@ -138,72 +138,74 @@
   }
 </script>
 
-<div class="strain-values flexrow">
-  <div class="strain-value">
-    <span class="value">{totalStrain}</span>
-    {localize('MCDMCB.TALENT.STRAIN.Total')}
+{#if context.actor.type === 'character'}
+  <div class="strain-values flexrow">
+    <div class="strain-value">
+      <span class="value">{totalStrain}</span>
+      {localize('MCDMCB.TALENT.STRAIN.Total')}
+    </div>
+    <div class="strain-value">
+      <span class="value">{maxStrain}</span>
+      {localize('MCDMCB.TALENT.STRAIN.Max')}
+    </div>
   </div>
-  <div class="strain-value">
-    <span class="value">{maxStrain}</span>
-    {localize('MCDMCB.TALENT.STRAIN.Max')}
-  </div>
-</div>
-<div class="tidy-strain-container" bind:this={sectionsContainer}>
-  <TidyTable key="strain-table">
-    {#snippet header(expanded)}
-      <TidyTableHeaderRow
-        class={[
-          'theme-dark'
-        ]}
-      >
-        <TidyTableHeaderCell columnWidth="5rem" primary={true} class="header-label-cell" data-tidy-column-key="strain-level">
-          <h3>{localize('MCDMCB.TALENT.STRAIN.Label')}</h3>
-        </TidyTableHeaderCell>
-        {#each Object.entries(strainTypes) as [strainKey, strainType]}
-          <TidyTableHeaderCell columnWidth="{dynamicColumnWidth}px" data-tidy-column-key={strainKey}>
-            {strainType.header}
+  <div class="tidy-strain-container" bind:this={sectionsContainer}>
+    <TidyTable key="strain-table">
+      {#snippet header(expanded)}
+        <TidyTableHeaderRow
+          class={[
+            'theme-dark'
+          ]}
+        >
+          <TidyTableHeaderCell columnWidth="5rem" primary={true} class="header-label-cell" data-tidy-column-key="strain-level">
+            <h3>{localize('MCDMCB.TALENT.STRAIN.Label')}</h3>
           </TidyTableHeaderCell>
-        {/each}
-      </TidyTableHeaderRow>
-    {/snippet}
+          {#each Object.entries(strainTypes) as [strainKey, strainType]}
+            <TidyTableHeaderCell columnWidth="{dynamicColumnWidth}px" data-tidy-column-key={strainKey}>
+              {strainType.header}
+            </TidyTableHeaderCell>
+          {/each}
+        </TidyTableHeaderRow>
+      {/snippet}
 
-    {#snippet body()}
-      {#each levels as level}
-        <TidyTableRow>
-          {#snippet children()}
-            <TidyTableCell columnWidth="5rem" attributes={{ ['data-tidy-column-key']: 'strain-level' }}>
-              {level}
-            </TidyTableCell>
-            {#each Object.entries(strainTypes) as [strainKey, strainType]}
-              <TidyTableCell
-                columnWidth="{dynamicColumnWidth}px"
-                class='tidy-mcdm-strain-effects'
-                attributes={{
-                  ['data-tidy-column-key']: strainKey,
-                  ['data-tooltip']: strainType.effects[level].tooltip
-                }}
-              >
-                <input
-                  id="{strainKey}-{level}"
-                  type="radio"
-                  name="{strainKey}"
-                  data-dtype="Number"
-                  value={currentStrain[strainKey]}
-                  checked={currentStrain[strainKey] === level}
-                  disabled={maxStrain - totalStrain < level - currentStrain[strainKey]}
-                  onchange={() => {
-                    onChangeStrain(strainKey, level);
+      {#snippet body()}
+        {#each levels as level}
+          <TidyTableRow>
+            {#snippet children()}
+              <TidyTableCell columnWidth="5rem" attributes={{ ['data-tidy-column-key']: 'strain-level' }}>
+                {level}
+              </TidyTableCell>
+              {#each Object.entries(strainTypes) as [strainKey, strainType]}
+                <TidyTableCell
+                  columnWidth="{dynamicColumnWidth}px"
+                  class='tidy-mcdm-strain-effects'
+                  attributes={{
+                    ['data-tidy-column-key']: strainKey,
+                    ['data-tooltip']: strainType.effects[level].tooltip
                   }}
                 >
-                <label class={currentStrain[strainKey] >= level ? 'selected' : ''} for="{strainKey}-{level}">{strainType.effects[level].label}</label>
-              </TidyTableCell>
-            {/each}
-          {/snippet}
-        </TidyTableRow>
-      {/each}
-    {/snippet}
-  </TidyTable>
-</div>
+                  <input
+                    id="{strainKey}-{level}"
+                    type="radio"
+                    name="{strainKey}"
+                    data-dtype="Number"
+                    value={currentStrain[strainKey]}
+                    checked={currentStrain[strainKey] === level}
+                    disabled={maxStrain - totalStrain < level - currentStrain[strainKey]}
+                    onchange={() => {
+                      onChangeStrain(strainKey, level);
+                    }}
+                  >
+                  <label class={currentStrain[strainKey] >= level ? 'selected' : ''} for="{strainKey}-{level}">{strainType.effects[level].label}</label>
+                </TidyTableCell>
+              {/each}
+            {/snippet}
+          </TidyTableRow>
+        {/each}
+      {/snippet}
+    </TidyTable>
+  </div>
+{/if}
 <ActionBar bind:searchCriteria sections={powerSections} {tabId} />
 <McdmPowersTables sections={powerSections} {searchCriteria} {context} {tabId}/>
 <div class={['sheet-footer flexrow']}>

--- a/src/integration/modules/McdmClassBundle/McdmPowersTables.svelte
+++ b/src/integration/modules/McdmClassBundle/McdmPowersTables.svelte
@@ -1,0 +1,248 @@
+<script lang="ts">
+  import TidyItemTableRow from 'src/components/table-quadrone/TidyItemTableRow.svelte';
+  import TidyTable from 'src/components/table-quadrone/TidyTable.svelte';
+  import TidyTableCell from 'src/components/table-quadrone/TidyTableCell.svelte';
+  import TidyTableHeaderCell from 'src/components/table-quadrone/TidyTableHeaderCell.svelte';
+  import TidyTableHeaderRow from 'src/components/table-quadrone/TidyTableHeaderRow.svelte';
+  import { CONSTANTS } from 'src/constants';
+  import type { InlineToggleService } from 'src/features/expand-collapse/InlineToggleService.svelte';
+  import { createSearchResultsState, setSearchResultsContext } from 'src/features/search/search.svelte';
+  import { ItemVisibility } from 'src/features/sections/ItemVisibility';
+  import { FoundryAdapter } from 'src/foundry/foundry-adapter';
+  import { ColumnsLoadout } from 'src/runtime/item/ColumnsLoadout.svelte';
+  import { getDefaultItemColumns } from 'src/runtime/tables/default-item-columns';
+  import type { ActorSheetQuadroneContext } from 'src/types/types';
+  import { getContext } from 'svelte';
+  import McdmPowerSpecialtyColumn from './McdmPowerSpecialtyColumn.svelte';
+  import { ItemColumnRuntime } from 'src/runtime/tables/ItemColumnRuntime.svelte';
+  import type { PowersSection } from './McdmClassBundle';
+
+  interface Props {
+    sections: PowersSection[];
+    searchCriteria: string;
+    context: ActorSheetQuadroneContext;
+    tabId: string;
+  }
+
+  let {
+    sections,
+    searchCriteria,
+    context,
+    tabId,
+  }: Props = $props();
+
+  let sectionsContainer: HTMLElement;
+  let sectionsInlineWidth: number = $state(0);
+
+  function onResize(entry: ResizeObserverEntry) {
+    sectionsInlineWidth = entry.borderBoxSize[0].inlineSize;
+  }
+
+  $effect(() => {
+    const observer = new ResizeObserver(([entry]) => onResize(entry));
+    observer.observe(sectionsContainer);
+
+    return () => {
+      observer.disconnect();
+    };
+  });
+
+  let inlineToggleService = getContext<InlineToggleService>(
+    CONSTANTS.SVELTE_CONTEXT.INLINE_TOGGLE_SERVICE,
+  );
+
+  let itemToggleMap = $derived(inlineToggleService.map);
+
+  const searchResults = createSearchResultsState();
+  setSearchResultsContext(searchResults);
+
+  $effect(() => {
+    searchResults.uuids = ItemVisibility.getItemsToShowAtDepth({
+      criteria: searchCriteria,
+      itemContext: context.itemContext,
+      sections,
+      tabId,
+    });
+  });
+
+  const localize = FoundryAdapter.localize;
+
+  const defaultColumns = getDefaultItemColumns()
+  let columns = $derived(
+    new ColumnsLoadout([
+      {
+        key: 'concentration',
+        headerContent: {
+          type: 'html',
+          html: ''
+        },
+        cellContent: {
+          type: 'callback',
+          callback: (rowDocument, rowContext) => {
+            if (!rowDocument.requiresConcentration) return "";
+            return `
+              <span class="concentration-icon">
+                <dnd5e-icon src="systems/dnd5e/icons/svg/statuses/concentrating.svg">
+              </span>
+            `
+          },
+        },
+        widthRems: 2,
+        order: 100,
+        priority: 900
+      },
+      {...defaultColumns.uses, key: 'uses', order: 200, priority: 200},
+      {
+        key: 'specialty',
+        headerContent: {
+          type: 'html',
+          html: localize('MCDMCB.TALENT.POWERS.SPECIALTIES.Header'),
+        },
+        cellContent: {
+          type: 'component',
+          component: McdmPowerSpecialtyColumn,
+        },
+        widthRems: 3.5,
+        order: 300,
+        priority: 100
+      },
+      {...defaultColumns.time, key: 'time', order: 400, priority: 500},
+      {...defaultColumns.formula, key: 'formula', order: 500, priority: 300},
+      {...defaultColumns.target, key: 'target', order: 600, priority: 400},
+      {...defaultColumns.range, key: 'range', order: 700, priority: 600},
+      {...defaultColumns.roll, key: 'roll', order: 800, priority: 700},
+      {...defaultColumns.actions, widthRems: defaultColumns.actions.widthRems(sections[0]), key: 'actions', order: 1000, priority: 1000},
+    ])
+  );
+  let hiddenColumns = $derived(
+    ItemColumnRuntime.determineHiddenColumns(sectionsInlineWidth, columns),
+  );
+</script>
+
+<div class="tidy-table-container" bind:this={sectionsContainer}>
+  {#each sections as section}
+    {#if section.show}
+      <TidyTable
+        key={section.key}
+        data-custom-section={false}
+        dataset={section.dataset}
+      >
+        {#snippet header(expanded)}
+          <TidyTableHeaderRow
+            class={[
+              'theme-dark'
+            ]}
+          >
+            <TidyTableHeaderCell primary={true} class="header-label-cell">
+              <h3>
+                {localize(section.label)}
+              </h3>
+              <span class="table-header-count">{section.items.length}</span>
+            </TidyTableHeaderCell>
+            {#each columns.ordered as column}
+              {@const hidden = hiddenColumns.has(column.key)}
+    
+              <TidyTableHeaderCell
+                class={[column.headerClasses, { hidden }]}
+                columnWidth="{column.widthRems}rem"
+                data-tidy-column-key={column.key}
+              >
+                {#if !!column.headerContent}
+                  {#if column.headerContent.type === 'callback'}
+                    {@html column.headerContent.callback?.(context.document, context)}
+                  {:else if column.headerContent.type === 'component'}
+                    <column.headerContent.component
+                      sheetContext={context}
+                      sheetDocument={context.document}
+                      {section}
+                    />
+                  {:else if column.headerContent.type === 'html'}
+                    {@html column.headerContent.html}
+                  {/if}
+                {/if}
+              </TidyTableHeaderCell>
+            {/each}
+          </TidyTableHeaderRow>
+        {/snippet}
+    
+        {#snippet body()}
+          {@const itemEntries = section.items.map((item) => ({
+            item,
+            ctx: context.itemContext[item.id],
+          }))}
+          {#each itemEntries as { item, ctx }, i (item.id)}
+            {@const expanded = !!itemToggleMap.get(tabId)?.has(item.id)}
+    
+            <TidyItemTableRow
+              {item}
+              hidden={!searchResults.show(item.uuid)}
+              rowClass={[
+                {
+                  expanded,
+                },
+              ]}
+              contextMenu={{
+                type: CONSTANTS.CONTEXT_MENU_TYPE_ITEMS,
+                uuid: item.uuid,
+              }}
+            >
+              {#snippet children({ toggleSummary, expanded })}
+                <div class="highlight"></div>
+                <a
+                  class={[
+                    'tidy-table-row-use-button',
+                    { disabled: !context.editable },
+                  ]}
+                  onclick={(ev) =>
+                    context.editable && FoundryAdapter.actorTryUseItem(item, ev)}
+                >
+                    <img class="item-image" alt={item.name} src={item.img} />
+                    <span class="roll-prompt">
+                      <i class="fa fa-dice-d20"></i>
+                    </span>
+                </a>
+    
+                <TidyTableCell primary={true} class="item-label text-cell">
+                  <a class="item-name" onclick={(ev) => toggleSummary()}>
+                    <span class="cell-text">
+                      <span class="cell-name">{item.name}</span>
+                      {#if ctx.subtitle}
+                        <span class="cell-context">{@html ctx.subtitle}</span>
+                      {/if}
+                    </span>
+                    <span class="row-detail-expand-indicator">
+                      <i
+                        class="fa-solid fa-angle-right expand-indicator"
+                        class:expanded
+                      >
+                      </i>
+                    </span>
+                  </a>
+                </TidyTableCell>
+                {#each columns.ordered as column}
+                  {@const hidden = hiddenColumns.has(column.key)}
+    
+                  <TidyTableCell
+                    columnWidth="{column.widthRems}rem"
+                    class={[column.cellClasses, { hidden }]}
+                    attributes={{ ['data-tidy-column-key']: column.key }}
+                  >
+                    {#if column.cellContent.type === 'callback'}
+                      {@html column.cellContent.callback?.(item, ctx)}
+                    {:else if column.cellContent.type === 'component'}
+                      <column.cellContent.component
+                        rowContext={ctx}
+                        rowDocument={item}
+                        {section}
+                      />
+                    {/if}
+                  </TidyTableCell>
+                {/each}
+              {/snippet}
+            </TidyItemTableRow>
+          {/each}
+        {/snippet}
+      </TidyTable>
+    {/if}
+  {/each}
+</div>

--- a/src/runtime/item/TabDocumentItemTypesRuntime.ts
+++ b/src/runtime/item/TabDocumentItemTypesRuntime.ts
@@ -1,0 +1,27 @@
+import type { TabIdDocumentItemTypesOptions, TabIdDocumentItemTypesParams } from 'src/api';
+import { CONSTANTS } from 'src/constants';
+import { Inventory } from 'src/features/sections/Inventory';
+
+export class TabDocumentItemTypesRuntime {
+  private static _registeredTypes: Record<string, string[]> = {
+    [CONSTANTS.TAB_CHARACTER_FEATURES]: ['feat'],
+    [CONSTANTS.TAB_NPC_STATBLOCK]: ['feat'],
+    [CONSTANTS.TAB_ACTOR_INVENTORY]: Inventory.getInventoryTypes(),
+    [CONSTANTS.TAB_ACTOR_SPELLBOOK]: ['spell'],
+  };
+
+  static getTypes(tabId: string): string[] {
+    return this._registeredTypes[tabId] ?? [];
+  }
+
+  static registerTypes(
+    {tabId, documentItemTypes}: TabIdDocumentItemTypesParams,
+    options?: TabIdDocumentItemTypesOptions
+  ) {
+    if (options?.mode === 'override') {
+      this._registeredTypes[tabId] = documentItemTypes;
+    } else {
+      this._registeredTypes[tabId] = Array.from(new Set((this._registeredTypes[tabId] ?? []).concat(documentItemTypes)));
+    }
+  }
+};

--- a/src/sheets/quadrone/Tidy5eActorSheetQuadroneBase.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eActorSheetQuadroneBase.svelte.ts
@@ -57,6 +57,7 @@ import { ExpansionTracker } from 'src/features/expand-collapse/ExpansionTracker.
 import { SvelteMap } from 'svelte/reactivity';
 import { mapGetOrInsert } from 'src/utils/map';
 import { ThemeQuadrone } from 'src/theme/theme-quadrone.svelte';
+import { TabDocumentItemTypesRuntime } from 'src/runtime/item/TabDocumentItemTypesRuntime';
 
 const POST_WINDOW_TITLE_ANCHOR_CLASS_NAME = 'sheet-warning-anchor';
 
@@ -1040,6 +1041,11 @@ export function Tidy5eActorSheetQuadroneBase<
      * @returns {string[]}  Types of items to allow to create.
      */
     _addDocumentItemTypes(tab: string): string[] {
+      const registeredTypes = TabDocumentItemTypesRuntime.getTypes(tab);
+
+      if (registeredTypes) return registeredTypes;
+
+      // TODO: Technically not necessary?
       switch (tab) {
         case CONSTANTS.TAB_CHARACTER_FEATURES:
         case CONSTANTS.TAB_NPC_STATBLOCK:

--- a/src/sheets/quadrone/Tidy5eActorSheetQuadroneBase.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eActorSheetQuadroneBase.svelte.ts
@@ -1041,22 +1041,7 @@ export function Tidy5eActorSheetQuadroneBase<
      * @returns {string[]}  Types of items to allow to create.
      */
     _addDocumentItemTypes(tab: string): string[] {
-      const registeredTypes = TabDocumentItemTypesRuntime.getTypes(tab);
-
-      if (registeredTypes) return registeredTypes;
-
-      // TODO: Technically not necessary?
-      switch (tab) {
-        case CONSTANTS.TAB_CHARACTER_FEATURES:
-        case CONSTANTS.TAB_NPC_STATBLOCK:
-          return ['feat'];
-        case CONSTANTS.TAB_ACTOR_INVENTORY:
-          return Inventory.getInventoryTypes();
-        case CONSTANTS.TAB_ACTOR_SPELLBOOK:
-          return ['spell'];
-        default:
-          return [];
-      }
+      return TabDocumentItemTypesRuntime.getTypes(tab);
     }
 
     private async setExpandedItemData() {

--- a/src/sheets/quadrone/actor/character-parts/favorites/FavoriteItemGeneric.svelte
+++ b/src/sheets/quadrone/actor/character-parts/favorites/FavoriteItemGeneric.svelte
@@ -15,7 +15,7 @@
 
   let subtitle = $derived(
     [
-      favorite.item.system.type.label ??
+      favorite.item.system.type?.label ??
         game.i18n.localize(CONFIG.Item.typeLabels[favorite.item.type]),
     ].filterJoin(` <div class="divider-dot"></div> `),
   );
@@ -29,8 +29,23 @@
   let modifier = $derived(favorite.item?.labels?.modifier);
 
   let save = $derived(
-    favorite.item?.system?.activities?.getByType?.('save')?.[0]?.save,
+    getSaveData(favorite.item?.system?.activities?.getByType?.('save')?.[0]?.save),
   );
+
+  function getSaveData(save: any) {
+    if (foundry.utils.getType(save?.ability) === 'Set')
+      save = {
+        ...save,
+        ability:
+          save.ability.size > 2
+            ? game.i18n.localize('DND5E.AbbreviationDC')
+            : Array.from<string>(save.ability)
+                .map((k: string) => CONFIG.DND5E.abilities[k]?.abbreviation)
+                .filterJoin(' / '),
+      };
+
+    return save;
+  }
 
   let quantity = $derived(favorite.item?.system?.quantity);
 
@@ -57,7 +72,7 @@
     name={favorite.item?.name || ''}
     {subtitle}
   />
-  <div class="">
+  <div class={uses?.max || !isNil(modifier) || save?.dc?.value || quantity ? "stacked" : ""}>
     <span class="primary">
       {#if uses?.max}
         <FavoriteItemUses {favorite} {uses} />
@@ -72,14 +87,12 @@
           </span>
         </span>
       {:else if save?.dc?.value}
-        <span class="save">
-          <span class="value">
-            {save.dc.value}
-          </span>
-          <span class="ability">
-            {save.ability}
-          </span>
-        </span>
+      <span class="ability font-label-medium color-text-gold-emphasis">
+        {save.ability}
+      </span>
+      <span class="value font-data-medium">
+        {save.dc.value}
+      </span>
       {:else if quantity}
         <span class="sign">&times;</span>
         <span class="value">{quantity}</span>

--- a/src/sheets/quadrone/actor/character-parts/favorites/FavoriteItemGeneric.svelte
+++ b/src/sheets/quadrone/actor/character-parts/favorites/FavoriteItemGeneric.svelte
@@ -28,24 +28,20 @@
 
   let modifier = $derived(favorite.item?.labels?.modifier);
 
-  let save = $derived(
-    getSaveData(favorite.item?.system?.activities?.getByType?.('save')?.[0]?.save),
-  );
-
-  function getSaveData(save: any) {
-    if (foundry.utils.getType(save?.ability) === 'Set')
-      save = {
-        ...save,
+  let save: any = $derived.by(() => {
+    const saveData = favorite.item?.system?.activities?.getByType?.('save')?.[0]?.save;
+    if (foundry.utils.getType(saveData?.ability) === 'Set')
+      return {
+        ...saveData,
         ability:
-          save.ability.size > 2
+          saveData.ability.size > 2
             ? game.i18n.localize('DND5E.AbbreviationDC')
-            : Array.from<string>(save.ability)
+            : Array.from<string>(saveData.ability)
                 .map((k: string) => CONFIG.DND5E.abilities[k]?.abbreviation)
-                .filterJoin(' / '),
-      };
-
-    return save;
-  }
+                .filterJoin(' / ')
+      }
+    return saveData;
+  });
 
   let quantity = $derived(favorite.item?.system?.quantity);
 
@@ -72,7 +68,7 @@
     name={favorite.item?.name || ''}
     {subtitle}
   />
-  <div class={uses?.max || !isNil(modifier) || save?.dc?.value || quantity ? "stacked" : ""}>
+    <div class={{stacked : uses?.max || !isNil(modifier) || save?.dc?.value || quantity}}>
     <span class="primary">
       {#if uses?.max}
         <FavoriteItemUses {favorite} {uses} />


### PR DESCRIPTION
Things added/changed:
- Added: API function for registering document types which are valid for creation on a given tab
- Added: MCDM Class Bundle integration (Quadrone only)
  - Powers tab for Characters and NPCs
    - Both have tables of powers
    - Characters get Strain table
  - Power item sheet
- Changed: `FavoriteItemGeneric` had a minor glow-up (same "save" treatment as favorited spells)