### PR TITLE
NPC Creature Type Fixes

### DIFF
--- a/src/sheets/quadrone/Tidy5eNpcSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eNpcSheetQuadrone.svelte.ts
@@ -134,7 +134,6 @@ export class Tidy5eNpcSheetQuadrone extends Tidy5eActorSheetQuadroneBase(
         actorContext.items
       ),
       conditions: conditions,
-      creatureType: this._getCreatureType(),
       currencies,
       effects: enhancedEffectSections,
       enriched: {

--- a/src/sheets/quadrone/actor/encounter-parts/EncounterMemberNameColumn.svelte
+++ b/src/sheets/quadrone/actor/encounter-parts/EncounterMemberNameColumn.svelte
@@ -94,13 +94,7 @@
         CONFIG.DND5E.actorSizes[member.actor.system.traits.size]?.label ??
         member.actor.system.traits.size}
 
-      {@const creatureType =
-        member.actor.system.details.type.value === 'custom'
-          ? member.actor.system.details.type.custom
-          : CONFIG.DND5E.creatureTypes[member.actor.system.details.type.value]
-              ?.label}
-
-      {@const creatureSubtype = member.actor.system.details.type.subtype}
+      {@const creatureType = member.actor.system.details.type.label}
 
       <span class="separated-list">
         <!-- <span class="cr">
@@ -118,9 +112,6 @@
           <span class="creature-type">
             <span class="font-label-medium color-text-gold-emphasis">
               {creatureType}
-              {#if creatureSubtype}
-                ({creatureSubtype})
-              {/if}
             </span>
           </span>
         {/if}

--- a/src/sheets/quadrone/actor/group-parts/GroupMemberNameColumn.svelte
+++ b/src/sheets/quadrone/actor/group-parts/GroupMemberNameColumn.svelte
@@ -116,57 +116,49 @@
           CONFIG.DND5E.actorSizes[member.actor.system.traits.size]?.label ??
           member.actor.system.traits.size}
 
-        {@const creatureType =
-          member.actor.system.details.type.value === 'custom'
-            ? member.actor.system.details.type.custom
-            : CONFIG.DND5E.creatureTypes[member.actor.system.details.type.value]
-                ?.label}
-
-        {@const creatureSubtype = member.actor.system.details.type.subtype}
+        {@const creatureType = member.actor.system.details.type.label}
 
         {@const classes = Object.values<Item5e>(member.actor.classes)}
 
-        {#if classes.length > 0}
-          <span class="separated-list">
-            {#each classes as thisClass, index}
-              <div class="class-names">
-                <span class="font-label-medium color-text-gold-emphasis"
-                  >{thisClass.name}</span
-                >
-                <span class="font-data-medium color-text-default"
-                  >{thisClass.system.levels}</span
-                >
-                {#if index < classes.length - 1}
-                  <div class="divider-dot"></div>
-                {/if}
-              </div>
-            {/each}
+        <span class="separated-list">
+          {#each classes as thisClass, index}
+            <div class="class-names">
+              <span class="font-label-medium color-text-gold-emphasis"
+                >{thisClass.name}</span
+              >
+              <span class="font-data-medium color-text-default"
+                >{thisClass.system.levels}</span
+              >
 
-        <div class="divider-dot"></div>
-        <span class="cr">
-          <span class="font-label-medium color-text-gold-emphasis"
-            >{localize('DND5E.AbbreviationCR')}</span
-          >
-          <span class="font-data-medium color-text-default">{formattedCr}</span>
-        </span>
-        <div class="divider-dot"></div>
-        <span class="size">
-          <span class="font-label-medium color-text-gold-emphasis">{size}</span>
-        </span>
-
-            {#if creatureType}
               <div class="divider-dot"></div>
-              <span class="creature-type">
-                <span class="font-label-medium color-text-gold-emphasis">
-                  {creatureType}
-                  {#if creatureSubtype}
-                    ({creatureSubtype})
-                  {/if}
-                </span>
-              </span>
-            {/if}
+            </div>
+          {/each}
+
+          <span class="cr">
+            <span class="font-label-medium color-text-gold-emphasis"
+              >{localize('DND5E.AbbreviationCR')}</span
+            >
+            <span class="font-data-medium color-text-default"
+              >{formattedCr}</span
+            >
           </span>
-        {/if}
+
+          <div class="divider-dot"></div>
+          <span class="size">
+            <span class="font-label-medium color-text-gold-emphasis"
+              >{size}</span
+            >
+          </span>
+
+          {#if creatureType}
+            <div class="divider-dot"></div>
+            <span class="creature-type">
+              <span class="font-label-medium color-text-gold-emphasis">
+                {creatureType}
+              </span>
+            </span>
+          {/if}
+        </span>
       {:else if member.actor.type === CONSTANTS.SHEET_TYPE_VEHICLE}
         {@const vehicleType =
           CONFIG.DND5E.vehicleTypes[member.actor.system.vehicleType] ??

--- a/src/sheets/quadrone/actor/npc-parts/NpcSubtitle.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/NpcSubtitle.svelte
@@ -72,14 +72,11 @@
         <span class="font-label-medium color-text-gold">{size}</span>
       </span>
     {/if}
-    {#if !isNil(context.creatureType?.title, '')}
+    {#if !isNil(context.system.details.type.label, '')}
       <div class="divider-dot"></div>
       <span class="creature-type">
         <span class="font-label-medium color-text-gold">
-          {context.creatureType.title}
-          {#if context.creatureType.subtitle}
-            ({context.creatureType.subtitle})
-          {/if}
+          {context.system.details.type.label}
         </span>
       </span>
     {/if}

--- a/src/sheets/quadrone/actor/npc-parts/traits/NpcTraitCreatureType.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/traits/NpcTraitCreatureType.svelte
@@ -15,8 +15,8 @@
   let creatureTypeEntries = $derived.by(() => {
     let result: ActorTraitContext[] = [];
 
-    if (!isNil(context.creatureType?.title, '')) {
-      result.push({ label: context.creatureType?.title });
+    if (!isNil(context.system.details.type.label, '')) {
+      result.push({ label: context.system.details.type.label });
     }
 
     return result;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1229,7 +1229,6 @@ export type NpcSheetQuadroneContext = {
   classes: ActorClassEntryContext[];
   conditions: Dnd5eActorCondition[];
   containerPanelItems: ContainerPanelItemContext[];
-  creatureType: CreatureTypeContext;
   currencies: CurrencyContext[];
   effects: ActiveEffectSection[];
   enriched: {


### PR DESCRIPTION
- Fixed: NPC Creature types were not showing Swarm information. 
- Fixed: Group Member NPC Subtitle was not showing at all for NPCs without classes.