### PR TITLE
feat: Updating effects management for modern system version

### DIFF
--- a/src/components/info-card/Cards/EffectInfoCard.svelte
+++ b/src/components/info-card/Cards/EffectInfoCard.svelte
@@ -55,7 +55,7 @@
 
     <ul style="margin-block-start: 1rem;" class="unlist flex-column small-gap">
       {#each activeEffect.changes as change}
-        {@const modeLabel = ActiveEffectsHelper.findMode(change.mode)}
+        {@const modeLabel = ActiveEffectsHelper.findMode(change)}
         <li>
           <div>
             <strong class="break-word">{change.key}</strong>

--- a/src/components/item-list/EffectSummary.svelte
+++ b/src/components/item-list/EffectSummary.svelte
@@ -48,7 +48,7 @@
       </thead>
       <tbody>
         {#each activeEffect.changes as change}
-          {@const modeLabel = ActiveEffectsHelper.findMode(change.mode)}
+          {@const modeLabel = ActiveEffectsHelper.findMode(change)}
 
           <tr>
             <td

--- a/src/components/table-quadrone/TidyEffectSummary.svelte
+++ b/src/components/table-quadrone/TidyEffectSummary.svelte
@@ -2,7 +2,6 @@
   import { CONSTANTS } from 'src/constants';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
   import type { ActiveEffect5e, EffectSummaryData } from 'src/types/types';
-  import HorizontalLineSeparator from '../layout/HorizontalLineSeparator.svelte';
   import { ActiveEffectsHelper } from 'src/utils/active-effect';
 
   interface Props {
@@ -15,6 +14,19 @@
   let pills = $derived.by(() =>
     ActiveEffectsHelper.getActiveEffectPills(activeEffect),
   );
+
+  let locKeys =
+    game.release.generation >= 14
+      ? {
+          key: 'EFFECT.FIELDS.changes.element.key.label',
+          mode: 'EFFECT.FIELDS.changes.element.type.label',
+          value: 'EFFECT.FIELDS.changes.element.value.label',
+        }
+      : {
+          key: 'EFFECT.ChangeKey',
+          mode: 'EFFECT.ChangeMode',
+          value: 'EFFECT.ChangeValue',
+        };
 
   const localize = FoundryAdapter.localize;
 </script>
@@ -35,19 +47,19 @@
       <thead>
         <tr>
           <th>
-            {localize('EFFECT.ChangeKey')}
+            {localize(locKeys.key)}
           </th>
           <th>
-            {localize('EFFECT.ChangeMode')}
+            {localize(locKeys.mode)}
           </th>
           <th>
-            {localize('EFFECT.ChangeValue')}
+            {localize(locKeys.value)}
           </th>
         </tr>
       </thead>
       <tbody>
         {#each activeEffect.changes as change}
-          {@const modeLabel = ActiveEffectsHelper.findMode(change.mode)}
+          {@const modeLabel = ActiveEffectsHelper.findMode(change)}
 
           <tr>
             <td

--- a/src/components/table-quadrone/TidyEffectTableRow.svelte
+++ b/src/components/table-quadrone/TidyEffectTableRow.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { type OnItemToggledFn } from 'src/types/types';
   import { getContext, type Snippet } from 'svelte';
-  import type { ActiveEffectContext, EffectSummaryData } from 'src/types/types';
+  import type { EffectSummaryData, ActiveEffectContext } from 'src/types/types';
   import { CONSTANTS } from 'src/constants';
   import ExpandableContainer from 'src/components/expandable/ExpandableContainer.svelte';
   import TidyEffectSummary from './TidyEffectSummary.svelte';

--- a/src/features/conditions-and-effects/ConditionsAndEffects.ts
+++ b/src/features/conditions-and-effects/ConditionsAndEffects.ts
@@ -81,6 +81,7 @@ export class ConditionsAndEffects {
             hasTooltip: source instanceof dnd5e.documents.Item5e,
             uuid: effect.uuid,
             effect: effect,
+            riders: []
           });
           return arr;
         },
@@ -168,6 +169,7 @@ export class ConditionsAndEffects {
               hasTooltip: source instanceof dnd5e.documents.Item5e,
               uuid: effect.uuid,
               effect: effect,
+              riders: []
             });
             return arr;
           },
@@ -221,6 +223,7 @@ export class ConditionsAndEffects {
               hasTooltip: true,
               uuid: effect.uuid,
               effect: effect,
+              riders: []
             });
             return arr;
           },

--- a/src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte.ts
@@ -24,7 +24,7 @@ import { FoundryAdapter } from 'src/foundry/foundry-adapter';
 import { initTidy5eContextMenu } from 'src/context-menu/tidy5e-context-menu';
 import { Activities } from 'src/features/activities/activities';
 import { getPercentage } from 'src/utils/numbers';
-import type { ActiveEffect5e, ActiveEffectContext, GroupableSelectOption, SectionCommand } from 'src/types/types';
+import type { ActiveEffect5e, ActiveEffectSection, GroupableSelectOption, ActiveEffectContext } from 'src/types/types';
 import { isNil } from 'src/utils/data';
 import ItemHeaderStart from './item/parts/ItemHeaderStart.svelte';
 import { ItemContext } from 'src/features/item/ItemContext';
@@ -40,7 +40,6 @@ import { SheetTabConfigurationQuadroneApplication } from 'src/applications/tab-c
 import { ThemeSettingsQuadroneApplication } from 'src/applications/theme/ThemeSettingsQuadroneApplication.svelte';
 import type { SpellProgressionConfig } from 'src/foundry/config.types';
 import TableRowActionsRuntime from 'src/runtime/tables/TableRowActionsRuntime.svelte';
-
 
 export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin<
   DocumentSheetApplicationConfiguration | undefined,
@@ -618,6 +617,10 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin<
 
     await this.item.system.getSheetData?.(context);
 
+    context.effects.forEach((s) => {
+      s.rowActions = TableRowActionsRuntime.getEffectsRowActions(context);
+    });
+
     TidyHooks.tidy5eSheetsPreConfigureSections(this, this.element, context);
 
     TidyHooks.tidy5eSheetsPrepareSheetContext(this.document, this, context);
@@ -629,51 +632,80 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin<
  
   async _getEffectsSections() {
     const effectMap: Record<string, ActiveEffectContext> = {};
-    const riders = [];
-    const riderIds = new Set(this.item.getFlag("dnd5e", "riders.effect") ?? []);
-    let effects = dnd5e.applications.components.EffectsElement.prepareCategories(this.item.effects, { parent: this.item });
-    for ( const category of Object.values(effects) ) {
-      category.effects = await (category as any).effects.reduce(async (arr, effect) => {
-        effect.updateDuration();
-        const { id, name, img, disabled, duration } = effect;
-        const source = await effect.getSource();
-        arr = await arr;
-        const ctx = effectMap[id] = { 
-          id, name, img, disabled, duration, source, parent,
-          durationParts: duration.remaining ? duration.label.split(", ") : [],
-          hasTooltip: true,
-          riders: []
-        };
-        if ( riderIds.has(id) ) riders.push(ctx);
-        else arr.push(ctx);
-        return arr;
-      }, []);
+    const riders: ActiveEffectContext[] = [];
+    const riderIds = new Set(this.item.getFlag('dnd5e', 'riders.effect') ?? []);
+    let defaultEffects: Record<string, ActiveEffect5e> =
+      dnd5e.applications.components.EffectsElement.prepareCategories(
+        this.item.effects,
+        { parent: this.item },
+      );
+    
+    let effects: Record<string, ActiveEffectSection> = {};
+    
+    for (const [key, category] of Object.entries(defaultEffects)) {
+      effects[key] = {
+        ...category,
+        effects: await category.effects.reduce(
+          async (arr: ActiveEffectContext[], effect: ActiveEffect5e) => {
+            effect.updateDuration();
+            const { id, name, img, disabled, duration } = effect;
+            const source = await effect.getSource();
+            arr = await arr;
+            const ctx: ActiveEffectContext = (effectMap[id] = {
+              id,
+              uuid: effect.uuid,
+              name,
+              img,
+              disabled,
+              duration,
+              source,
+              parent,
+              durationParts: duration.remaining
+                ? duration.label.split(', ')
+                : [],
+              hasTooltip: true,
+              effect: effect,
+              riders: [],
+            });
+            if (riderIds.has(id)) riders.push(ctx);
+            else arr.push(ctx);
+            return arr;
+          },
+          [],
+        ),
+      };
     }
-    const origins = (this.item.system.activities?.getByType("enchant") ?? [])
-      .flatMap(a => a.effects)
-      .reduce((obj, effects) => {
-        const { _id, riders } = effects;
-        for ( const id of riders.effect ) {
+
+    const origins = (this.item.system.activities?.getByType('enchant') ?? [])
+      .flatMap((a: any) => a.effects)
+      .reduce((obj: Record<string, string[]>, effect: ActiveEffect5e) => {
+        const { _id, riders } = effect;
+        for (const id of riders.effect) {
           obj[id] ??= [];
           obj[id].push(_id);
         }
         return obj;
       }, {});
-    riders.forEach(r => {
-      for ( const origin of origins[r.id] ?? [] ) {
-        if ( origin in effectMap ) effectMap[origin].riders.push(r);
+
+    riders.forEach((r) => {
+      for (const origin of origins[r.id] ?? []) {
+        if (origin in effectMap) effectMap[origin].riders.push(r);
       }
     });
 
-    return Object.entries(effects).map(([key, value]) => ({
-      ...value,
-      canCreate: context.editable && !value.isEnchantment && !value.disabled,
-      dataset: {}, // TODO: put things that help with effect creation via _addDocument here
-      show: !value.hidden,
-      rowActions: TableRowActionsRuntime.getEffectsRowActions(context),
-      sectionActions: [],
-      key,
-    }));
+    return Object.entries(effects).map(
+      ([key, value]) =>
+        ({
+          ...value,
+          canCreate:
+            this.isEditable && !value.isEnchantment && !value.disabled,
+          dataset: {}, // TODO: put things that help with effect creation via _addDocument here
+          show: !value.hidden,
+          rowActions: [],
+          sectionActions: [],
+          key,
+        }) satisfies ActiveEffectSection,
+    );
   }
  
   /* -------------------------------------------- */

--- a/src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte.ts
@@ -24,7 +24,7 @@ import { FoundryAdapter } from 'src/foundry/foundry-adapter';
 import { initTidy5eContextMenu } from 'src/context-menu/tidy5e-context-menu';
 import { Activities } from 'src/features/activities/activities';
 import { getPercentage } from 'src/utils/numbers';
-import type { ActiveEffect5e, ActiveEffectSection, GroupableSelectOption, ActiveEffectContext } from 'src/types/types';
+import type { ActiveEffect5e, ActiveEffectSection, GroupableSelectOption, ActiveEffectContext, DocumentSheetV2Context } from 'src/types/types';
 import { isNil } from 'src/utils/data';
 import ItemHeaderStart from './item/parts/ItemHeaderStart.svelte';
 import { ItemContext } from 'src/features/item/ItemContext';
@@ -383,7 +383,7 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin<
         documentSheetContext.unlocked
       ),
 
-      effects: await this._getEffectsSections(),
+      effects: await this._getEffectsSections(documentSheetContext),
 
       concealDetails:
         !game.user.isGM && this.document.system.identified === false,
@@ -630,7 +630,7 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin<
 
   /* -------------------------------------------- */
  
-  async _getEffectsSections() {
+  async _getEffectsSections(context: DocumentSheetV2Context) {
     const effectMap: Record<string, ActiveEffectContext> = {};
     const riders: ActiveEffectContext[] = [];
     const riderIds = new Set(this.item.getFlag('dnd5e', 'riders.effect') ?? []);
@@ -700,7 +700,7 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin<
           canCreate:
             this.isEditable && !value.isEnchantment && !value.disabled,
           dataset: {}, // TODO: put things that help with effect creation via _addDocument here
-          show: !value.hidden,
+          show: !value.hidden || !!value.effects.length,
           rowActions: [],
           sectionActions: [],
           key,

--- a/src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte.ts
@@ -383,7 +383,7 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin<
         documentSheetContext.unlocked
       ),
 
-      effects: await this._getEffectsSections(documentSheetContext),
+      effects: await this._getEffectsSections(),
 
       concealDetails:
         !game.user.isGM && this.document.system.identified === false,
@@ -630,7 +630,7 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin<
 
   /* -------------------------------------------- */
  
-  async _getEffectsSections(context: DocumentSheetV2Context) {
+  async _getEffectsSections() {
     const effectMap: Record<string, ActiveEffectContext> = {};
     const riders: ActiveEffectContext[] = [];
     const riderIds = new Set(this.item.getFlag('dnd5e', 'riders.effect') ?? []);

--- a/src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte.ts
@@ -24,7 +24,7 @@ import { FoundryAdapter } from 'src/foundry/foundry-adapter';
 import { initTidy5eContextMenu } from 'src/context-menu/tidy5e-context-menu';
 import { Activities } from 'src/features/activities/activities';
 import { getPercentage } from 'src/utils/numbers';
-import type { ActiveEffect5e, GroupableSelectOption } from 'src/types/types';
+import type { ActiveEffect5e, ActiveEffectContext, GroupableSelectOption, SectionCommand } from 'src/types/types';
 import { isNil } from 'src/utils/data';
 import ItemHeaderStart from './item/parts/ItemHeaderStart.svelte';
 import { ItemContext } from 'src/features/item/ItemContext';
@@ -34,12 +34,13 @@ import {
   TidyExtensibleDocumentSheetMixin,
   type TidyDocumentSheetRenderOptions,
 } from 'src/mixins/TidyDocumentSheetMixin.svelte';
-import { ConditionsAndEffects } from 'src/features/conditions-and-effects/ConditionsAndEffects';
 import { SheetSections } from 'src/features/sections/SheetSections';
 import { ItemSheetRuntime } from 'src/runtime/item/ItemSheetRuntime';
 import { SheetTabConfigurationQuadroneApplication } from 'src/applications/tab-configuration/SheetTabConfigurationQuadroneApplication.svelte';
 import { ThemeSettingsQuadroneApplication } from 'src/applications/theme/ThemeSettingsQuadroneApplication.svelte';
 import type { SpellProgressionConfig } from 'src/foundry/config.types';
+import TableRowActionsRuntime from 'src/runtime/tables/TableRowActionsRuntime.svelte';
+
 
 export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin<
   DocumentSheetApplicationConfiguration | undefined,
@@ -292,18 +293,6 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin<
 
     const target = this.item.type === 'spell' ? this.item.system.target : null;
 
-    const defaultEffectCategories =
-      dnd5e.applications.components.EffectsElement.prepareCategories(
-        this.document.effects,
-        { parent: this.item }
-      );
-
-    const enhancedEffectsCategories =
-      await ConditionsAndEffects.getEffectsForItem(
-        documentSheetContext,
-        defaultEffectCategories
-      );
-
     const context: ItemSheetQuadroneContext = {
       activities: (this.document.system.activities ?? [])
         .filter((a: any) => {
@@ -395,7 +384,7 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin<
         documentSheetContext.unlocked
       ),
 
-      effects: enhancedEffectsCategories,
+      effects: await this._getEffectsSections(),
 
       concealDetails:
         !game.user.isGM && this.document.system.identified === false,
@@ -637,6 +626,58 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin<
   }
 
   /* -------------------------------------------- */
+ 
+  async _getEffectsSections() {
+    const effectMap: Record<string, ActiveEffectContext> = {};
+    const riders = [];
+    const riderIds = new Set(this.item.getFlag("dnd5e", "riders.effect") ?? []);
+    let effects = dnd5e.applications.components.EffectsElement.prepareCategories(this.item.effects, { parent: this.item });
+    for ( const category of Object.values(effects) ) {
+      category.effects = await (category as any).effects.reduce(async (arr, effect) => {
+        effect.updateDuration();
+        const { id, name, img, disabled, duration } = effect;
+        const source = await effect.getSource();
+        arr = await arr;
+        const ctx = effectMap[id] = { 
+          id, name, img, disabled, duration, source, parent,
+          durationParts: duration.remaining ? duration.label.split(", ") : [],
+          hasTooltip: true,
+          riders: []
+        };
+        if ( riderIds.has(id) ) riders.push(ctx);
+        else arr.push(ctx);
+        return arr;
+      }, []);
+    }
+    const origins = (this.item.system.activities?.getByType("enchant") ?? [])
+      .flatMap(a => a.effects)
+      .reduce((obj, effects) => {
+        const { _id, riders } = effects;
+        for ( const id of riders.effect ) {
+          obj[id] ??= [];
+          obj[id].push(_id);
+        }
+        return obj;
+      }, {});
+    riders.forEach(r => {
+      for ( const origin of origins[r.id] ?? [] ) {
+        if ( origin in effectMap ) effectMap[origin].riders.push(r);
+      }
+    });
+
+    return Object.entries(effects).map(([key, value]) => ({
+      ...value,
+      canCreate: context.editable && !value.isEnchantment && !value.disabled,
+      dataset: {}, // TODO: put things that help with effect creation via _addDocument here
+      show: !value.hidden,
+      rowActions: TableRowActionsRuntime.getEffectsRowActions(context),
+      sectionActions: [],
+      key,
+    }));
+  }
+ 
+  /* -------------------------------------------- */
+
 
   /**
    * Get the display object used to show the advancement tab.

--- a/src/sheets/quadrone/item/columns/EffectDurationColumn.svelte
+++ b/src/sheets/quadrone/item/columns/EffectDurationColumn.svelte
@@ -10,5 +10,5 @@
 </script>
 
 <span class="truncate">
-  {rowContext.effect.effect.duration.label ?? ''}
+  {rowContext.effect.duration.label ?? ''}
 </span>

--- a/src/sheets/quadrone/item/columns/EffectSourceColumn.svelte
+++ b/src/sheets/quadrone/item/columns/EffectSourceColumn.svelte
@@ -9,9 +9,9 @@
   }: ColumnCellProps<ActiveEffect5e, ActiveEffectContext> = $props();
 </script>
 
-{#if rowContext.effect.source}
+{#if rowContext.source}
   <a data-action="showDocument" data-uuid={rowContext.effect.source?.uuid}>
-    {rowContext.effect.source.name ?? ''}
+    {rowContext.source.name ?? ''}
   </a>
 {:else}
   <span class="color-text-disabled"> &mdash; </span>

--- a/src/sheets/quadrone/item/columns/EffectSourceColumn.svelte
+++ b/src/sheets/quadrone/item/columns/EffectSourceColumn.svelte
@@ -10,7 +10,7 @@
 </script>
 
 {#if rowContext.source}
-  <a data-action="showDocument" data-uuid={rowContext.effect.source?.uuid}>
+  <a data-action="showDocument" data-uuid={rowContext.source?.uuid}>
     {rowContext.source.name ?? ''}
   </a>
 {:else}

--- a/src/sheets/quadrone/shared/EffectsTables.svelte
+++ b/src/sheets/quadrone/shared/EffectsTables.svelte
@@ -33,6 +33,8 @@
 
   let sections = $derived(context.effects);
 
+  $inspect(sections);
+
   const localize = FoundryAdapter.localize;
 
   let tabId = getContext<string>(CONSTANTS.SVELTE_CONTEXT.TAB_ID);

--- a/src/sheets/quadrone/shared/EffectsTables.svelte
+++ b/src/sheets/quadrone/shared/EffectsTables.svelte
@@ -117,7 +117,7 @@
                 {columns}
                 {context}
                 ctx={effectContext}
-                entry={effectContext.effect.effect /* TODO: stop. get some help. */}
+                entry={effectContext.effect.effect}
                 {hiddenColumns}
                 {section}
               />

--- a/src/sheets/quadrone/shared/EffectsTables.svelte
+++ b/src/sheets/quadrone/shared/EffectsTables.svelte
@@ -7,6 +7,7 @@
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
   import type {
     ActiveEffectContext,
+    ActiveEffectSection,
     CharacterSheetQuadroneContext,
   } from 'src/types/types';
   import { getContext } from 'svelte';
@@ -84,45 +85,71 @@
             effect,
           }),
         )}
-
         {#each effectEntries as effectContext}
-          <TidyEffectTableRow effectContext={effectContext.effect}>
-            {#snippet children({ toggleSummary, expanded })}
-              <span class="tidy-table-row-use-button disabled">
-                <img
-                  class="item-image"
-                  src={effectContext.effect.img ??
-                    effectContext.effect.effect.icon}
-                  alt={effectContext.effect.name ?? ''}
-                />
-              </span>
-              <TidyTableCell primary={true}>
-                <a class="item-name" onclick={(ev) => toggleSummary()}>
-                  <span class="cell-text">
-                    <span class="cell-name">{effectContext.effect.name}</span>
-                  </span>
-                  <span class="row-detail-expand-indicator">
-                    <i
-                      class="fa-solid fa-angle-right expand-indicator"
-                      class:expanded
-                    >
-                    </i>
-                  </span>
-                </a>
-              </TidyTableCell>
-
-              <TidyTableCustomCells
-                {columns}
-                {context}
-                ctx={effectContext}
-                entry={effectContext.effect.effect}
-                {hiddenColumns}
-                {section}
-              />
-            {/snippet}
-          </TidyEffectTableRow>
+          {@render EffectRow(
+            effectContext.effect,
+            columns,
+            hiddenColumns,
+            section,
+          )}
+          {#each effectContext.effect.riders as rider}
+            {@render EffectRow(rider, columns, hiddenColumns, section, true)}
+          {/each}
         {/each}
       {/snippet}
     </TidyTable>
   {/if}
 {/each}
+
+{#snippet EffectRow(
+  ctx: ActiveEffectContext,
+  columns: ColumnsLoadout,
+  hiddenColumns: Set<string>,
+  section: ActiveEffectSection,
+  isRider?: boolean,
+)}
+  <TidyEffectTableRow effectContext={ctx}>
+    {#snippet children({ toggleSummary, expanded })}
+      {#if isRider}
+        <span class="inline-activity-arrow">
+          <i class="fa-solid fa-turn-up fa-fw fa-rotate-90 color-text-disabled"></i>
+        </span>
+      {/if}
+      <span class="tidy-table-row-use-button disabled">
+        <img
+          class="item-image"
+          src={ctx.effect.img ?? ctx.effect.icon}
+          alt={ctx.effect.name ?? ''}
+        />
+      </span>
+      <TidyTableCell primary={true}>
+        <a class="item-name" onclick={(ev) => toggleSummary()}>
+          <span class="cell-text">
+            <span class="cell-name">{ctx.effect.name}</span>
+          </span>
+          <span class="row-detail-expand-indicator">
+            <i class="fa-solid fa-angle-right expand-indicator" class:expanded>
+            </i>
+          </span>
+        </a>
+      </TidyTableCell>
+
+      <TidyTableCustomCells
+        {columns}
+        {context}
+        {ctx}
+        entry={ctx}
+        {hiddenColumns}
+        {section}
+      />
+    {/snippet}
+  </TidyEffectTableRow>
+{/snippet}
+
+<!-- TODO: hightouch, remove these temp styles whenever you apply the official ones -->
+<style lang="less">
+  .inline-activity-arrow {
+    padding-inline: 0.25rem;
+    align-self: center;
+  }
+</style>

--- a/src/sheets/quadrone/shared/EffectsTables.svelte
+++ b/src/sheets/quadrone/shared/EffectsTables.svelte
@@ -33,8 +33,6 @@
 
   let sections = $derived(context.effects);
 
-  $inspect(sections);
-
   const localize = FoundryAdapter.localize;
 
   let tabId = getContext<string>(CONSTANTS.SVELTE_CONTEXT.TAB_ID);

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1007,11 +1007,12 @@ export type ActiveEffectContext = {
   duration: number;
   source: any;
   parent: any;
-  parentId: string;
+  parentId?: string;
   durationParts: string | string[];
   hasTooltip: boolean;
   uuid: string;
   effect: ActiveEffect5e;
+  riders: ActiveEffectContext[];
 };
 
 export type ActiveEffectSection = EffectCategory<ActiveEffectContext> &

--- a/src/utils/active-effect.ts
+++ b/src/utils/active-effect.ts
@@ -15,7 +15,7 @@ export class ActiveEffectsHelper {
       error(
         'An error occurred while checking if a field has an active effect applied',
         false,
-        e
+        e,
       );
       debug('Active effect error troubleshooting info', { document, field });
       return false;
@@ -39,7 +39,7 @@ export class ActiveEffectsHelper {
 
     Array.from<string>(activeEffect.statuses)
       .map(
-        (x: string) => CONFIG.statusEffects.find((y) => y.id === x)?.name ?? x
+        (x: string) => CONFIG.statusEffects.find((y) => y.id === x)?.name ?? x,
       )
       .forEach((e) => {
         result.push(e);
@@ -48,15 +48,18 @@ export class ActiveEffectsHelper {
     return result;
   }
 
-  static findMode(mode: number, fallback = '—') {
-    const entry = Object.entries(CONST.ACTIVE_EFFECT_MODES).find(
-      ([_, value]) => value === mode
-    );
-
-    if (!entry) {
-      return fallback;
+  static findMode(change: any, fallback = '—') {
+    if (game.release.generation >= 14) {
+      const key = `EFFECT.CHANGES.TYPES.${change.type}`;
+      return change.type ? FoundryAdapter.localize(key) : fallback;
     }
 
-    return FoundryAdapter.localize(`EFFECT.MODE_${entry[0]}`);
+    const entry = Object.entries(CONST.ACTIVE_EFFECT_MODES).find(
+      ([_, value]) => value === change.mode,
+    );
+
+    return entry
+      ? FoundryAdapter.localize(`EFFECT.MODE_${entry[0]}`)
+      : fallback;
   }
 }


### PR DESCRIPTION
From the community: https://discord.com/channels/1167985253072257115/1497163151056310382

- fixed: Effect summary columns and change modes were not localizing in Foundry 14.
- fixed: Enchantment effects were not showing on item sheets.
- new: Rider effects now show as sub-effects on the relevant enchantment effect with which they ride.

Sample JSON:
- feature with enchantments whose effects have rider effects 
[fvtt-Item-ride-or-die-gHJKNfphUco8jMcZ.json](https://github.com/user-attachments/files/27182433/fvtt-Item-ride-or-die-gHJKNfphUco8jMcZ.json)

Sample item:
- Corrosive Form (SRD) - the effect "Damaged: -1 Attack" was not showing previously.