### PR TITLE
Feature / Statblock Tab for Little Lost Items

### DIFF
--- a/src/features/sections/CharacterSheetSections.ts
+++ b/src/features/sections/CharacterSheetSections.ts
@@ -15,6 +15,7 @@ import { TidyFlags } from 'src/foundry/TidyFlags';
 import { FoundryAdapter } from 'src/foundry/foundry-adapter';
 import { SheetSections } from './SheetSections';
 import { isNil } from 'src/utils/data';
+import { Inventory } from './Inventory';
 
 export class CharacterSheetSections {
   static buildClassicFeaturesSections(
@@ -374,8 +375,6 @@ export class CharacterSheetSections {
   ) {
     if (item.type === CONSTANTS.ITEM_TYPE_SPELL) {
       partitions.spells.push(item);
-    } else if (item.type === CONSTANTS.ITEM_TYPE_FEAT) {
-      partitions.feats.push(item);
     } else if (item.type === CONSTANTS.ITEM_TYPE_RACE) {
       partitions.species.push(item);
     } else if (item.type === CONSTANTS.ITEM_TYPE_BACKGROUND) {
@@ -388,6 +387,8 @@ export class CharacterSheetSections {
       partitions.facilities.push(item);
     } else if (Object.keys(inventory).includes(item.type)) {
       partitions.items.push(item);
+    } else if (SheetSections.showInFeatures(item)) {
+      partitions.feats.push(item);
     }
   }
 

--- a/src/features/sections/SheetSections.ts
+++ b/src/features/sections/SheetSections.ts
@@ -879,4 +879,18 @@ export class SheetSections {
 
     return sections;
   }
+
+  static showInFeatures(item: Item5e) {
+      return (
+        !item.type.includes([
+          CONSTANTS.ITEM_TYPE_CONTAINER,
+          CONSTANTS.ITEM_TYPE_SPELL,
+          CONSTANTS.ITEM_TYPE_BACKGROUND,
+          CONSTANTS.ITEM_TYPE_CLASS,
+          CONSTANTS.ITEM_TYPE_SUBCLASS,
+          CONSTANTS.ITEM_TYPE_RACE,
+          CONSTANTS.ITEM_TYPE_FACILITY,
+        ]) && !Inventory.isItemInventoryType(item)
+      );
+    }
 }

--- a/src/sheets/quadrone/Tidy5eActorSheetQuadroneBase.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eActorSheetQuadroneBase.svelte.ts
@@ -893,7 +893,7 @@ export function Tidy5eActorSheetQuadroneBase<
       };
     }
 
-    protected abstract _getSheetPinTabIdsForItem(sheetPin: Item5e): string[];
+    protected abstract _getSheetPinTabIdsForItem(item: Item5e): string[];
 
     async _getSheetPins(): Promise<SheetPinContext[]> {
       let flagPins = TidyFlags.sheetPins

--- a/src/sheets/quadrone/Tidy5eCharacterSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eCharacterSheetQuadrone.svelte.ts
@@ -938,14 +938,14 @@ export class Tidy5eCharacterSheetQuadrone extends Tidy5eActorSheetQuadroneBase<C
     );
   }
 
-  protected _getSheetPinTabIdsForItem(sheetPin: Item5e): string[] {
+  protected _getSheetPinTabIdsForItem(item: Item5e): string[] {
     const tabIds: string[] = [CONSTANTS.TAB_ACTOR_ACTIONS];
 
-    const originTab = Inventory.isItemInventoryType(sheetPin)
+    const originTab = Inventory.isItemInventoryType(item)
       ? CONSTANTS.TAB_ACTOR_INVENTORY
-      : sheetPin.type === CONSTANTS.ITEM_TYPE_SPELL
+      : item.type === CONSTANTS.ITEM_TYPE_SPELL
       ? CONSTANTS.TAB_ACTOR_SPELLBOOK
-      : sheetPin.type === CONSTANTS.ITEM_TYPE_FEAT
+      : SheetSections.showInFeatures(item)
       ? CONSTANTS.TAB_CHARACTER_FEATURES
       : null;
 

--- a/src/sheets/quadrone/Tidy5eEncounterSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eEncounterSheetQuadrone.svelte.ts
@@ -358,10 +358,10 @@ export class Tidy5eEncounterSheetQuadrone extends Tidy5eMultiActorSheetQuadroneB
     }
   }
 
-  protected _getSheetPinTabIdsForItem(sheetPin: Item5e): string[] {
+  protected _getSheetPinTabIdsForItem(item: Item5e): string[] {
     const tabIds: string[] = [CONSTANTS.TAB_MEMBERS];
 
-    if (Inventory.isItemInventoryType(sheetPin)) {
+    if (Inventory.isItemInventoryType(item)) {
       tabIds.push(CONSTANTS.TAB_ACTOR_INVENTORY);
     }
 

--- a/src/sheets/quadrone/Tidy5eGroupSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eGroupSheetQuadrone.svelte.ts
@@ -419,10 +419,10 @@ export class Tidy5eGroupSheetQuadrone extends Tidy5eMultiActorSheetQuadroneBase<
     });
   }
 
-  protected _getSheetPinTabIdsForItem(sheetPin: Item5e): string[] {
+  protected _getSheetPinTabIdsForItem(item: Item5e): string[] {
     const tabIds: string[] = [CONSTANTS.TAB_MEMBERS];
 
-    if (Inventory.isItemInventoryType(sheetPin)) {
+    if (Inventory.isItemInventoryType(item)) {
       tabIds.push(CONSTANTS.TAB_ACTOR_INVENTORY);
     }
 

--- a/src/sheets/quadrone/Tidy5eNpcSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eNpcSheetQuadrone.svelte.ts
@@ -402,7 +402,7 @@ export class Tidy5eNpcSheetQuadrone extends Tidy5eActorSheetQuadroneBase<NpcShee
     this.actor.items.forEach((item: Item5e) => {
       if (
         !inventoryTypesSet.has(item.type) &&
-        item.type !== CONSTANTS.ITEM_TYPE_FEAT
+        !SheetSections.showInFeatures(item)
       ) {
         return;
       }
@@ -496,13 +496,12 @@ export class Tidy5eNpcSheetQuadrone extends Tidy5eActorSheetQuadroneBase<NpcShee
     );
 
     const applyStandardItemHeaderActions = (section: TidyItemSectionBase) => {
-      section.sectionActions =
-        SectionActions.getStandardItemHeaderActions(
-          this.actor,
-          this.actor.isOwner,
-          context.unlocked,
-          section
-        );
+      section.sectionActions = SectionActions.getStandardItemHeaderActions(
+        this.actor,
+        this.actor.isOwner,
+        context.unlocked,
+        section
+      );
     };
 
     context.inventory = Object.values(inventory);
@@ -513,13 +512,12 @@ export class Tidy5eNpcSheetQuadrone extends Tidy5eActorSheetQuadroneBase<NpcShee
     context.spellbook = spellbook;
 
     context.spellbook.forEach((section) => {
-      section.sectionActions =
-        SectionActions.getSpellbookItemHeaderActions(
-          this.actor,
-          this.actor.isOwner,
-          context.unlocked,
-          section
-        );
+      section.sectionActions = SectionActions.getSpellbookItemHeaderActions(
+        this.actor,
+        this.actor.isOwner,
+        context.unlocked,
+        section
+      );
     });
 
     context.features = Object.values(featureSections);
@@ -599,12 +597,12 @@ export class Tidy5eNpcSheetQuadrone extends Tidy5eActorSheetQuadroneBase<NpcShee
     return [npcSpellcasting];
   }
 
-  protected _getSheetPinTabIdsForItem(sheetPin: Item5e): string[] {
+  protected _getSheetPinTabIdsForItem(item: Item5e): string[] {
     const tabIds: string[] = [CONSTANTS.TAB_NPC_STATBLOCK];
 
-    const originTab = Inventory.isItemInventoryType(sheetPin)
+    const originTab = Inventory.isItemInventoryType(item)
       ? CONSTANTS.TAB_ACTOR_INVENTORY
-      : sheetPin.type === CONSTANTS.ITEM_TYPE_SPELL
+      : item.type === CONSTANTS.ITEM_TYPE_SPELL
       ? CONSTANTS.TAB_ACTOR_SPELLBOOK
       : null;
 

--- a/src/sheets/quadrone/actor/tabs/ActorInventoryTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/ActorInventoryTab.svelte
@@ -49,7 +49,7 @@
     ),
   );
 
-  let showSheetPin = $derived(
+  let showSheetPins = $derived(
     UserSheetPreferencesService.getDocumentTypeTabPreference(
       context.document.type,
       tabId,
@@ -70,7 +70,7 @@
 <div class="inventory-content">
   <InventoryActionBar bind:searchCriteria sections={inventory} {tabId} />
 
-  {#if showSheetPin}
+  {#if showSheetPins}
     <SheetPins />
   {/if}
 

--- a/src/sheets/quadrone/actor/tabs/ActorSpellbookTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/ActorSpellbookTab.svelte
@@ -111,7 +111,7 @@
     },
   ]);
 
-  let showSheetPin = $derived(
+  let showSheetPins = $derived(
     UserSheetPreferencesService.getDocumentTypeTabPreference(
       context.document.type,
       tabId,
@@ -131,7 +131,7 @@
 
 <ItemsActionBar bind:searchCriteria sections={spellbook} {tabId} {tabOptionGroups} />
 
-{#if showSheetPin}
+{#if showSheetPins}
   <SheetPins />
 {/if}
 

--- a/src/sheets/quadrone/actor/tabs/CharacterActionsTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/CharacterActionsTab.svelte
@@ -48,7 +48,7 @@
     },
   ]);
 
-  let showSheetPin = $derived(
+  let showSheetPins = $derived(
     UserSheetPreferencesService.getDocumentTypeTabPreference(
       context.document.type,
       tabId,
@@ -68,7 +68,7 @@
 
 <ItemsActionBar bind:searchCriteria sections={actions} {tabId} {tabOptionGroups} />
 
-{#if showSheetPin}
+{#if showSheetPins}
   <SheetPins />
 {/if}
 

--- a/src/sheets/quadrone/actor/tabs/CharacterFeaturesTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/CharacterFeaturesTab.svelte
@@ -49,7 +49,7 @@
     },
   ]);
 
-  let showSheetPin = $derived(
+  let showSheetPins = $derived(
     UserSheetPreferencesService.getDocumentTypeTabPreference(
       context.document.type,
       tabId,
@@ -69,7 +69,7 @@
 
 <ItemsActionBar bind:searchCriteria sections={features} {tabId} {tabOptionGroups} />
 
-{#if showSheetPin}
+{#if showSheetPins}
   <SheetPins />
 {/if}
 

--- a/src/sheets/quadrone/actor/tabs/EncounterInventoryTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/EncounterInventoryTab.svelte
@@ -39,7 +39,7 @@
     ),
   );
 
-  let showSheetPin = $derived(
+  let showSheetPins = $derived(
     UserSheetPreferencesService.getDocumentTypeTabPreference(
       context.document.type,
       tabId,
@@ -61,7 +61,7 @@
   <div class="inventory-content">
     <InventoryActionBar bind:searchCriteria sections={inventory} {tabId} />
 
-    {#if showSheetPin}
+    {#if showSheetPins}
       <SheetPins />
     {/if}
 

--- a/src/sheets/quadrone/actor/tabs/EncounterMembersTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/EncounterMembersTab.svelte
@@ -33,7 +33,7 @@
     sectionsInlineWidth = entry.borderBoxSize[0].inlineSize;
   }
 
-  let showSheetPin = $derived(
+  let showSheetPins = $derived(
     UserSheetPreferencesService.getDocumentTypeTabPreference(
       context.document.type,
       CONSTANTS.TAB_MEMBERS,
@@ -56,7 +56,7 @@
   class="group-tab-content group-members-content flexcol"
   bind:this={sectionsContainer}
 >
-  {#if showSheetPin}
+  {#if showSheetPins}
     <SheetPins />
   {/if}
 

--- a/src/sheets/quadrone/actor/tabs/GroupInventoryTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/GroupInventoryTab.svelte
@@ -43,7 +43,7 @@
     ),
   );
 
-  let showSheetPin = $derived(
+  let showSheetPins = $derived(
     UserSheetPreferencesService.getDocumentTypeTabPreference(
       context.document.type,
       tabId,
@@ -168,7 +168,7 @@
   <div class="inventory-content">
     <InventoryActionBar bind:searchCriteria sections={inventory} {tabId} />
 
-    {#if showSheetPin}
+    {#if showSheetPins}
       <SheetPins />
     {/if}
 

--- a/src/sheets/quadrone/actor/tabs/GroupMembersTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/GroupMembersTab.svelte
@@ -36,7 +36,7 @@
     sectionsInlineWidth = entry.borderBoxSize[0].inlineSize;
   }
 
-  const showSheetPin = $derived(
+  const showSheetPins = $derived(
     UserSheetPreferencesService.getDocumentTypeTabPreference(
       context.document.type,
       CONSTANTS.TAB_MEMBERS,
@@ -103,7 +103,7 @@
     {tabOptionGroups}
   />
 
-  {#if showSheetPin}
+  {#if showSheetPins}
     <SheetPins />
   {/if}
 

--- a/src/sheets/quadrone/actor/tabs/NpcStatblockTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/NpcStatblockTab.svelte
@@ -169,7 +169,7 @@
     );
   });
 
-  let showSheetPin = $derived(
+  let showSheetPins = $derived(
     UserSheetPreferencesService.getDocumentTypeTabPreference(
       context.document.type,
       tabId,
@@ -195,7 +195,7 @@
   </div>
 {/if}
 
-{#if showSheetPin}
+{#if showSheetPins}
   <SheetPins />
 {/if}
 


### PR DESCRIPTION
- Fixed: For some modules that add non-inventory item subtypes to dnd5e, Tidy was not showing them in the Other Features section of the Features tab for Characters and Statblock tab for NPCs.