### PR TITLE
Truncate-and-tooltip

### DIFF
--- a/src/sheets/quadrone/item/tabs/ItemAdvancementTab.svelte
+++ b/src/sheets/quadrone/item/tabs/ItemAdvancementTab.svelte
@@ -214,7 +214,7 @@
             <TidyTableCell {...columnSpecs.value}>
               {#if !isNil(advancement.value)}
                 {@const value = advancement.value?.toString()}
-                <span>
+                <span class="truncate" data-tooltip={value}>
                   {value}
                 </span>
               {:else}


### PR DESCRIPTION
- Fixed: The Value column in the Advancement table was not handling long strings of text like scale value paths well. Now it truncates and has a tooltip.