### PR TITLE
fixed: In "Low" performance mode, the sheet sections don't collapse

### DIFF
--- a/src/components/expandable/ExpandableContainer.svelte
+++ b/src/components/expandable/ExpandableContainer.svelte
@@ -4,6 +4,8 @@
   import { onMount, untrack, type Snippet } from 'svelte';
   import type { HTMLAttributes } from 'svelte/elements';
 
+  // TODO: There has to be a better way than all this, and perhaps a more performant approach?
+
   type Props = {
     expanded?: boolean;
     children?: Snippet;

--- a/src/components/expandable/ExpandableContainer.svelte
+++ b/src/components/expandable/ExpandableContainer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { usePerformanceMode } from 'src/settings/settings.svelte';
   import { EventHelper } from 'src/utils/events';
   import { onMount, untrack, type Snippet } from 'svelte';
   import type { HTMLAttributes } from 'svelte/elements';
@@ -22,19 +23,36 @@
     ...rest
   }: Props = $props();
 
+  // svelte-ignore state_referenced_locally
   let overflowYHidden = $state(!expanded);
   let expandableContainer: HTMLElement;
 
+  // svelte-ignore state_referenced_locally
   let renderContents = $state<boolean>(expanded);
 
+  const usesTransitions = !usePerformanceMode();
+
+  $effect(() => {
+    if (usesTransitions) {
+      return;
+    }
+
+    expanded;
+    onStart();
+    onEnd();
+  });
+
   onMount(() => {
+    if (!usesTransitions) {
+      return;
+    }
     const controller = new AbortController();
 
     expandableContainer.addEventListener(
       'transitionstart',
       (ev) => {
         if (ev.target === expandableContainer) {
-          overflowYHidden = true;
+          onStart();
         }
       },
       {
@@ -47,8 +65,7 @@
       'transitionend',
       (ev) => {
         if (ev.target === expandableContainer) {
-          overflowYHidden = !expanded;
-          renderContents = expanded;
+          onEnd();
         }
       },
       {
@@ -66,7 +83,16 @@
     if (expanded) {
       renderContents = true;
     }
-  })
+  });
+
+  function onStart() {
+    overflowYHidden = true;
+  }
+
+  function onEnd() {
+    overflowYHidden = !expanded;
+    renderContents = expanded;
+  }
 </script>
 
 <div

--- a/src/settings/settings.svelte.ts
+++ b/src/settings/settings.svelte.ts
@@ -2158,11 +2158,16 @@ export let SettingsProvider: ReturnType<typeof createSettings>;
 
 export type Tidy5eSheetsPerformanceClassToggles = [string, boolean][];
 
-export function getTidyPerformanceSettings(): Tidy5eSheetsPerformanceClassToggles {
-  const performanceModeEnabled =
+export function usePerformanceMode(): boolean {
+  return (
     (SettingsProvider.settings.debug.get() &&
       SettingsProvider.settings.performanceMode.get()) ||
-    foundryCoreSettings.value.performanceMode === 0;
+    foundryCoreSettings.value.performanceMode === 0
+  );
+}
+
+export function getTidyPerformanceSettings(): Tidy5eSheetsPerformanceClassToggles {
+  const performanceModeEnabled = usePerformanceMode();
 
   return [
     ['disable-shadows', performanceModeEnabled],


### PR DESCRIPTION
From one of the dnd5e foundry communities out there.