### PR TITLE
Bug: Duplicate Header Controls

### DIFF
--- a/src/applications/header-control-configuration/WorldHeaderControlConfigurationQuadroneApplication.svelte.ts
+++ b/src/applications/header-control-configuration/WorldHeaderControlConfigurationQuadroneApplication.svelte.ts
@@ -103,7 +103,12 @@ export class WorldHeaderControlConfigurationQuadroneApplication extends SvelteAp
       }),
     });
 
-    const controls = [...sheet.getAllHeaderControls()];
+    const controls = [...sheet.getAllHeaderControls()].sort((l, r) =>
+      FoundryAdapter.localize(l.label ?? '').localeCompare(
+        FoundryAdapter.localize(r.label ?? ''),
+        game.i18n.lang
+      )
+    );
 
     const headerSet = new Set(
       (

--- a/src/mixins/TidyDocumentSheetMixin.svelte.ts
+++ b/src/mixins/TidyDocumentSheetMixin.svelte.ts
@@ -680,7 +680,12 @@ export function TidyExtensibleDocumentSheetMixin<
         options
       ) as DocumentSheetConfiguration;
 
-      const effectiveControls = [...(updatedOptions.window?.controls ?? [])];
+      const headerControls = new Map<string, CustomHeaderControlsEntry>();
+
+      [...(updatedOptions.window?.controls ?? [])].forEach((c) =>
+        headerControls.set(c.label, c)
+      );
+
       const effectiveActions = { ...(updatedOptions.actions ?? {}) };
 
       try {
@@ -701,6 +706,8 @@ export function TidyExtensibleDocumentSheetMixin<
           updatedOptions.document
         );
 
+        customControls.controls.forEach((c) => headerControls.set(c.label, c));
+
         /*
           Rather than update the source object, make a new one and spread the actions across.
           Otherwise, it has a chance of updating DEFAULT_OPTIONS.
@@ -711,10 +718,7 @@ export function TidyExtensibleDocumentSheetMixin<
           ...effectiveActions,
           ...customControls.actions,
         };
-        updatedOptions.window.controls = [
-          ...effectiveControls,
-          ...customControls.controls,
-        ];
+        updatedOptions.window.controls = [...headerControls.values()];
 
         this._headerControlSettings = this._getHeaderControlSettings(
           options.document
@@ -802,7 +806,7 @@ export function TidyExtensibleDocumentSheetMixin<
       };
     }
 
-    getAllHeaderControls() {
+    getAllHeaderControls(): ApplicationHeaderControlsEntry[] {
       return this.options.window.controls?.slice() ?? [];
     }
 


### PR DESCRIPTION
- Fixed: Some header controls were appearing multiple times, due to multiple means of registering header controls. Tidy now takes the last duplicate it sees, preferring Tidy-registered controls and then those which are added in the standard App V2 manner.