### PR TITLE
fix: add missing mode on activities

### DIFF
--- a/src/components/table-quadrone/TidyInlineActivitiesList.svelte
+++ b/src/components/table-quadrone/TidyInlineActivitiesList.svelte
@@ -90,6 +90,7 @@
         <a
           class={['tidy-table-row-use-button', { disabled: !context.editable }]}
           onclick={(ev) => item.isOwner && rollActivity(ctx.activity, ev)}
+          data-has-roll-modes
         >
           <img
             class="item-image"


### PR DESCRIPTION
Activities didn't have the indicator on. 

Unsure if you want to add logic to change whether or not the modes exists based on activity type (e.g use probably doesn't, likewise with saves). The issue with this is that custom activities would be more challenging to include.