### PR TITLE
fix: Classic item / container sheets locked?

### DIFF
--- a/src/mixins/TidyDocumentSheetMixin.svelte.ts
+++ b/src/mixins/TidyDocumentSheetMixin.svelte.ts
@@ -60,6 +60,8 @@ export function TidyExtensibleDocumentSheetMixin<
   }>
 >(sheetType: string, BaseApplication: any) {
   class TidyDocumentSheet extends DragAndDropMixin(BaseApplication) {
+    // TODO: Remove _fixedMode when classic sheets are gone
+    _fixedMode: number | undefined;
     _mode = $state<number | undefined>();
     _headerControlSettings: Map<string, SheetHeaderControlPosition> = new Map();
 
@@ -127,7 +129,14 @@ export function TidyExtensibleDocumentSheetMixin<
     };
 
     get sheetMode() {
-      return this._mode;
+      return this._fixedMode ?? this._mode;
+    }
+
+    set sheetMode(value) {
+      if (this._fixedMode !== undefined) {
+        return;
+      }
+      this._mode = value;
     }
 
     /**
@@ -224,7 +233,7 @@ export function TidyExtensibleDocumentSheetMixin<
         mode = CONSTANTS.SHEET_MODE_EDIT;
       }
 
-      this._mode = mode ?? this._mode ?? CONSTANTS.SHEET_MODE_PLAY;
+      this.sheetMode = mode ?? this.sheetMode ?? CONSTANTS.SHEET_MODE_PLAY;
     }
 
     async _prepareContext(
@@ -502,7 +511,7 @@ export function TidyExtensibleDocumentSheetMixin<
      * @protected
      */
     async changeSheetMode(mode: number) {
-      this._mode = mode;
+      this.sheetMode = mode;
       await this.submit();
       this._applySheetModeClass(this.element);
       await this.render();
@@ -514,7 +523,7 @@ export function TidyExtensibleDocumentSheetMixin<
      */
     async toggleSheetMode() {
       const newMode =
-        this._mode === CONSTANTS.SHEET_MODE_PLAY
+        this.sheetMode === CONSTANTS.SHEET_MODE_PLAY
           ? CONSTANTS.SHEET_MODE_EDIT
           : CONSTANTS.SHEET_MODE_PLAY;
 

--- a/src/sheets/classic/Tidy5eContainerSheetClassic.svelte.ts
+++ b/src/sheets/classic/Tidy5eContainerSheetClassic.svelte.ts
@@ -52,6 +52,8 @@ export class Tidy5eContainerSheetClassic extends TidyExtensibleDocumentSheetMixi
   constructor(options?: Partial<ApplicationConfiguration> | undefined) {
     super(options);
 
+    this._fixedMode = CONSTANTS.SHEET_MODE_EDIT;
+
     this.itemFilterService = new ItemFilterService({}, this.item);
 
     this.sectionExpansionTracker = new ExpansionTracker(

--- a/src/sheets/classic/Tidy5eItemSheetClassic.svelte.ts
+++ b/src/sheets/classic/Tidy5eItemSheetClassic.svelte.ts
@@ -41,7 +41,9 @@ export class Tidy5eItemSheetClassic extends TidyExtensibleDocumentSheetMixin(
 
   constructor(options?: Partial<ApplicationConfiguration> | undefined) {
     super(options);
-
+    
+    this._fixedMode = CONSTANTS.SHEET_MODE_EDIT;
+    
     this.sectionExpansionTracker = new ExpansionTracker(
       true,
       this.document,


### PR DESCRIPTION
- Fixed: Classic item / container sheets sometimes act as though locked and prevent actions like setting the image.