### PR TITLE
Vehicle spells section enhancements

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -909,6 +909,7 @@
   "TIDY5E.Utilities.CastActivitySpellGroupingTitle": "Cast Activity Spell Grouping",
   "TIDY5E.Utilities.CastActivitySpellGroupingOptionAdditional": "Additional Spells section",
   "TIDY5E.Utilities.CastActivitySpellGroupingOptionPerItem": "Section Per Item",
+  "TIDY5E.Utilities.CastActivityMissingSpell": "No spell is attached to this activity.",
   "TIDY5E.Utilities.ShowSheetPins": "Show Sheet Pins",
   "TIDY5E.Utilities.HideSheetPins": "Hide Sheet Pins",
   "TIDY5E.Utilities.ShowLegendaryTrackersOnNpcStatblock": "Show Legendary/Lair trackers in the Statblock tab",

--- a/src/features/activities/activities.ts
+++ b/src/features/activities/activities.ts
@@ -69,6 +69,11 @@ export class Activities {
             activationAbbr
           )}`
         : activity.labels.activation,
+      spell: activity.spell
+        ? {
+            uuid: activity.spell.uuid,
+          }
+        : undefined,
       save: activity.save
         ? {
             ability: activity.save.ability?.size
@@ -80,6 +85,7 @@ export class Activities {
           }
         : null,
       toHit: isNaN(toHit) ? null : toHit,
+      type: activity.type,
     };
   }
 

--- a/src/features/sections/SheetSections.ts
+++ b/src/features/sections/SheetSections.ts
@@ -505,6 +505,17 @@ export class SheetSections {
       // Apply visibility from configuration
       section.show = sectionConfig?.[section.key]?.show !== false;
 
+      console.log('section', section);
+
+      // Hide empty spell section since they can only come from activities.
+      if (
+        section.type === CONSTANTS.SECTION_TYPE_INVENTORY &&
+        section.key === CONSTANTS.ITEM_TYPE_SPELL &&
+        section.items.length === 0
+      ) {
+        section.show = false;
+      }
+
       return section;
     });
   }

--- a/src/less/quadrone/sheets.less
+++ b/src/less/quadrone/sheets.less
@@ -108,15 +108,6 @@
       }
     }
 
-    &.empty-classes {
-      flex: 0 1 fit-content;
-
-      .button {
-        padding-inline-start: var(--t5e-size-8x);
-        padding-inline-end: var(--t5e-size-8x);
-      }
-    }
-
     &.empty-state-description {
       padding: var(--t5e-size-3x);
       border-radius: var(--t5e-component-card-radius);

--- a/src/less/quadrone/tables.less
+++ b/src/less/quadrone/tables.less
@@ -776,6 +776,16 @@
     }
   }
 
+  .cast-activity-missing-spell-indicator {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: var(--t5e-color-icon-disabled);
+    font-size: var(--font-size-12);
+    margin-inline-start: var(--t5e-size-1x);
+    margin-inline-end: var(--t5e-size-2x);
+  }
+
   /* Inline Containers */
   .tidy-table-row~.expandable .expandable-child-animation-wrapper {
     padding-inline-start: 1rem;

--- a/src/sheets/quadrone/Tidy5eVehicleSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eVehicleSheetQuadrone.svelte.ts
@@ -247,6 +247,7 @@ export class Tidy5eVehicleSheetQuadrone extends Tidy5eActorSheetQuadroneBase<Veh
       type: CONSTANTS.SHEET_TYPE_VEHICLE,
       utilities: {},
       ...actorContext,
+      spellComponentLabels: FoundryAdapter.getSpellComponentLabels(),
     };
 
     context.useActionsFeature = actorUsesActionFeature(this.actor);

--- a/src/sheets/quadrone/actor/parts/ActorTraitClasses.svelte
+++ b/src/sheets/quadrone/actor/parts/ActorTraitClasses.svelte
@@ -38,19 +38,32 @@
     </div>
 
     <div class="list-content">
-      <div class="list-values trait-item empty-state-container empty-classes">
         <button
-          aria-label="Add {localize('TYPES.Item.class')}"
+          aria-label={localize('TIDY5E.CompendiumBrowser', {
+            name: localize('TYPES.Item.class'),
+          })}
           type="button"
-          class="button button-tertiary"
-          data-tooltip="DND5E.ClassAdd"
+          class="button button-primary"
+          data-tooltip
           data-action="findItem"
           data-item-type="class"
         >
-          <i class="fa-solid fa-plus"></i>
+          <i class="fa-solid fa-book-atlas"></i>
           {localize('DND5E.ClassAdd')}
         </button>
-      </div>
+        <button
+          aria-label={localize('TIDY5E.AddCustom', {
+            name: localize('TYPES.Item.class'),
+          })}
+          type="button"
+          class="button button-secondary"
+          onclick={(ev) =>
+            FoundryAdapter.createItem({ type: 'class' }, context.actor)}
+        >
+          {localize('TIDY5E.AddCustom', {
+            name: localize('TYPES.Item.class'),
+          })}
+        </button>
     </div>
   </div>
 {:else}

--- a/src/sheets/quadrone/item/columns/GroupMemberHpColumn.svelte
+++ b/src/sheets/quadrone/item/columns/GroupMemberHpColumn.svelte
@@ -36,12 +36,23 @@
 </script>
 
 <div
+  role="meter"
+  aria-valuenow={hpValue}
+  aria-valuemin="0"
+  aria-valuemax={effectiveMaxHp}
+  aria-valuetext={hpValue.toString()}
   class="hp-column-content"
   onmouseenter={(ev) => getHpTooltip?.()?.tryShow(ev, rowDocument)}
 >
   <div
     class="meter meter-small progress hit-points"
-    style="--bar-percentage: {hpPct.toFixed(0)}%; --bar-adjusted: {tempHpValue.toFixed(0)}%; --bar-adjusted-background: var(--t5e-color-hp-temp); --bar-adjusted-content: '';"
+    style=
+    {tempHpValue > 0
+      ? `--bar-percentage: ${hpPct.toFixed(0)}%;` +
+        ` --bar-adjusted: ${tempHpValue.toFixed(0)}%;` +
+        ` --bar-adjusted-background: var(--t5e-color-hp-temp);` +
+        ` --bar-adjusted-content: '';`
+      : `--bar-percentage: ${hpPct.toFixed(0)}%;`}
   ></div>
   <div class="flexrow">
     <span class="font-data-medium color-text-default value">{hpValue}</span>

--- a/src/sheets/quadrone/item/columns/ItemSpellComponentsColumn.svelte
+++ b/src/sheets/quadrone/item/columns/ItemSpellComponentsColumn.svelte
@@ -4,6 +4,7 @@
   import type {
     CharacterSheetQuadroneContext,
     NpcSheetQuadroneContext,
+    VehicleSheetQuadroneContext,
   } from 'src/types/types';
 
   let { rowDocument, rowContext }: ColumnCellProps = $props();
@@ -11,7 +12,9 @@
   let context =
     $derived(
       getSheetContext<
-        CharacterSheetQuadroneContext | NpcSheetQuadroneContext
+        | CharacterSheetQuadroneContext
+        | NpcSheetQuadroneContext
+        | VehicleSheetQuadroneContext
       >(),
     );
 </script>

--- a/src/sheets/quadrone/item/tabs/ItemActivitiesTab.svelte
+++ b/src/sheets/quadrone/item/tabs/ItemActivitiesTab.svelte
@@ -98,10 +98,18 @@
       {#each context.activities as ctx (ctx.id)}
         <TidyActivityTableRow {ctx}>
           {#snippet children()}
+            <!-- svelte-ignore a11y_missing_attribute -->
             <a
+              role="button"
+              tabindex="0"
               class={['tidy-table-row-use-button']}
+              aria-label={ctx.activity.name}
               onclick={(ev) =>
                 ctx.activity.use({ event: ev, options: { sheet: context.sheet } })}
+              onkeydown={(ev) =>
+                ev.key === 'Enter' ||
+                (ev.key === ' ' &&
+                  ctx.activity.use({ event: ev, options: { sheet: context.sheet } }))}
               data-has-roll-modes
             >
               <img class="item-image" alt="" src={ctx.activity.img} />
@@ -123,6 +131,12 @@
                 </i>
               </span> -->
               </span>
+              {#if ctx.type === CONSTANTS.ACTIVITY_TYPE_CAST && !ctx.spell?.uuid}
+                <span data-tooltip={localize('TIDY5E.Utilities.CastActivityMissingSpell')} class="cast-activity-missing-spell-indicator">
+                  <i class="fa-solid fa-link-simple-slash"></i>
+                  <!-- TODO: Update to link-broken for FA 7.2.0-->
+                </span>
+              {/if}
             </TidyTableCell>
 
             <TidyTableCustomCells

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -353,7 +353,13 @@ export type ActivityItemContext = {
     ability: string;
   } | null;
   toHit: number | null;
+  spell?: ActivityItemSpellContext;
+  type: string;
 };
+
+export type ActivityItemSpellContext = {
+  uuid?: string;
+}
 
 // TODO: Trim to minimum necessary
 export type FavoriteEffectContext = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1741,6 +1741,7 @@ export type VehicleSheetQuadroneContext = {
   quality: number;
   size: ActorSizeContext;
   speeds: ActorSpeedSenseEntryContext[];
+  spellComponentLabels: Record<string, string>;
   statblock: (InventorySection | DraftAnimalSection)[];
   traits: Record<string, ActorTraitContext[]>;
   travelSpeeds: {


### PR DESCRIPTION
- Hid spell section when 0 spells present since you cannot add them directly
- Added missing linked spell indicator to `cast` activities
- Updated Add Class buttons to match other missing data types
- Updated Group member HP to correctly hide temp HP bar when temp HP = 0