### PR TITLE
Fix: Weapon Activity and Effects tab missing

### DIFF
--- a/src/runtime/item/ItemSheetQuadroneRuntime.svelte.ts
+++ b/src/runtime/item/ItemSheetQuadroneRuntime.svelte.ts
@@ -613,12 +613,7 @@ export const ItemSheetQuadroneRuntime = new ItemSheetQuadroneRuntimeImpl(
       CONSTANTS.ITEM_TYPE_LOOT,
       {
         component: LootSheet,
-        defaultTabs: [
-          CONSTANTS.TAB_DESCRIPTION,
-          CONSTANTS.TAB_ITEM_DETAILS,
-          CONSTANTS.TAB_ITEM_ACTIVITIES,
-          CONSTANTS.TAB_EFFECTS,
-        ],
+        defaultTabs: [CONSTANTS.TAB_DESCRIPTION, CONSTANTS.TAB_ITEM_DETAILS],
       },
     ],
     [
@@ -671,7 +666,12 @@ export const ItemSheetQuadroneRuntime = new ItemSheetQuadroneRuntimeImpl(
       CONSTANTS.ITEM_TYPE_WEAPON,
       {
         component: WeaponSheet,
-        defaultTabs: [CONSTANTS.TAB_DESCRIPTION, CONSTANTS.TAB_ITEM_DETAILS],
+        defaultTabs: [
+          CONSTANTS.TAB_DESCRIPTION,
+          CONSTANTS.TAB_ITEM_DETAILS,
+          CONSTANTS.TAB_ITEM_ACTIVITIES,
+          CONSTANTS.TAB_EFFECTS,
+        ],
       },
     ],
   ]


### PR DESCRIPTION
- Fixed: Weapon sheets were not showing Activity or Effect tabs.
#1458 
