### PR TITLE
Theme cleanup

### DIFF
--- a/src/applications/theme/ThemeSettingColorFormGroupQuadrone.svelte
+++ b/src/applications/theme/ThemeSettingColorFormGroupQuadrone.svelte
@@ -11,6 +11,7 @@
     placeholder?: string;
     colorSelected?: () => void;
     disableDelete?: boolean;
+    requireValue?: boolean;
   }
 
   let {
@@ -20,6 +21,7 @@
     colorSelected,
     placeholder = '#FFFFFF',
     disableDelete = false,
+    requireValue = false,
   }: Props = $props();
 
   const eyeDropperEnabled = 'EyeDropper' in window;
@@ -56,7 +58,7 @@
     <label
       for="{inputId}-picker"
       class="color-picker-preview"
-      style:--bg-color={value}
+      style:--bg-color={value || placeholder}
     >
       <i class="fa-solid fa-palette"></i>
     </label>
@@ -79,8 +81,10 @@
       {placeholder}
       oninput={(ev) => onColorSelected(ev.currentTarget.value)}
       onblur={() => {
-        if (disableDelete && (isNil(value, '') || !chroma.valid(value))) {
+        if (requireValue && (isNil(value, '') || !chroma.valid(value))) {
           onColorSelected(placeholder);
+        } else if (!isNil(value, '') && !chroma.valid(value)) {
+          value = '';
         }
       }}
     />

--- a/src/applications/theme/ThemeSettingsQuadrone.svelte
+++ b/src/applications/theme/ThemeSettingsQuadrone.svelte
@@ -325,7 +325,7 @@
     </div>
 
     <!-- TODO: Add item sidebar background setting -->
-    <!-- {#if settings.value.truesight}
+    {#if app.document?.documentName === CONSTANTS.DOCUMENT_NAME_ITEM}
       <div class="form-group">
         <label for="{idPrefix}-item-sidebar-background">
           {localize('TIDY5E.ThemeSettings.ItemSidebarBackground.title')}
@@ -344,7 +344,7 @@
           />
         </div>
       </div>
-    {/if} -->
+    {/if}
   </fieldset>
   <fieldset>
     <legend>

--- a/src/applications/theme/ThemeSettingsQuadrone.svelte
+++ b/src/applications/theme/ThemeSettingsQuadrone.svelte
@@ -35,14 +35,11 @@
   );
 
   let portraitShapeDefaultLabel = $derived(
-    localize(
-      'TIDY5E.UseSpecificDefaultValue.Label',
-      {
-        value: localize(
-          `TIDY5E.ThemeSettings.PortraitShape.option.${portraitShapeDefaultValue}`,
-        ),
-      },
-    ),
+    localize('TIDY5E.UseSpecificDefaultValue.Label', {
+      value: localize(
+        `TIDY5E.ThemeSettings.PortraitShape.option.${portraitShapeDefaultValue}`,
+      ),
+    }),
   );
 
   let methodColorPlaceholders = $derived.by(() =>
@@ -74,11 +71,49 @@
 
     const liveSettings = ThemeQuadrone.getSheetThemeSettings({
       doc: app.document,
-      settingsOverride: app.mapContextToSettings(context),
+      settingsOverride: app.mapContextToChangedSettings(context) as any,
     });
 
     TidyHooks.tidy5eSheetsThemeSettingsChanged(app.document, liveSettings);
   });
+
+  let useBasicThemeIfChanged = $derived(
+    context.value.useBasicTheme ?? placeholders?.value.useBasicTheme ?? false,
+  );
+  let useHeaderBackgroundIfChanged = $derived(
+    context.value.useHeaderBackground ??
+      placeholders?.value.useHeaderBackground ??
+      true,
+  );
+
+  let useBasicThemeDefaultLabel = $derived(
+    localize('TIDY5E.UseSpecificDefaultValue.Label', {
+      value: localize(
+        (placeholders?.value.useBasicTheme ?? false)
+          ? localize('COMMON.Yes')
+          : localize('COMMON.No'),
+      ),
+    }),
+  );
+  let useHeaderBackgroundDefaultLabel = $derived(
+    localize('TIDY5E.UseSpecificDefaultValue.Label', {
+      value: localize(
+        (placeholders?.value.useHeaderBackground ?? true)
+          ? localize('COMMON.Yes')
+          : localize('COMMON.No'),
+      ),
+    }),
+  );
+
+  function onUseBasicThemeChange(newValue: boolean | null) {
+    context.value.useBasicTheme = newValue;
+    // Keep the legacy invariant: explicit basic theme dictates header background.
+    if (newValue === true) {
+      context.value.useHeaderBackground = false;
+    } else if (newValue === false) {
+      context.value.useHeaderBackground = true;
+    }
+  }
 
   async function onDrop(
     ev: DragEvent & {
@@ -110,7 +145,10 @@
       type="button"
       class="button flexshrink"
       onclick={() =>
-        ThemeQuadroneImportService.export(app.mapContextToSettings(context))}
+        ThemeQuadroneImportService.export({
+          ...ThemeQuadrone.getDefaultThemeSettings(),
+          ...app.mapContextToChangedSettings(context),
+        })}
     >
       <i class="fa-solid fa-file-export"></i>
       {localize('TIDY5E.ThemeSettings.Sheet.export')}
@@ -130,11 +168,10 @@
         placeholders?.value.accentColor,
         ThemeQuadrone.DEFAULT_ACCENT_COLOR,
       )}
-      disableDelete
     />
 
-    {#if !context.value.useBasicTheme}
-
+    <!-- Hide if basic theme -->
+    {#if !useBasicThemeIfChanged}
       {#if !app.document?.documentName || app.document?.documentName === CONSTANTS.DOCUMENT_NAME_ACTOR}
         <div class="form-group">
           <label for="{idPrefix}-actor-portrait-shape">
@@ -165,19 +202,49 @@
           <label for="{idPrefix}-use-header-background">
             {localize('TIDY5E.ThemeSettings.UseHeaderBackground.title')}
           </label>
-          <div class="form-fields">
-            <input
-              id="{idPrefix}-use-header-background"
-              type="checkbox"
-              bind:checked={context.value.useHeaderBackground}
-            />
+          <div class="form-fields vertical">
+            {#if app.document}
+              <label class="radio">
+                <input
+                  type="radio"
+                  name="{idPrefix}-use-header-background"
+                  checked={context.value.useHeaderBackground === true}
+                  onclick={() => (context.value.useHeaderBackground = true)}
+                />
+                {localize('Yes')}
+              </label>
+              <label class="radio">
+                <input
+                  type="radio"
+                  name="{idPrefix}-use-header-background"
+                  checked={context.value.useHeaderBackground === false}
+                  onclick={() => (context.value.useHeaderBackground = false)}
+                />
+                {localize('No')}
+              </label>
+              <label class="radio">
+                <input
+                  type="radio"
+                  name="{idPrefix}-use-header-background"
+                  checked={context.value.useHeaderBackground === null}
+                  onclick={() => (context.value.useHeaderBackground = null)}
+                />
+                {useHeaderBackgroundDefaultLabel}
+              </label>
+            {:else}
+              <input
+                id="{idPrefix}-use-header-background"
+                type="checkbox"
+                bind:checked={context.value.useHeaderBackground}
+              />
+            {/if}
           </div>
           <p class="hint">
             {localize('TIDY5E.ThemeSettings.UseHeaderBackground.hint')}
           </p>
         </div>
 
-        {#if context.value.useHeaderBackground}
+        {#if useHeaderBackgroundIfChanged}
           <div class="form-group">
             <label for="{idPrefix}-actor-header-background">
               {localize('TIDY5E.ThemeSettings.ActorHeaderBackground.title')}
@@ -214,15 +281,43 @@
       <label for="{idPrefix}-use-basic-theme">
         {localize('TIDY5E.ThemeSettings.UseBasicTheme.title')}
       </label>
-      <div class="form-fields">
-        <input
-          id="{idPrefix}-use-basic-theme"
-          type="checkbox"
-          bind:checked={context.value.useBasicTheme}
-          onchange={() => {
-            context.value.useHeaderBackground = !context.value.useBasicTheme;
-          }}
-        />
+      <div class="form-fields vertical">
+        {#if app.document}
+          <label class="radio">
+            <input
+              type="radio"
+              name="{idPrefix}-use-basic-theme"
+              checked={context.value.useBasicTheme === true}
+              onclick={() => onUseBasicThemeChange(true)}
+            />
+            {localize('Yes')}
+          </label>
+          <label class="radio">
+            <input
+              type="radio"
+              name="{idPrefix}-use-basic-theme"
+              checked={context.value.useBasicTheme === false}
+              onclick={() => onUseBasicThemeChange(false)}
+            />
+            {localize('No')}
+          </label>
+          <label class="radio">
+            <input
+              type="radio"
+              name="{idPrefix}-use-basic-theme"
+              checked={context.value.useBasicTheme === null}
+              onclick={() => onUseBasicThemeChange(null)}
+            />
+            {useBasicThemeDefaultLabel}
+          </label>
+        {:else}
+          <input
+            id="{idPrefix}-use-basic-theme"
+            type="checkbox"
+            checked={context.value.useBasicTheme ?? false}
+            onchange={(ev) => onUseBasicThemeChange(ev.currentTarget.checked)}
+          />
+        {/if}
       </div>
       <p class="hint">
         {localize('TIDY5E.ThemeSettings.UseBasicTheme.hint')}

--- a/src/applications/theme/ThemeSettingsQuadroneApplication.svelte.ts
+++ b/src/applications/theme/ThemeSettingsQuadroneApplication.svelte.ts
@@ -26,8 +26,8 @@ export type ThemeColorSettingConfigEntry = ThemeColorSetting & {
 export type ThemeSettingsContext = {
   value: {
     accentColor: string;
-    useBasicTheme: boolean;
-    useHeaderBackground: boolean;
+    useBasicTheme: boolean | null;
+    useHeaderBackground: boolean | null;
     headerColor: string;
     actorHeaderBackground: string;
     headerBackgroundColor: string;
@@ -47,9 +47,9 @@ export class ThemeSettingsQuadroneApplication extends SvelteApplicationMixin<Con
 
   _settings: ThemeSettingsContext = $state({
     value: {
-      accentColor: ThemeQuadrone.DEFAULT_ACCENT_COLOR,
-      useBasicTheme: false,
-      useHeaderBackground: true,
+      accentColor: '',
+      useBasicTheme: null,
+      useHeaderBackground: null,
       headerColor: '',
       actorHeaderBackground: '',
       headerBackgroundColor: '',
@@ -111,18 +111,20 @@ export class ThemeSettingsQuadroneApplication extends SvelteApplicationMixin<Con
   _createComponent(node: HTMLElement): Record<string, any> {
     this._settings = this._getSettings();
     const placeholders = this.document
-      ? this._mapSettings(ThemeQuadrone.getWorldThemeSettings())
+      ? this._mapSettings(ThemeQuadrone.getWorldThemeSettings(), {
+        allowNullBooleans: false,
+      })
       : undefined;
 
 
-      const component = mount(ThemeSettingsQuadrone, {
-        target: node,
-        props: {
-          app: this,
-          settings: this._settings,
-          placeholders,
-        },
-      });
+    const component = mount(ThemeSettingsQuadrone, {
+      target: node,
+      props: {
+        app: this,
+        settings: this._settings,
+        placeholders,
+      },
+    });
 
     return component;
   }
@@ -133,57 +135,49 @@ export class ThemeSettingsQuadroneApplication extends SvelteApplicationMixin<Con
     return {};
   }
 
-  _getSettings(settingsOverride?: ThemeSettingsV3) {
-    let worldSettings = ThemeQuadrone.getWorldThemeSettings();
+  _getSettings(settingsOverride?: Partial<ThemeSettingsV3>) {
+    const allowNullBooleans = !!this.document;
 
-    let themeSettings =
+    const source =
       settingsOverride ??
-      structuredClone(
-        this.document
-          ? ThemeQuadrone.getSheetThemeSettings({
-            doc: this.document,
-            applyWorldThemeSetting: false,
-            alternateDefaults: {
-              useHeaderBackground: worldSettings.useHeaderBackground,
-            },
-          })
-          : worldSettings
-      );
+      (this.document
+        ? TidyFlags.sheetThemeSettings.get(this.document) ?? {}
+        : ThemeQuadrone.getChangedWorldThemeSettingsForForm());
 
-    let context: ThemeSettingsContext = this._mapSettings(themeSettings);
-
-    return context;
+    return this._mapSettings(source, { allowNullBooleans });
   }
 
-  private _mapSettings(themeSettings: ThemeSettingsV3): ThemeSettingsContext {
+  private _mapSettings(
+    source: Partial<ThemeSettingsV3>,
+    options: { allowNullBooleans: boolean }
+  ): ThemeSettingsContext {
+    const nullableBool = (value: boolean | null | undefined, fallback: boolean) =>
+      options.allowNullBooleans ? value ?? null : value ?? fallback;
+
     return {
       value: {
-        accentColor: themeSettings.accentColor,
-        useBasicTheme: themeSettings.useBasicTheme,
-        useHeaderBackground: themeSettings.useHeaderBackground,
-        headerColor: themeSettings.headerColor,
-        actorHeaderBackground: themeSettings.actorHeaderBackground,
-        headerBackgroundColor: themeSettings.headerBackgroundColor,
-        itemSidebarBackground: themeSettings.itemSidebarBackground,
-        portraitShape: themeSettings.portraitShape,
+        accentColor: source.accentColor ?? '',
+        useBasicTheme: nullableBool(source.useBasicTheme, false),
+        useHeaderBackground: nullableBool(source.useHeaderBackground, true),
+        headerColor: source.headerColor ?? '',
+        actorHeaderBackground: source.actorHeaderBackground ?? '',
+        headerBackgroundColor: source.headerBackgroundColor ?? '',
+        itemSidebarBackground: source.itemSidebarBackground ?? '',
+        portraitShape: source.portraitShape,
         rarityColors: Object.entries(CONFIG.DND5E.itemRarity).map(
-          ([key, label]) => {
-            return {
-              label,
-              key: key,
-              value: themeSettings.rarityColors[key] ?? '',
-            };
-          }
+          ([key, label]) => ({
+            label,
+            key,
+            value: source.rarityColors?.[key] ?? '',
+          })
         ),
         spellPreparationMethodColors: Object.entries(
           CONFIG.DND5E.spellcasting
-        ).map(([key, config]) => {
-          return {
-            label: config.label,
-            key: key,
-            value: themeSettings.spellPreparationMethodColors[key] ?? '',
-          };
-        }),
+        ).map(([key, config]) => ({
+          label: config.label,
+          key,
+          value: source.spellPreparationMethodColors?.[key] ?? '',
+        })),
       },
     };
   }
@@ -198,40 +192,72 @@ export class ThemeSettingsQuadroneApplication extends SvelteApplicationMixin<Con
   }
 
   async apply() {
-    const context = this._settings;
-
-    let themeSettings: ThemeSettingsV3 = this.mapContextToSettings(context);
+    const changedSettings = this.mapContextToChangedSettings(this._settings);
 
     if (this.document) {
-      await ThemeQuadrone.saveSheetThemeSettings(this.document, themeSettings);
+      if (Object.keys(changedSettings).length === 0) {
+        await TidyFlags.sheetThemeSettings.unset(this.document);
+      } else {
+        await ThemeQuadrone.saveSheetThemeSettings(
+          this.document,
+          changedSettings as ThemeSettingsV3
+        );
+      }
     } else {
-      await ThemeQuadrone.saveWorldThemeSettings(themeSettings);
+      await ThemeQuadrone.saveWorldThemeSettings(changedSettings as ThemeSettingsV3);
     }
   }
 
-  mapContextToSettings(context: ThemeSettingsContext): ThemeSettingsV3 {
-    return {
-      accentColor: context.value.accentColor ?? '',
-      useBasicTheme: context.value.useBasicTheme,
-      useHeaderBackground: context.value.useHeaderBackground,
-      headerColor: context.value.headerColor,
-      actorHeaderBackground: context.value.actorHeaderBackground,
-      headerBackgroundColor: context.value.headerBackgroundColor,
-      itemSidebarBackground: context.value.itemSidebarBackground,
-      portraitShape: context.value.portraitShape,
-      rarityColors: context.value.rarityColors
-        .filter((t) => !isNil(t.value.trim(), ''))
-        .reduce<Record<string, string>>((prev, curr) => {
-          prev[curr.key] = curr.value;
-          return prev;
-        }, {}),
-      spellPreparationMethodColors: context.value.spellPreparationMethodColors
-        .filter((t) => !isNil(t.value.trim(), ''))
-        .reduce<Record<string, string>>((prev, curr) => {
-          prev[curr.key] = curr.value;
-          return prev;
-        }, {}),
-    };
+  // Only capture settings that have been changed
+  mapContextToChangedSettings(
+    context: ThemeSettingsContext
+  ): Partial<ThemeSettingsV3> {
+    const currentSettings = context.value;
+    const changedSettings: Partial<ThemeSettingsV3> = {};
+
+    const stringFields = [
+      'accentColor',
+      'headerColor',
+      'actorHeaderBackground',
+      'headerBackgroundColor',
+      'itemSidebarBackground',
+    ] as const;
+    for (const key of stringFields) {
+      if (!isNil(currentSettings[key], '')) {
+        changedSettings[key] = currentSettings[key];
+      }
+    }
+
+    if (currentSettings.useBasicTheme !== null) {
+      changedSettings.useBasicTheme = currentSettings.useBasicTheme;
+    }
+    if (currentSettings.useHeaderBackground !== null) {
+      changedSettings.useHeaderBackground = currentSettings.useHeaderBackground;
+    }
+    if (currentSettings.portraitShape !== undefined) {
+      changedSettings.portraitShape = currentSettings.portraitShape;
+    }
+
+    const rarities = this._collectColors(currentSettings.rarityColors);
+    if (Object.keys(rarities).length) {
+      changedSettings.rarityColors = rarities;
+    }
+
+    const methods = this._collectColors(currentSettings.spellPreparationMethodColors);
+    if (Object.keys(methods).length) {
+      changedSettings.spellPreparationMethodColors = methods;
+    }
+
+    return changedSettings;
+  }
+
+  private _collectColors(entries: ThemeColorSettingConfigEntry[]) {
+    return entries
+      .filter((t) => !isNil(t.value.trim(), ''))
+      .reduce<Record<string, string>>((prev, curr) => {
+        prev[curr.key] = curr.value;
+        return prev;
+      }, {});
   }
 
   async useDefault() {

--- a/src/less/quadrone/abilities.css
+++ b/src/less/quadrone/abilities.css
@@ -485,10 +485,6 @@
       padding-bottom: 0.25rem;
     }
 
-    .ability-bonus-container {
-      aspect-ratio: 1/1;
-    }
-
     .ability-bonus-container,
     .initiative-bonus {
 
@@ -601,7 +597,7 @@
       padding-bottom: 0.25rem;
     }
 
-    .sheet-header .abilities-container {
+    .abilities-container {
       &.abilities-size-compact .abilities-container-inner > * {
         --ability-collapsed-bg: var(--t5e-component-card-darker);
       }
@@ -636,10 +632,6 @@
         margin-top: 0.125rem;
       }
 
-      .ac-container .shield {
-        margin-top: 0.375rem;
-      }
-
       .abilities-container-inner {
         justify-content: space-between;
 
@@ -662,6 +654,7 @@
         }
 
         .ac-container .shield {
+          margin-top: 0.375rem;
           max-width: 4rem;
 
           .ac-label {

--- a/src/less/quadrone/actors.css
+++ b/src/less/quadrone/actors.css
@@ -104,7 +104,7 @@
   /* THEMES
   ------------------------------------------------------------ */
   &:not(.theme-parchment) {
-    background: var(--t5e-theme-header-color, var(--t5e-theme-color-default));
+    background: var(--t5e-theme-color-header, var(--t5e-theme-color-default));
   }
 
   &.theme-parchment {

--- a/src/less/quadrone/character.css
+++ b/src/less/quadrone/character.css
@@ -272,7 +272,7 @@
       padding-top: 0;
 
       .shield {
-        margin-top: 0.1875rem;
+        margin-top: 0.125rem;
         height: auto;
         min-height: 3.25rem;
         min-width: auto;
@@ -304,7 +304,6 @@
     }
 
     .ability {
-      max-width: 3.25rem;
       gap: 0;
 
       .initiative-score-container {

--- a/src/less/quadrone/header.css
+++ b/src/less/quadrone/header.css
@@ -42,7 +42,7 @@
   /* These headers use var(--t5e-background-image).
   /* ------------------------------------------------------------ */
   &:not(.theme-parchment) {
-    background: var(--t5e-theme-header-color, var(--t5e-theme-color-default));
+    background: var(--t5e-theme-color-header, var(--t5e-theme-color-default));
 
     /* Background image */
     &::before {

--- a/src/less/quadrone/items.css
+++ b/src/less/quadrone/items.css
@@ -140,6 +140,9 @@
   /* Sidebar */
   .sidebar {
     background: var(--sidebar-bg);
+    background-position: top center;
+    background-size: auto;
+    background-repeat: no-repeat;
     background-attachment: scroll, local;
     background-blend-mode: luminosity;
     border-right: 0.0625rem solid var(--window-border-color, #9f9275);

--- a/src/less/quadrone/npc.css
+++ b/src/less/quadrone/npc.css
@@ -52,10 +52,20 @@
   .abilities-container.abilities-size-small {
     .initiative-score-container {
       height: 3.75rem;
+
+      .ability-roll-button {
+        gap: 0.25rem;
+        padding-top: 0.375rem;
+      }
     }
   }
 
-  &.theme-basic .abilities-container,
+  /* &.theme-basic .abilities-container.abilities-size-compact {
+    .initiative-score-container .ability-roll-button {
+      gap: 0.125rem;
+      margin-top: 0;
+    }
+  } */
   .abilities-container.abilities-size-compact {
     .initiative-score-container {
       margin-top: 0;
@@ -63,6 +73,18 @@
 
       .ability-roll-button {
         gap: 0.125rem;
+        margin-top: 0.25rem;
+      }
+    }
+  }
+
+  &.theme-basic .abilities-container {
+    .initiative-score-container {
+      margin-top: 0;
+      padding-top: 0;
+
+      .ability-roll-button {
+        margin-top: 0;
       }
     }
   }

--- a/src/sheets/quadrone/Tidy5eEncounterSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eEncounterSheetQuadrone.svelte.ts
@@ -67,11 +67,11 @@ export class Tidy5eEncounterSheetQuadrone extends Tidy5eMultiActorSheetQuadroneB
   static DEFAULT_OPTIONS: Partial<
     ApplicationConfiguration & { dragDrop: Partial<DragDropConfiguration>[] }
   > = {
-    position: {
-      width: 740,
-      height: 810,
-    },
-  };
+      position: {
+        width: 740,
+        height: 810,
+      },
+    };
 
   static _lockedSkillAllowlist = new Set<string>(['ins', 'per']);
 
@@ -114,11 +114,11 @@ export class Tidy5eEncounterSheetQuadrone extends Tidy5eMultiActorSheetQuadroneB
       .filter((x: Actor5e) => x.type === 'group')
       .map(
         (x: Actor5e) =>
-          ({
-            id: x.id,
-            name: x.name,
-            primary: x.id === game.actors.party?.id,
-          } satisfies DifficultyTarget)
+        ({
+          id: x.id,
+          name: x.name,
+          primary: x.id === game.actors.party?.id,
+        } satisfies DifficultyTarget)
       );
 
     if (!game.actors.party) {
@@ -233,11 +233,9 @@ export class Tidy5eEncounterSheetQuadrone extends Tidy5eMultiActorSheetQuadroneB
         );
 
         const accentColor = coalesce(
-          // Use the actor's accent color, if configured
-          ThemeQuadrone.getSheetThemeSettings({
-            doc: actor,
-            applyWorldThemeSetting: false,
-          }).accentColor,
+          // Use the actor's accent color, if configured, which references global themes if configured
+          TidyFlags.sheetThemeSettings.get(actor)?.accentColor,
+          // Else, use the group sheet's accent color, with fallback to world default accent color
           // Else, use the encounter sheet's accent color, with fallback to world default accent color
           context.themeSettings.accentColor
         );

--- a/src/sheets/quadrone/Tidy5eGroupSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eGroupSheetQuadrone.svelte.ts
@@ -265,11 +265,8 @@ export class Tidy5eGroupSheetQuadrone extends Tidy5eMultiActorSheetQuadroneBase<
       );
 
       const accentColor = coalesce(
-        // Use the actor's accent color, if configured
-        ThemeQuadrone.getSheetThemeSettings({
-          doc: actor,
-          applyWorldThemeSetting: false,
-        }).accentColor,
+        // Use the actor's accent color, if configured, which references global themes if configured
+        TidyFlags.sheetThemeSettings.get(actor)?.accentColor,
         // Else, use the group sheet's accent color, with fallback to world default accent color
         actorContext.themeSettings.accentColor
       );

--- a/src/theme/theme-quadrone.svelte.ts
+++ b/src/theme/theme-quadrone.svelte.ts
@@ -79,8 +79,19 @@ export class ThemeQuadrone {
     );
   }
 
+  /** Get any settings that have been changed, or null  */
+  static getChangedWorldThemeSettingsForForm(): Partial<ThemeSettingsV3> {
+    return SettingsProvider.settings.worldThemeSettings.get() ?? {};
+  }
+
   static saveWorldThemeSettings(settings: ThemeSettingsV3) {
     const toSave = { ...settings };
+
+    for (const [key, value] of Object.entries(toSave)) {
+      if (isNil(value, '')) {
+        delete toSave[key as keyof ThemeSettingsV3];
+      }
+    }
 
     return FoundryAdapter.setTidySetting('worldThemeSettings', toSave);
   }


### PR DESCRIPTION
- Fixed issue with global defaults not displaying in Group/Encounter sheets
- Fixed default styles and global styles filling forms automatically, not allowing defaults to be used if you saved
- Updated theme settings so that it only saves changes instead of always saving all settings
- Updated theme settings to allow selecting yes/no/default (null) for all fields
- Allow sidebar image customization. No guardrails here, it's just whatever you put in.