### PR TITLE
Fix: Item Equipment AC Label

### DIFF
--- a/src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte.ts
@@ -835,6 +835,17 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin(
     return undefined;
   }
 
+  static ShouldShowAc(item: Item5e) {
+    return (
+      item.system.armor?.value &&
+      (item.system.isArmor || item.system.type.value === 'shield')
+    );
+  }
+
+  _shouldShowAc() {
+    return Tidy5eItemSheetQuadrone.ShouldShowAc(this.item);
+  }
+
   /* -------------------------------------------- */
   /*  Drag and Drop                               */
   /* -------------------------------------------- */

--- a/src/sheets/quadrone/item/EquipmentSheet.svelte
+++ b/src/sheets/quadrone/item/EquipmentSheet.svelte
@@ -24,13 +24,16 @@
   let itemNameEl: HTMLElement | undefined = $state();
 
   let subtitle = $derived(
-    [context.item.system.type?.label, context.labels.armor]
+    [
+      context.item.system.type?.label,
+      context.sheet._shouldShowAc() ? context.labels.armor : null,
+    ]
       .filter((x) => !isNil(x, ''))
       .join(', '),
   );
 
   let armorPills = $derived.by(() => {
-    if (!context.system.isArmor) {
+    if (!context.sheet._shouldShowAc()) {
       return [];
     }
 


### PR DESCRIPTION
- Fixed: AC Labels were showing for equipment even when the equipment was changed from armor or shield to a different type.