### PR TITLE
Bug: Nullish Species in Character Traits

### DIFF
--- a/src/sheets/quadrone/actor/character-parts/traits/CharacterTraitSpecies.svelte
+++ b/src/sheets/quadrone/actor/character-parts/traits/CharacterTraitSpecies.svelte
@@ -8,7 +8,7 @@
 
   const localize = FoundryAdapter.localize;
 
-  let species = $derived(context.species);
+  let species = $derived(context.species?.id ? context.species : null);
 
   function openSheet(mode: number) {
     if (species) {


### PR DESCRIPTION
- Fixed: For some characters without a selected species, the species add / compendium buttons were not appearing.