### PR TITLE
Feature/mobile responsive

### DIFF
--- a/src/less/quadrone/actors.less
+++ b/src/less/quadrone/actors.less
@@ -1374,6 +1374,13 @@
     }
   }
 
+  // Override: prevent external modules from reversing the inventory tab flex direction on mobile.
+  @media (max-width: 800px) {
+    &.actor.character .tidy-tab.inventory.tidy-tab-contents.active {
+      flex-direction: column;
+    }
+  }
+
   .tidy-tab.inventory {
 
     .inline-content-view .currency-container {

--- a/src/less/quadrone/actors.less
+++ b/src/less/quadrone/actors.less
@@ -8,7 +8,7 @@
   container-type: inline-size;
 
   &:not(.minimized) {
-    min-width: 43.75rem;
+    min-width: 20rem; /* 320px - mobile friendly */
   }
 
   section.window-content {

--- a/src/less/quadrone/actors.less
+++ b/src/less/quadrone/actors.less
@@ -8,7 +8,7 @@
   container-type: inline-size;
 
   &:not(.minimized) {
-    min-width: 20rem; /* 320px - mobile friendly */
+    min-width: 23rem; /* 368px - mobile friendly */
   }
 
   section.window-content {

--- a/src/less/quadrone/character.less
+++ b/src/less/quadrone/character.less
@@ -1,6 +1,6 @@
 .tidy5e-sheet.application:where(.quadrone.character) {
   &:not(.minimized) {
-    min-width: 43.75rem;
+    min-width: 20rem; /* 320px - mobile friendly */
   }
 
   .sheet-header {

--- a/src/less/quadrone/character.less
+++ b/src/less/quadrone/character.less
@@ -9,6 +9,10 @@
       display: none;
     }
 
+    .death-saves-mobile-accordion {
+      display: none;
+    }
+
     .show-xp {
       .actor-details-name-row {
         margin-top: var(--t5e-size-1x);
@@ -509,6 +513,7 @@
       }
     }
 
+
     .abilities-container-inner {
       margin-left: 0;
     }
@@ -522,9 +527,7 @@
       padding: 4px 8px;
     }
 
-    .actor-vitals-container {
-      width: calc(100% - 20px);
-    }
+    
 
     .actor-context-row {
       .actor-name {
@@ -560,6 +563,7 @@
         flex-direction: column;
 
         .actor-vitals-container {
+          width: calc(100% - 20px);
           order: -1;
           max-width: 100%;
           padding-bottom: 0;
@@ -568,6 +572,10 @@
           flex-direction: row;
           align-items: flex-start;
           gap: var(--t5e-size-2x);
+
+          .death-saves-overlay{
+            display: none;
+          }
 
           .actor-image {
             min-width: 3.63rem;
@@ -621,6 +629,66 @@
         &.header-collapsed {
           .header-collapsible {
             grid-template-rows: 0fr;
+          }
+        }
+
+        .death-saves-mobile-accordion {
+          order: -1;
+          display: grid;
+          grid-template-rows: 0fr;
+          transition: grid-template-rows 0.3s ease;
+          width: 100%;
+          flex-basis: 100%;
+
+          > * {
+            overflow: hidden;
+          }
+
+          &.active {
+            grid-template-rows: 1fr;
+          }
+
+          .death-saves-mobile-inner {
+            .death-saves-overlay {
+              position: relative;
+              top: auto;
+              left: auto;
+              right: auto;
+              bottom: auto;
+              display: flex;
+              flex-direction: row;
+              align-items: center;
+              justify-content: center;
+              padding: var(--t5e-size-1x) 0;
+
+              .failures,
+              .successes {
+                position: relative;
+                top: auto;
+                transform: none;
+                flex-direction: row;
+                gap: var(--t5e-size-1x);
+              }
+
+              .death-save-roll-button {
+                position: relative;
+                top: auto;
+                left: auto;
+                transform: none;
+                // opacity: 1;
+                // animation: none;
+                margin: 0 12px;
+
+                i {
+                  font-size: 1.75rem;
+                }
+              }
+
+              &:hover .death-save-roll-button {
+                // opacity: 1;
+                // animation: none;
+              }
+            }
           }
         }
 

--- a/src/less/quadrone/character.less
+++ b/src/less/quadrone/character.less
@@ -1,9 +1,13 @@
 .tidy5e-sheet.application:where(.quadrone.character) {
   &:not(.minimized) {
-    min-width: 20rem; /* 320px - mobile friendly */
+    min-width: 23rem; /* 368px - mobile friendly */
   }
 
   .sheet-header {
+
+    .header-collapse-toggle {
+      display: none;
+    }
 
     .show-xp {
       .actor-details-name-row {
@@ -583,6 +587,40 @@
             flex: 1;
             margin-top: 0;
             width: auto;
+          }
+
+          .header-collapse-toggle {
+            display: flex;
+            align-self: center;
+            flex-shrink: 0;
+            color: var(--t5e-color-text-lighter);
+            opacity: 0.7;
+            transition: opacity var(--t5e-transition-default);
+
+            &:hover {
+              opacity: 1;
+            }
+
+            i {
+              transition: transform 0.3s ease;
+            }
+          }
+        }
+
+        .header-collapsible {
+          display: grid;
+          grid-template-rows: 1fr;
+          transition: grid-template-rows 0.3s ease;
+          width: 100%;
+
+          > * {
+            overflow: hidden;
+          }
+        }
+
+        &.header-collapsed {
+          .header-collapsible {
+            grid-template-rows: 0fr;
           }
         }
 

--- a/src/less/quadrone/character.less
+++ b/src/less/quadrone/character.less
@@ -497,6 +497,108 @@
   }
 
 
+  @container actor-sheet (max-width: 34rem) {
+    .tabs-row {
+      > .sidebar-toggle {
+        z-index: 1;
+        background-color: var(--t5e-component-card-darker);
+      }
+    }
+
+    .abilities-container-inner {
+      margin-left: 0;
+    }
+
+    .sheet-header .abilities-container {
+      margin-right: 0;
+    }
+
+    .actor-details-container.flexcol {
+      width: 100%;
+      padding: 4px 8px;
+    }
+
+    .actor-vitals-container {
+      width: calc(100% - 20px);
+    }
+
+    .actor-context-row {
+      .actor-name {
+        margin-left: 0;
+      }
+
+      .actor-subtitle.flexrow {
+        margin-left: 0;
+      }
+    }
+
+    .sidebar.flexcol {
+      position: absolute;
+      height: 100%;
+      background-color: #19191b;
+      z-index: 10;
+      border-right: 1px solid #02020278;
+      box-shadow: 6px 6px #0000002e;
+    }
+
+    .tabs-row .tidy-tabs.actor-tabs {
+      justify-content: flex-start;
+      gap: var(--t5e-size-3x);
+      padding-inline-start: 2.5rem;
+
+      > .tab-option {
+        padding: 0.375rem 0.2rem;
+      }
+    }
+
+    .sheet-header {
+      .sheet-header-content {
+        flex-direction: column;
+
+        .actor-vitals-container {
+          order: -1;
+          max-width: 100%;
+          padding-bottom: 0;
+          margin-left: 0;
+          display: flex;
+          flex-direction: row;
+          align-items: flex-start;
+          gap: var(--t5e-size-2x);
+
+          .actor-image {
+            min-width: 3.63rem;
+            max-width: 3.63rem;
+            max-height: 3.63rem;
+
+            img {
+              height: 3.63rem;
+              width: 3.63rem;
+              border-radius: 2px;
+            }
+          }
+
+          .actor-vitals {
+            position: relative;
+            bottom: auto;
+            flex: 1;
+            margin-top: 0;
+            width: auto;
+          }
+        }
+
+        .actor-details-container {
+          .actor-name {
+            font-size: 2rem;
+          }
+
+          .sheet-header-actions-container {
+            padding-top: 4px;
+          }
+        }
+      }
+    }
+  }
+
   &.theme-dark,
   .theme-dark {
 

--- a/src/less/quadrone/header.less
+++ b/src/less/quadrone/header.less
@@ -642,6 +642,7 @@
     position: relative;
     padding-bottom: 2rem;
     max-width: 11.25rem;
+    flex-wrap: wrap-reverse;
 
     .actor-image {
       --inset: 0.3125rem;

--- a/src/less/quadrone/items.less
+++ b/src/less/quadrone/items.less
@@ -123,7 +123,7 @@
   }
 
   &:not(:is(.minimized, .minimizing, .maximizing)) {
-    min-width: 31.25rem;
+    min-width: 20rem; /* 320px - mobile friendly */
   }
 
   .header-control {

--- a/src/sheets/quadrone/actor/CharacterSheet.svelte
+++ b/src/sheets/quadrone/actor/CharacterSheet.svelte
@@ -15,6 +15,7 @@
   import { untrack } from 'svelte';
   import { UserSheetPreferencesService } from 'src/features/user-preferences/SheetPreferencesService';
   import AbilitiesContainer from './parts/AbilitiesContainer.svelte';
+  import DeathSavesOverlay from './character-parts/DeathSavesOverlay.svelte';
   import { CONSTANTS } from 'src/constants';
 
   let context = $derived(getCharacterSheetQuadroneContext());
@@ -667,6 +668,11 @@
       >
         <i class={headerCollapsed ? 'fas fa-chevron-down' : 'fas fa-chevron-up'}></i>
       </button>
+      <div class={['death-saves-mobile-accordion', { active: context.showDeathSaves }]}>
+        <div class="death-saves-mobile-inner">
+          {#if context.showDeathSaves} <DeathSavesOverlay /> {/if}
+        </div>
+      </div>
     </div>
   </div>
   <div class="tabs-row">

--- a/src/sheets/quadrone/actor/CharacterSheet.svelte
+++ b/src/sheets/quadrone/actor/CharacterSheet.svelte
@@ -26,6 +26,7 @@
   let selectedTabId: string = $derived(context.currentTabId);
 
   let sidebarExpanded = $state(true);
+  let headerCollapsed = $state(false);
 
   // When the user changes tabs, check their preference on the new tab and apply expanded state.
   $effect(() => {
@@ -97,7 +98,8 @@
 </script>
 
 <header class="sheet-header flexcol">
-  <div class="sheet-header-content flexrow">
+  <div class={['sheet-header-content flexrow', { 'header-collapsed': headerCollapsed }]}>
+    <div class="header-collapsible">
     <div class="actor-details-container flexcol">
       <div
         class="actor-context-row flexrow {context.enableXp ? 'show-xp' : ''}"
@@ -333,6 +335,7 @@
           {/if}
         </div>
       </AbilitiesContainer>
+    </div>
     </div>
     <div class="actor-vitals-container">
       <!-- TODO: Add switch for size -->
@@ -655,6 +658,15 @@
           {/if}
         </div>
       </div>
+      <button
+        type="button"
+        class="header-collapse-toggle button button-borderless button-icon-only"
+        onclick={() => (headerCollapsed = !headerCollapsed)}
+        aria-label={headerCollapsed ? localize('JOURNAL.ViewExpand') : localize('JOURNAL.ViewCollapse')}
+        data-tooltip={headerCollapsed ? localize('JOURNAL.ViewExpand') : localize('JOURNAL.ViewCollapse')}
+      >
+        <i class={headerCollapsed ? 'fas fa-chevron-down' : 'fas fa-chevron-up'}></i>
+      </button>
     </div>
   </div>
   <div class="tabs-row">


### PR DESCRIPTION
## feat(mobile): Responsive layout for Quadrone character sheet

This PR adds mobile-responsive support for the Quadrone character sheet, allowing it to be used comfortably at narrow viewport widths (down to ~368px).

### Changes

**Minimum width reduction**
- Character sheet: `43.75rem → 23rem` (700px → 368px)
- Item sheets: `31.25rem → 20rem` (500px → 320px)

This unblocks use on narrow windows, mobile browsers, or small secondary monitors.

**Responsive header layout (`@container actor-sheet (max-width: 34rem)`)**
- Header content reflows to a vertical column layout at narrow widths
- Actor portrait, vitals, and name row adapt to available space
- Sidebar overlays content (absolute positioned with z-index) instead of pushing it

**Header collapse toggle**
- A new collapse/expand button appears in narrow widths
- Collapses the header's detail section (abilities, traits, etc.) using a CSS grid `grid-template-rows` animation to free up vertical space
- Uses existing `JOURNAL.ViewExpand` / `JOURNAL.ViewCollapse` i18n keys for accessibility

**Death saves mobile accordion**
- At narrow widths the `DeathSavesOverlay` is hidden from its normal position (overlapping the portrait)
- A dedicated accordion slot below the vitals row shows/hides death saves via the same CSS grid transition, driven by the existing `context.showDeathSaves` reactive value

**Inventory tab fix**
- Added a `@media (max-width: 800px)` override to prevent external modules from reversing `flex-direction` on the inventory tab

### Testing

- [ ] Character sheet opens and is functional at 368px width
- [ ] Header collapse toggle hides/shows details with animation
- [ ] Death saves accordion appears and functions when character is dying
- [ ] Sidebar opens as overlay at narrow widths without breaking tab content
- [ ] No visual regressions at normal (≥700px) widths
- [ ] New distribution at 34rem (<544px)
- [ ] Item sheets open correctly at reduced minimum width

### Tested on

Manually tested on iPhone SE resolution (375×667) using the [Sheet Only](https://foundryvtt.com/packages/sheet-only) module to render the sheet in isolation. Screenshots will be added shortly.

<img width="373" height="667" alt="screenshot_2026-03-25_20-51-58" src="https://github.com/user-attachments/assets/27284bcd-ba16-40e6-8900-f05d6ab81894" />
<img width="374" height="668" alt="screenshot_2026-03-25_21-05-58" src="https://github.com/user-attachments/assets/f7aeed0f-a4c5-41af-97f7-62821a94464a" />
<img width="375" height="669" alt="screenshot_2026-03-25_21-06-08" src="https://github.com/user-attachments/assets/09b27ad8-90a2-47c4-b5fa-86a1bedac71b" />
<img width="376" height="670" alt="screenshot_2026-03-25_21-06-16" src="https://github.com/user-attachments/assets/77162418-9594-4af8-ae56-9e63e6361ea7" />
