### PR TITLE
Misc updates and fixes

### DIFF
--- a/src/main.svelte.ts
+++ b/src/main.svelte.ts
@@ -34,6 +34,7 @@ import { Tidy5eEncounterSheetClassic } from './sheets/classic/Tidy5eEncounterShe
 import { Tidy5eGroupSheetQuadrone } from './sheets/quadrone/Tidy5eGroupSheetQuadrone.svelte';
 import { Tidy5eEncounterSheetQuadrone } from './sheets/quadrone/Tidy5eEncounterSheetQuadrone.svelte';
 import { formatResourcePathForCss } from './utils/path';
+import './theme/theme-quadrone-detached';
 
 Hooks.once('init', () => {
   const documentSheetConfig = foundry.applications.apps.DocumentSheetConfig;
@@ -191,7 +192,7 @@ Hooks.once('init', () => {
       label: 'TIDY5E.Tidy5eGroupSheetQuadrone',
     }
   );
-  
+
   documentSheetConfig.registerSheet(
     Actor,
     CONSTANTS.DND5E_SYSTEM_ID,
@@ -201,10 +202,9 @@ Hooks.once('init', () => {
       label: 'TIDY5E.Tidy5eEncounterSheetQuadrone',
     }
   );
-  
+
   /* FOR THOSE WITH TRUE SIGHT */
   if (settings.value.truesight) {
-
     documentSheetConfig.registerSheet(
       Item,
       CONSTANTS.DND5E_SYSTEM_ID,

--- a/src/mixins/TidyDocumentSheetMixin.svelte.ts
+++ b/src/mixins/TidyDocumentSheetMixin.svelte.ts
@@ -68,7 +68,7 @@ export function TidyExtensibleDocumentSheetMixin<
               'The editImage action is available only for IMG elements.'
             );
           }
-          const attr = target.dataset.edit ?? '';
+          const attr = target.dataset.path ?? '';
           const current = foundry.utils.getProperty(
             this.document._source,
             attr
@@ -104,7 +104,7 @@ export function TidyExtensibleDocumentSheetMixin<
               'The editImageVideo action is available only for IMG and VIDEO elements.'
             );
           }
-          const attr = target.dataset.edit ?? '';
+          const attr = target.dataset.path ?? '';
           const current = foundry.utils.getProperty(
             this.document._source,
             attr

--- a/src/runtime/tables/GroupMemberColumnRuntime.svelte.ts
+++ b/src/runtime/tables/GroupMemberColumnRuntime.svelte.ts
@@ -122,6 +122,7 @@ class GroupMemberColumnRuntimeImpl extends TableColumnRuntimeBase {
         type: 'component',
         component: GroupVehicleCrewColumn,
       },
+      cellClasses: 'truncate',
       widthRems: 3.75,
     };
 

--- a/src/runtime/tables/default-item-columns.ts
+++ b/src/runtime/tables/default-item-columns.ts
@@ -175,7 +175,7 @@ export function getDefaultItemColumns() {
         type: 'component',
         component: ItemTimeColumn,
       },
-      widthRems: 3,
+      widthRems: 4,
     },
     uses: {
       headerContent: {

--- a/src/scss/quadrone/actors.scss
+++ b/src/scss/quadrone/actors.scss
@@ -2777,14 +2777,6 @@
       }
     }
 
-    .tidy-tab.biography {
-      .biography-editor-container {
-        .editor {
-          background: rgba(0, 0, 0, 0.24);
-        }
-      }
-    }
-
     .use-ability-list {
 
       button.proficiency {

--- a/src/scss/quadrone/editors.scss
+++ b/src/scss/quadrone/editors.scss
@@ -397,9 +397,12 @@
     }
 
     figcaption {
+      color: var(--t5e-color-text-gold-emphasis);
       display: flex;
       flex-direction: column;
+      font: var(--t5e-font-label-medium);
       gap: var(--t5e-size-2x);
+      margin: var(--t5e-size-2x) 0;
       text-align: right;
       font-style: italic;
     }
@@ -457,248 +460,7 @@
       flex-wrap: wrap;
       gap: 0.25rem;
     }
-
-
-    // button.item-summary-command {
-    //   width: auto;
-    //   line-height: 1rem;
-    //   padding: var(--t5e-size-1x);
-    //   background: none; //var(--t5e-component-field-background);
-    //   color: var(--t5e-color-text-lighter);
-    //   border: none; // 0.0625rem solid var(--t5e-component-field-border);
-    //   font-size: var(--font-size-12);
-    //   margin: -0.25rem 0;
-
-    //   display: inline-flex;
-    //   align-items: center;
-    //   gap: 0.25rem;
-    //   height: var(--t5e-tag-size-default);
-    //   min-height: var(--t5e-tag-size-default);
-
-    //   i {
-    //     color: var(--t5e-color-icon-diminished);
-    //   }
-
-    //   &:hover {
-    //     color: var(--t5e-color-text-default);
-    //     background: var(--t5e-component-field-background-hover);
-    //     border-color: var(--t5e-component-field-border-hover);
-
-    //     i {
-    //       color: var(--t5e-color-icon-default);
-    //     }
-    //   }
-    // }
   }
-
-
-  .statblock.npc {
-    --statblock-text-secondary: var(--t5e-color-text-lighter);
-    --statblock-border: var(--t5e-color-gold);
-    --statblock-column-width: 100%;
-    --statblock-text-primary: var(--t5e-color-text-default);
-    --statblock-text-header: var(--t5e-theme-color-darkest);
-    --statblock-background: rgba(0, 0, 0, 0.08);
-    --statblock-dividers: var(--t5e-theme-color-darker);
-    --statblock-ability-header-1st: rgba(0, 0, 0, 0.08);
-    --statblock-ability-header-2nd: rgba(0, 0, 0, 0.16);
-    --statblock-ability-stat-1st: rgba(0, 0, 0, 0.16);
-    --statblock-ability-stat-2nd: rgba(0, 0, 0, 0.24);
-    box-shadow: none;
-    background: none;
-    --notchSize: 0.5rem;
-    position: relative;
-    clip-path: polygon(0% var(--notchSize), var(--notchSize) 0%, calc(100% - var(--notchSize)) 0%, 100% var(--notchSize), 100% calc(100% - var(--notchSize)), calc(100% - var(--notchSize)) 100%, var(--notchSize) 100%, 0% calc(100% - var(--notchSize)));
-    background: var(--t5e-color-gold);
-    box-shadow: 0 0 0.25rem 0 var(--t5e-color-gold);
-    padding: 1rem 1.25rem;
-    border: none;
-    color: var(--t5e-color-text-default);
-    // max-width: 100%;
-
-    &::before {
-      clip-path: polygon(0% var(--notchSize), var(--notchSize) 0%, calc(100% - var(--notchSize)) 0%, 100% var(--notchSize), 100% calc(100% - var(--notchSize)), calc(100% - var(--notchSize)) 100%, var(--notchSize) 100%, 0% calc(100% - var(--notchSize)));
-      position: absolute;
-      background: var(--t5e-component-card-darker);
-      content: '';
-      z-index: -1;
-      top: 0.125rem;
-      left: 0.125rem;
-      bottom: 0.125rem;
-      right: 0.125rem;
-    }
-
-    &::after {
-      position: absolute;
-      content: '';
-      border: 0.125rem solid var(--t5e-color-gold);
-      border-radius: 1.625rem;
-      top: 0;
-      left: 0;
-      bottom: 0;
-      right: 0;
-      pointer-events: none;
-    }
-
-    p {
-      margin: 0;
-      display: inline;
-    }
-
-    .statblock-title {
-      margin-top: var(--t5e-size-halfx);
-      border-bottom: 0.0625rem solid var(--statblock-dividers);
-
-      a {
-        align-items: center;
-        background: none;
-        color: var(--statblock-text-header);
-        display: flex;
-        font: var(--t5e-font-title-medium);
-        font-size: var(--font-size-24);
-        transition: all var(--t5e-transition-default);
-
-        i {
-          font-size: var(--font-size-16);
-
-          &::before {
-            content: '\f6d5';
-          }
-        }
-
-        &:hover {
-          color: var(--t5e-color-text-default);
-        }
-      }
-    }
-
-    .statblock-tags {
-      color: var(--t5e-color-text-lighter);
-    }
-
-    .statblock-header {
-      padding-bottom: var(--t5e-size-1x);
-
-      dl {
-        div {
-          display: flex;
-          gap: var(--t5e-size-1x);
-          margin-bottom: var(--t5e-size-halfx);
-
-          &.half-width {}
-
-          dt {
-            padding-right: var(--t5e-size-halfx);
-          }
-
-          dd {
-            margin-bottom: 0;
-          }
-
-          >* {
-            line-height: normal;
-            margin: 0;
-            padding: 0;
-          }
-        }
-      }
-
-      .abilities {
-        margin-bottom: var(--t5e-size-3x);
-
-        td {
-          color: var(--statblock-text-primary);
-        }
-
-        thead {
-          th {
-            font: var(--t5e-font-label-small);
-            color: var(--t5e-color-text-lighter);
-            text-transform: initial;
-          }
-        }
-
-        tbody {
-          tr {}
-
-          th {
-            font-variant: normal;
-            text-transform: uppercase;
-            font-weight: var(--font-weight-label);
-          }
-        }
-      }
-    }
-
-
-    .statblock-actions {
-      >* {
-        margin-bottom: 0.375rem;
-        display: flex;
-        flex-direction: column;
-      }
-
-      .statblock-action {
-        align-items: baseline;
-        gap: var(--t5e-size-1x);
-
-        .name {
-          display: inline;
-
-          &::after {
-            content: '.';
-            display: inline;
-          }
-        }
-
-        >* {
-          display: inline;
-        }
-      }
-
-      h5.statblock-actions-title {
-        border-bottom: 0.0625rem solid var(--statblock-dividers);
-        // color: var(--t5e-theme-color-darkest);
-        font: var(--t5e-font-title-small);
-        font-size: var(--font-size-20);
-      }
-    }
-
-    .name {
-      font: var(--t5e-font-label-medium);
-    }
-  }
-
-  .flexible-editor-container {
-    flex: 1;
-
-    display: flex;
-    flex-direction: column;
-
-    prose-mirror {
-      flex: 1;
-    }
-  }
-
-  fieldset .editor-rendered-content {
-    flex: auto;
-    margin-top: var(--t5e-size-1x);
-    margin-bottom: var(--t5e-size-1x);
-    border: none;
-  }
-
-  // &.theme-light {
-  //   button.item-summary-command {
-  //     box-shadow: none;
-  //     text-shadow: var(--t5e-drop-shadow-field);
-
-  //     &:hover {
-  //       background: none;
-  //       border-color: var(--t5e-component-field-border-hover);
-  //     }
-  //   }
-  // }
-
 
   &.theme-dark {
 
@@ -765,17 +527,6 @@
       ol li::marker {
         color: var(--t5e-color-text-lighter);
       }
-    }
-
-    .statblock.npc {
-      --statblock-text-primary: var(--t5e-color-text-default);
-      --statblock-text-header: var(--t5e-color-text-lighter);
-      --statblock-dividers: var(--t5e-theme-color-default);
-      --statblock-background: rgba(255, 255, 255, 0.12);
-      --statblock-ability-header-1st: rgba(255, 255, 255, 0.12);
-      --statblock-ability-header-2nd: rgba(255, 255, 255, 0.24);
-      --statblock-ability-stat-1st: rgba(255, 255, 255, 0.24);
-      --statblock-ability-stat-2nd: rgba(255, 255, 255, 0.32);
     }
   }
 }

--- a/src/scss/quadrone/tables.scss
+++ b/src/scss/quadrone/tables.scss
@@ -442,6 +442,7 @@
       flex-wrap: nowrap;
       text-wrap: nowrap;
       overflow: hidden;
+      width: 100%;
 
       .remaining-damages-count {
         border: none;

--- a/src/scss/shared/dnd5e2-ports.scss
+++ b/src/scss/shared/dnd5e2-ports.scss
@@ -1,77 +1,180 @@
 .tidy5e-sheet {
+
   /* NPC Stat Blocks */
   .statblock.npc {
-    --statblock-background: rgb(235 228 214 / 0.35);
-    --statblock-ability-header-1st: rgb(234 229 217);
-    --statblock-ability-header-2nd: rgb(215 217 208);
-    --statblock-ability-stat-1st: rgb(218 211 203);
-    --statblock-ability-stat-2nd: rgb(205 201 201);
-    --statblock-border: rgb(78 76 74);
-    --statblock-column-width: 400px;
-    --statblock-text-header: rgb(79 29 21);
-    --statblock-text-primary: rgb(31, 30, 30);
-    --statblock-text-secondary: rgba(73 72 73 / 0.75);
+    --statblock-color-gold: var(--t5e-color-gold, rgba(159, 146, 117, 1));
+    --statblock-theme-color-default: rgba(116, 27, 43, 1);
+    --statblock-theme-color-darkest: oklch(from var(--t5e-theme-color-default) calc(l * 0.75) calc(c * 1.2) h);
+    --statblock-weight-label: var(--font-weight-label, 500);
+    --statblock-font-title-medium: var(--t5e-font-title-medium, 400 var(--font-size-28) 'Modesto Condensed', 'Palatino Linotype', serif);
+    --statblock-font-title-small: var(--t5e-font-title-small, 400 var(--font-size-18) 'Modesto Condensed', 'Palatino Linotype', serif);
+    --statblock-text-header: var(--t5e-theme-color-darkest);
+    --statblock-text-primary: var(--t5e-color-text-default, rgb(0, 0, 0));
+    --statblock-text-secondary: var(--t5e-color-text-lighter, rgba(75, 74, 68, 1));
+    --statblock-text-gold: var(--t5e-color-text-gold-emphasis, rgb(115, 99, 63));
+    --statblock-column-width: 100%;
+    --statblock-background: var(--t5e-component-card-default, rgb(248, 244, 241, 1));
+    --statblock-callout: rgba(255, 255, 255, 0.48);
+    --statblock-border: var(--statblock-color-gold);
+    --statblock-dividers: var(--statblock-theme-color-darkest);
+    --statblock-ability-header-1st: rgba(0, 0, 0, 0.08);
+    --statblock-ability-header-2nd: rgba(0, 0, 0, 0.16);
+    --statblock-ability-stat-1st: rgba(0, 0, 0, 0.16);
+    --statblock-ability-stat-2nd: rgba(0, 0, 0, 0.24);
+    --notchSize: 0.5rem;
+  }
+
+  &.theme-dark {
+    .statblock.npc {
+      --statblock-text-primary: var(--statblock-text-primary);
+      --statblock-text-header: var(--statblock-text-secondary);
+      --statblock-dividers: var(--statblock-color-gold);
+      --statblock-ability-header-1st: rgba(255, 255, 255, 0.12);
+      --statblock-ability-header-2nd: rgba(255, 255, 255, 0.24);
+      --statblock-ability-stat-1st: rgba(255, 255, 255, 0.24);
+      --statblock-ability-stat-2nd: rgba(255, 255, 255, 0.32);
+      --statblock-text-primary: var(--t5e-color-text-default, rgb(255, 255, 255));
+      --statblock-text-secondary: var(--t5e-color-text-lighter, rgba(207, 210, 218, 1));
+      --statblock-text-gold: var(--t5e-color-text-gold-emphasis, rgba(192, 173, 129, 1));
+      --statblock-background: var(--t5e-component-card-default, rgba(22, 24, 29, 1));
+    }
+  }
+
+  .statblock.npc {
+    box-shadow: none;
+    background: var(--statblock-color-gold);
+    border: none;
+    box-shadow: 0 0 0.25rem 0 var(--statblock-color-gold);
+    color: var(--statblock-text-primary);
+    position: relative;
+    clip-path: polygon(0% var(--notchSize), var(--notchSize) 0%, calc(100% - var(--notchSize)) 0%, 100% var(--notchSize), 100% calc(100% - var(--notchSize)), calc(100% - var(--notchSize)) 100%, var(--notchSize) 100%, 0% calc(100% - var(--notchSize)));
+    padding: 0.75rem 1rem;
+    // max-width: 100%;
+
+    display: flex;
+    flex-direction: column;
 
     max-width: var(--statblock-column-width);
-    background: var(--statblock-background);
-    border: 3px double var(--statblock-border);
-    border-radius: 8px;
-    padding-block: 4px;
-    padding-inline: 8px;
     box-shadow: 2px 2px 2px var(--dnd5e-shadow-15);
 
-    h4.statblock-title,
-    h5.statblock-actions-title {
-      border-block-end: 1px solid currentcolor;
-      font-variant: small-caps;
+
+    &::before {
+      clip-path: polygon(0% var(--notchSize), var(--notchSize) 0%, calc(100% - var(--notchSize)) 0%, 100% var(--notchSize), 100% calc(100% - var(--notchSize)), calc(100% - var(--notchSize)) 100%, var(--notchSize) 100%, 0% calc(100% - var(--notchSize)));
+      position: absolute;
+      background: var(--statblock-background);
+      content: '';
+      z-index: -1;
+      top: 0.125rem;
+      left: 0.125rem;
+      bottom: 0.125rem;
+      right: 0.125rem;
     }
-    h4.statblock-title {
-      color: color-mix(in oklab, var(--statblock-text-header) 75%, transparent);
-      font-size: var(--font-size-18);
+
+    &::after {
+      position: absolute;
+      content: '';
+      border: 0.125rem solid var(--statblock-color-gold);
+      border-radius: 1.625rem;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      right: 0;
+      pointer-events: none;
     }
+
+    .statblock-title {
+      margin-top: 0.125rem;
+      border-bottom: 0.0625rem solid var(--statblock-dividers);
+
+      a {
+        align-items: center;
+        background: none;
+        border-radius: 0;
+        border: 0;
+        border-bottom: 0.0625rem solid var(--statblock-dividers);
+        color: var(--statblock-text-header);
+        display: flex;
+        font: var(--statblock-font-title-medium);
+        font-size: var(--font-size-24);
+        transition: all var(--t5e-transition-default);
+
+        i {
+          font-size: var(--font-size-16);
+
+          &::before {
+            content: '\f6d5';
+          }
+        }
+
+        &:hover {
+          color: var(--statblock-text-primary);
+        }
+      }
+    }
+
     h5.statblock-actions-title {
       margin-block-start: 8px;
       color: var(--statblock-text-header);
-      font-size: var(--font-size-16);
-      font-weight: normal;
     }
+
     .statblock-tags {
       color: var(--statblock-text-secondary);
       font-style: italic;
+      margin-bottom: var(--t5e-size-2x);
     }
 
     .statblock-content {
       display: column;
       column-width: var(--statblock-column-width);
     }
+
     .statblock-header {
       break-inside: avoid;
-      color: var(--statblock-text-header);
 
       dl {
         display: flex;
         flex-wrap: wrap;
 
-        > div {
+        div {
+          display: flex;
           flex: 1 0 100%;
+          gap: 0.25rem;
+
           &.half-width {
             flex: 1 0 50%;
           }
+
+          dt {
+            color: var(--statblock-text-primary);
+            font-weight: var(--statblock-weight-label);
+            padding-right: 0.125rem;
+          }
+
+          dd {
+            color: var(--statblock-text-primary);
+          }
+
+          >* {
+            margin: 0;
+            padding: 0;
+          }
         }
 
-        div > :is(dt, dd) {
+        div> :is(dt, dd) {
           display: inline;
-          line-height: 1.5;
+          line-height: 1.125rem;
         }
+
         dt {
           color: var(--statblock-text-header);
           text-shadow: none;
         }
       }
+
       .abilities {
-        display: grid;
-        grid-template-columns: 1fr 1fr 1fr;
-        gap: 6px;
+        margin-top: 0.125rem;
+        margin-bottom: 0.125rem;
+        padding-bottom: 0.25rem;
 
         table,
         thead,
@@ -81,15 +184,120 @@
         td {
           all: revert;
         }
-        table {
-          border-collapse: collapse;
+      }
+    }
+
+    .statblock-actions {
+      color: var(--statblock-text-primary);
+
+      .statblock-action {
+        align-items: baseline;
+        gap: 0.25rem;
+
+        >p:first-child>.name {
+          display: inline;
+          font-style: italic;
+          font-weight: bold;
+
+          &::after {
+            content: '.';
+            display: inline;
+          }
         }
+
+        a,
+        button {
+          display: contents;
+          cursor: inherit;
+          pointer-events: none;
+
+          :is(.fas, .fa-solid, .far, .fa-regular) {
+            display: none;
+          }
+        }
+
+        >* {
+          display: inline;
+          line-height: 1rem;
+        }
+      }
+
+      >* {
+        margin-bottom: 0.375rem;
+        display: flex;
+        flex-direction: column;
+      }
+
+      h5.statblock-actions-title {
+        border-bottom: 0.0625rem solid var(--statblock-dividers);
+        font: var(--statblock-font-title-small);
+      }
+    }
+  }
+
+  .double-column .statblock {
+    max-width: calc(var(--statblock-column-width) * 2);
+
+    .statblock-content {
+      columns: 2;
+    }
+  }
+
+  p {
+    margin: 0;
+    display: inline;
+  }
+
+
+  .statblock.npc.rules-2014 {
+
+    .statblock-header .abilities {
+      display: flex;
+      flex-direction: row;
+      gap: 0.0625rem;
+
+      .ability {
+        background: var(--statblock-ability-header-1st);
+        border-radius: 0.0625rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        flex: 1;
+        max-width: initial;
+        padding: 0.0625rem;
+
+        .name {
+          color: var(--statblock-text-header);
+          font-weight: var(--statblock-weight-label);
+          text-transform: uppercase;
+        }
+
+        .score {
+          color: var(--statblock-text-primary);
+        }
+      }
+    }
+  }
+
+  .statblock.npc.rules-2024 {
+    .statblock-header {
+      color: var(--statblock-text-header);
+
+      .abilities {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 0.375rem;
+
+
+        table {
+          border-collapse: separate;
+          border-spacing: 0 0.0625rem;
+        }
+
         thead th {
           color: var(--statblock-text-secondary);
-          font-family: var(--dnd5e-font-roboto);
-          font-size: var(--font-size-10);
-          font-weight: normal;
-          text-transform: uppercase;
+          font: var(--statblock-font-label-small);
+          text-transform: initial;
 
           &.visually-hidden {
             clip: rect(0 0 0 0);
@@ -99,66 +307,78 @@
             white-space: nowrap;
           }
         }
+
         tbody {
           tr {
-            border-block: 1px solid white;
+            border-radius: 0.0625rem;
+
             &:nth-of-type(odd) {
+
               th,
               .score {
                 background: var(--statblock-ability-header-1st);
               }
+
               td {
                 background: var(--statblock-ability-stat-1st);
               }
             }
+
             &:nth-of-type(even) {
+
               th,
               .score {
                 background: var(--statblock-ability-header-2nd);
               }
+
               td {
                 background: var(--statblock-ability-stat-2nd);
               }
             }
           }
+
           th {
-            font-variant: small-caps;
+            font-variant: normal;
+            text-transform: uppercase;
+            font-weight: var(--statblock-weight-label);
           }
+
           td {
+            color: var(--statblock-text-primary);
             text-align: center;
-          }
-        }
-      }
-    }
-
-    .statblock-actions {
-      color: var(--statblock-text-primary);
-
-      .statblock-action {
-        > p:first-child > .name {
-          font-style: italic;
-          font-weight: bold;
-          &::after {
-            content: '. ';
-          }
-        }
-        a,
-        button {
-          display: contents;
-          cursor: inherit;
-          pointer-events: none;
-          :is(.fas, .fa-solid, .far, .fa-regular) {
-            display: none;
           }
         }
       }
     }
   }
 
-  .double-column .statblock {
-    max-width: calc(var(--statblock-column-width) * 2);
-    .statblock-content {
-      columns: 2;
+
+  &.classic .statblock.npc {
+    background: var(--statblock-color-gold);
+    gap: 0.25rem;
+
+    .statblock-title {
+      a i {
+        color: var(--statblock-text-gold);
+      }
     }
+  }
+
+  .flexible-editor-container {
+    flex: 1;
+
+    display: flex;
+    flex-direction: column;
+
+    prose-mirror {
+      flex: 1;
+    }
+  }
+
+  fieldset .editor-rendered-content {
+    flex: auto;
+    margin-top: 0.25rem;
+    margin-bottom: 0.25rem;
+    border: none;
   }
 }

--- a/src/sheets/quadrone/Tidy5eActorSheetQuadroneBase.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eActorSheetQuadroneBase.svelte.ts
@@ -172,14 +172,10 @@ export function Tidy5eActorSheetQuadroneBase<
           }).render({ force: true });
         },
         showArtwork: async function (this: Tidy5eActorSheetQuadroneBase) {
-          const showTokenPortrait =
-            this.actor.flags.dnd5e?.[CONSTANTS.SYSTEM_FLAG_SHOW_TOKEN_PORTRAIT];
-          const token = this.actor.isToken
-            ? this.actor.token
-            : this.actor.prototypeToken;
-          const img = showTokenPortrait ? token.texture.src : this.actor.img;
+          const { src } = await this._preparePortrait(this.actor);
+
           new foundry.applications.apps.ImagePopout({
-            src: img,
+            src,
             uuid: this.actor.uuid,
             window: { title: this.actor.name },
           }).render({ force: true });
@@ -304,14 +300,6 @@ export function Tidy5eActorSheetQuadroneBase<
         doc: this.actor,
       });
 
-      const showToken =
-        this.actor.flags.dnd5e?.[CONSTANTS.SYSTEM_FLAG_SHOW_TOKEN_PORTRAIT] ===
-          true || themeSettings.portraitShape === 'token';
-
-      const effectiveToken = this.actor.isToken
-        ? this.actor.token
-        : this.actor.prototypeToken;
-
       const rollData = this.actor.getRollData();
 
       let context: ActorSheetQuadroneContext = {
@@ -404,7 +392,6 @@ export function Tidy5eActorSheetQuadroneBase<
         shape: showToken ? 'token' : themeSettings.portraitShape ?? 'round',
         isVideo,
         isRandom,
-        truePath: isRandom ? rawSrc : undefined,
       };
     }
 

--- a/src/sheets/quadrone/Tidy5eNpcSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eNpcSheetQuadrone.svelte.ts
@@ -577,7 +577,19 @@ export class Tidy5eNpcSheetQuadrone extends Tidy5eActorSheetQuadroneBase(
   async rollFormula() {
     try {
       const roll = await this.document.rollNPCHitPoints();
-      this.actor.update({ 'system.attributes.hp.max': roll.total });
+
+      const updates: Record<string, any> = {
+        'system.attributes.hp.max': roll.total,
+      };
+
+      if (
+        this.actor.system.attributes.hp.value ===
+        this.actor.system.attributes.hp.max
+      ) {
+        updates['actor.system.attributes.hp.value'] = roll.total;
+      }
+
+      this.actor.update(updates);
     } catch (error) {
       ui.notifications.error('DND5E.HPFormulaError', { localize: true });
       throw error;

--- a/src/sheets/quadrone/actor/GroupSheet.svelte
+++ b/src/sheets/quadrone/actor/GroupSheet.svelte
@@ -103,7 +103,7 @@
             class="button short-rest button-gold flexshrink"
             data-tooltip="DND5E.REST.Short.Label"
             aria-label={localize('DND5E.REST.Short.Label')}
-            onclick={() => context.sheet.shortRest()}
+            onclick={() => context.actor.shortRest()}
           >
             <i class="fas fa-utensils"></i>
             {localize('DND5E.REST.Short.Label')}

--- a/src/sheets/quadrone/actor/parts/ActorPortrait.svelte
+++ b/src/sheets/quadrone/actor/parts/ActorPortrait.svelte
@@ -92,7 +92,7 @@
       disablepictureinpicture
       class={['pointer', { dead: actorIsDead }]}
       data-action={context.unlocked ? 'editImageVideo' : 'showArtwork'}
-      data-edit={context.portrait.truePath ?? context.portrait.path}
+      data-path={context.portrait.path}
       title={imageAlt}>{imageUrl}</video
     >
   {:else}
@@ -101,7 +101,7 @@
       alt={imageAlt}
       class={['pointer', { dead: actorIsDead }]}
       data-action={context.unlocked ? 'editImage' : 'showArtwork'}
-      data-edit={context.portrait.truePath ?? context.portrait.path}
+      data-path={context.portrait.path}
     />
   {/if}
   {#if actorIsDead}

--- a/src/sheets/quadrone/item/columns/GroupVehicleCrewColumn.svelte
+++ b/src/sheets/quadrone/item/columns/GroupVehicleCrewColumn.svelte
@@ -25,8 +25,8 @@
   class="meter meter-small progress capacity"
   style="--bar-percentage: {crewPct}%;"
 ></div>
-<div class="flexrow">
-  <span class="font-data-large color-text-default">{crewCount}</span>
+<div class="flexrow truncate damage-formula-container" data-tooltip={`${crewCount} / ${crewMax}`}>
+  <span class="font-data-medium color-text-default">{crewCount}</span>
   <span class="font-body-medium color-text-lightest separator">/</span>
   <span class="font-label-medium color-text-default">{crewMax}</span>
 </div>

--- a/src/sheets/quadrone/item/columns/ItemTimeColumn.svelte
+++ b/src/sheets/quadrone/item/columns/ItemTimeColumn.svelte
@@ -6,6 +6,8 @@
 
   let { rowDocument: item, rowContext }: ColumnCellProps = $props();
 
+const localize = FoundryAdapter.localize;
+
   let inferredActivation = $derived(
     item.system.activities
       ? firstOfSet<any>(item.system.activities)?.activation
@@ -16,15 +18,19 @@
     FoundryAdapter.getActivationText(inferredActivation?.type),
   );
 
-  const localize = FoundryAdapter.localize;
+  let fullLabel = $derived(
+    (inferredActivation?.value ?? '') + ' ' + localize(abbrOrLabel.label)
+  );
 </script>
 
 {#if !isNil(abbrOrLabel.abbreviation, '')}
-  {inferredActivation?.value ?? ''}<span data-tooltip={abbrOrLabel.label} class="uppercase"
+  {inferredActivation?.value ?? ''}<span data-tooltip={abbrOrLabel.label} class="property-time uppercase"
     >{localize(abbrOrLabel.abbreviation)}</span
   >
 {:else if !isNil(abbrOrLabel.label, '')}
-  {inferredActivation?.value ?? ''} {localize(abbrOrLabel.label)}
+  <span class="truncate property-time" data-tooltip={fullLabel}>
+    {fullLabel}
+  </span>
 {:else}
-  <span class="color-text-disabled">—</span>
+  <span class="property-time color-text-disabled">—</span>
 {/if}

--- a/src/theme/theme-quadrone-detached.ts
+++ b/src/theme/theme-quadrone-detached.ts
@@ -1,0 +1,27 @@
+import { ThemeQuadrone } from './theme-quadrone.svelte';
+
+const _detachedWindowIdsToStylesheets = new Map<string, CSSStyleSheet>();
+
+Hooks.on('openDetachedWindow', function (id: string, window: Window) {
+  const detachedDocument = window.document;
+  const detachedWindow = detachedDocument.defaultView;
+
+  if (!detachedWindow) {
+    return;
+  }
+
+  const copiedStylesheet = new detachedWindow.CSSStyleSheet();
+
+  _detachedWindowIdsToStylesheets.set(id, copiedStylesheet);
+  ThemeQuadrone.subscribeStylesheet(copiedStylesheet);
+
+  detachedDocument.adoptedStyleSheets.push(copiedStylesheet);
+});
+
+Hooks.on('closeDetachedWindow', function (id: string) {
+  const stylesheet = _detachedWindowIdsToStylesheets.get(id);
+  if (stylesheet) {
+    _detachedWindowIdsToStylesheets.delete(id);
+    ThemeQuadrone.unsubscribeStylesheet(stylesheet);
+  }
+});

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -983,7 +983,6 @@ export type ActorSheetQuadroneContext<TSheet = any> = {
     shape: PortraitShape;
     path: string;
     isVideo: boolean;
-    truePath: string | undefined;
   };
   rollData: any;
   saves: ActorSaves;


### PR DESCRIPTION
- Ensured Foundry theme colors carry over to Foundry V14 Detached Windows. Addresses part of #1400 
- Fixed: Group sheet short rest button was not working.
- New: When rolling NPC HP, if the HP value is equal to the HP max, then HP value is now updated to match the new HP max.
- Fixed: When using Vehicle sheet crew labels like "30 crew / 40 passengers", the Group sheet crew column was strange. Thank you hightouch!
- Fixed: 2014-style statblock embeds had some layout issues. Thank you hightouch!
- Fixed: Time column was not handling longer text like Legendary Action very well. Thank you hightouch!
- Various style adjustments that make the sheets feel nice. Thank you hightouch!
- Fixed: Actor portrait paths could not be changed when the actor had wildcard tokens configured. Addresses #1401 