### PR TITLE
fix: Having spellbook in statblock tab with identical custom sections from both sections crashes tab

### DIFF
--- a/src/sheets/quadrone/Tidy5eNpcSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eNpcSheetQuadrone.svelte.ts
@@ -387,7 +387,7 @@ export class Tidy5eNpcSheetQuadrone extends Tidy5eActorSheetQuadroneBase<NpcShee
 
     const featureSections = Object.entries(
       CONFIG.DND5E.activityActivationTypes
-    ).reduce<Record<string, FeatureSection>>((obj, [id, config], i) => {
+    ).reduce<Record<string, FeatureSection | SpellbookSection>>((obj, [id, config], i) => {
       const label = config.header ?? config.label;
 
       if (!!config.passive) {
@@ -531,14 +531,10 @@ export class Tidy5eNpcSheetQuadrone extends Tidy5eActorSheetQuadroneBase<NpcShee
     });
 
     if (context.includeSpellbookInStatblockTab) {
-      const featuresAndSpells: Record<
-        string,
-        FeatureSection | SpellbookSection
-      > = featureSections;
       context.spellbook.forEach((section) => {
-        const addSpells = !!featuresAndSpells[section.key];
+        const addSpells = !!featureSections[section.key];
         
-        const addedOrUpdated = (featuresAndSpells[section.key] ??= {
+        const addedOrUpdated = (featureSections[section.key] ??= {
           ...section,
         });
         

--- a/src/sheets/quadrone/Tidy5eNpcSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eNpcSheetQuadrone.svelte.ts
@@ -10,6 +10,7 @@ import type {
   NpcItemQuadroneContext,
   NpcSheetQuadroneContext,
   NpcSpellcastingContext,
+  SpellbookSection,
   SpellcastingClassContext,
   TidyItemSectionBase,
 } from 'src/types/types';
@@ -528,6 +529,24 @@ export class Tidy5eNpcSheetQuadrone extends Tidy5eActorSheetQuadroneBase<NpcShee
         section
       );
     });
+
+    if (context.includeSpellbookInStatblockTab) {
+      const featuresAndSpells: Record<
+        string,
+        FeatureSection | SpellbookSection
+      > = featureSections;
+      context.spellbook.forEach((section) => {
+        const addSpells = !!featuresAndSpells[section.key];
+        
+        const addedOrUpdated = (featuresAndSpells[section.key] ??= {
+          ...section,
+        });
+        
+        if (addSpells) {
+          addedOrUpdated.items.push(...section.items);
+        }
+      });
+    }
 
     context.features = Object.values(featureSections);
 

--- a/src/sheets/quadrone/actor/tabs/NpcStatblockTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/NpcStatblockTab.svelte
@@ -155,13 +155,8 @@
   });
 
   let sections = $derived.by(() => {
-    let sectionsToConfigure: (FeatureSection | SpellbookSection)[] =
-      context.includeSpellbookInStatblockTab
-        ? [...context.features, ...context.spellbook]
-        : context.features;
-
     return SheetSections.configureStatblock(
-      sectionsToConfigure,
+      context.features,
       context,
       tabId,
       UserSheetPreferencesService.getByType(context.actor.type),

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1380,7 +1380,7 @@ export type NpcSheetQuadroneContext = {
     publicBiography: string;
     trait: string;
   };
-  features: FeatureSection[];
+  features: (FeatureSection | SpellbookSection)[];
   gear: ActorTraitContext[];
   habitats: { label: string }[];
   important: boolean;


### PR DESCRIPTION
from the community: https://discord.com/channels/1167985253072257115/1492217548660539412

> Hi, I'm not sure whether this is on my end or if anyone else if having any trouble with this, but on the Tidy sheets whenever I open an NPC I can't see any of their features. Here is what the modern Tidy sheet looks like vs. the classic Tidy sheet (where the features show up).
