### PR TITLE
Misc fixes

### DIFF
--- a/src/less/quadrone/reset.css
+++ b/src/less/quadrone/reset.css
@@ -42,11 +42,9 @@
     margin: 0;
   }
 
-  /* TODO: when game.release.generation > 13, lower the specificity of this rule to bare minimum */
-  .theme-dark & .window-content,
-  &.theme-dark .window-content {
-    backdrop-filter: unset;
+  &.themed.theme-dark .window-content {
     -webkit-backdrop-filter: unset;
+    backdrop-filter: unset;
   }
 
   /* Form Resets */
@@ -54,7 +52,7 @@
   form {
     .form-group {
       .form-fields {
-        input[type="checkbox"] {
+        input[type='checkbox'] {
           flex-basis: var(--checkbox-size);
         }
       }

--- a/src/sheets/classic/Tidy5eActorSheetClassicV2Base.svelte.ts
+++ b/src/sheets/classic/Tidy5eActorSheetClassicV2Base.svelte.ts
@@ -39,7 +39,7 @@ import { ItemFilterService } from 'src/features/filtering/ItemFilterService.svel
 import { TidyHooks } from 'src/api';
 
 // TODO: Simplify mixins to mostly a class hierarchy
-export function Tidy5eActorSheetClassicV2Base<
+export function GetTidy5eActorSheetClassicV2Base<
   TContext extends ActorSheetContextV1
 >(sheetType: string) {
   abstract class Tidy5eActorSheetClassicV2Base extends TidyExtensibleDocumentSheetMixin(

--- a/src/sheets/classic/Tidy5eCharacterSheet.svelte.ts
+++ b/src/sheets/classic/Tidy5eCharacterSheet.svelte.ts
@@ -56,12 +56,12 @@ import { AttributePins } from 'src/features/attribute-pins/AttributePins';
 import type { AttributePinFlag } from 'src/foundry/TidyFlags.types';
 import { ItemContext } from 'src/features/item/ItemContext';
 import { ItemFilterRuntime } from 'src/runtime/item/ItemFilterRuntime.svelte';
-import { Tidy5eActorSheetClassicV2Base } from './Tidy5eActorSheetClassicV2Base.svelte';
+import { GetTidy5eActorSheetClassicV2Base } from './Tidy5eActorSheetClassicV2Base.svelte';
 import type { ApplicationConfiguration } from 'src/types/application.types';
 import { mapGetOrInsert } from 'src/utils/map';
 
 export class Tidy5eCharacterSheet
-  extends Tidy5eActorSheetClassicV2Base<CharacterSheetContext>(
+  extends GetTidy5eActorSheetClassicV2Base<CharacterSheetContext>(
     CONSTANTS.SHEET_TYPE_CHARACTER
   )
   implements

--- a/src/sheets/classic/Tidy5eKgarVehicleSheet.svelte.ts
+++ b/src/sheets/classic/Tidy5eKgarVehicleSheet.svelte.ts
@@ -34,12 +34,12 @@ import { ItemContext } from 'src/features/item/ItemContext';
 import VehicleSheetClassicRuntime from 'src/runtime/actor/VehicleSheetClassicRuntime.svelte';
 import { Inventory } from 'src/features/sections/Inventory';
 import { ItemFilterRuntime } from 'src/runtime/item/ItemFilterRuntime.svelte';
-import { Tidy5eActorSheetClassicV2Base } from './Tidy5eActorSheetClassicV2Base.svelte';
+import { GetTidy5eActorSheetClassicV2Base } from './Tidy5eActorSheetClassicV2Base.svelte';
 import type { ApplicationConfiguration } from 'src/types/application.types';
 import { mapGetOrInsert } from 'src/utils/map';
 
 export class Tidy5eVehicleSheet
-  extends Tidy5eActorSheetClassicV2Base<VehicleSheetContext>(
+  extends GetTidy5eActorSheetClassicV2Base<VehicleSheetContext>(
     CONSTANTS.SHEET_TYPE_VEHICLE
   )
   implements

--- a/src/sheets/classic/Tidy5eNpcSheet.svelte.ts
+++ b/src/sheets/classic/Tidy5eNpcSheet.svelte.ts
@@ -42,12 +42,12 @@ import { ItemContext } from 'src/features/item/ItemContext';
 import { splitSemicolons } from 'src/utils/array';
 import NpcSheetClassicRuntime from 'src/runtime/actor/NpcSheetClassicRuntime.svelte';
 import { ItemFilterRuntime } from 'src/runtime/item/ItemFilterRuntime.svelte';
-import { Tidy5eActorSheetClassicV2Base } from './Tidy5eActorSheetClassicV2Base.svelte';
+import { GetTidy5eActorSheetClassicV2Base } from './Tidy5eActorSheetClassicV2Base.svelte';
 import type { ApplicationConfiguration } from 'src/types/application.types';
 import { mapGetOrInsert } from 'src/utils/map';
 
 export class Tidy5eNpcSheet
-  extends Tidy5eActorSheetClassicV2Base<NpcSheetContext>(
+  extends GetTidy5eActorSheetClassicV2Base<NpcSheetContext>(
     CONSTANTS.SHEET_TYPE_NPC
   )
   implements

--- a/src/sheets/quadrone/Tidy5eActorSheetQuadroneBase.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eActorSheetQuadroneBase.svelte.ts
@@ -67,7 +67,7 @@ import { SpecialTraitsApplication } from 'src/applications-quadrone/special-trai
 
 const POST_WINDOW_TITLE_ANCHOR_CLASS_NAME = 'sheet-warning-anchor';
 
-export function Tidy5eActorSheetQuadroneBase<
+export function GetTidy5eActorSheetQuadroneBase<
   TContext extends ActorSheetQuadroneContext
 >(sheetType: string) {
   abstract class Tidy5eActorSheetQuadroneBase extends TidyExtensibleDocumentSheetMixin(

--- a/src/sheets/quadrone/Tidy5eCharacterSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eCharacterSheetQuadrone.svelte.ts
@@ -30,7 +30,7 @@ import { initTidy5eContextMenu } from 'src/context-menu/tidy5e-context-menu';
 import { CharacterSheetQuadroneRuntime } from 'src/runtime/actor/CharacterSheetQuadroneRuntime.svelte';
 import { ConditionsAndEffects } from 'src/features/conditions-and-effects/ConditionsAndEffects';
 import { ThemeQuadrone } from 'src/theme/theme-quadrone.svelte';
-import { Tidy5eActorSheetQuadroneBase } from './Tidy5eActorSheetQuadroneBase.svelte';
+import { GetTidy5eActorSheetQuadroneBase } from './Tidy5eActorSheetQuadroneBase.svelte';
 import { TidyFlags } from 'src/foundry/TidyFlags';
 import type {
   Activity5e,
@@ -65,7 +65,7 @@ import MenuButton from 'src/components/table-quadrone/table-buttons/MenuButton.s
 import CharacterSheetTabToggleButton from 'src/components/table-quadrone/table-buttons/CharacterSheetTabToggleButton.svelte';
 import { arrayTransfer } from 'src/utils/array';
 
-export class Tidy5eCharacterSheetQuadrone extends Tidy5eActorSheetQuadroneBase<CharacterSheetQuadroneContext>(
+export class Tidy5eCharacterSheetQuadrone extends GetTidy5eActorSheetQuadroneBase<CharacterSheetQuadroneContext>(
   CONSTANTS.SHEET_TYPE_CHARACTER,
 ) {
   currentTabId: string;

--- a/src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte.ts
@@ -1037,22 +1037,25 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin<
     _event: Event,
     target: HTMLElement,
   ) {
-    switch ( target.dataset.config ) {
-      case "movement":
-      case "senses":
-        return FoundryAdapter.renderMovementSensesConfig(this.item, target.dataset.config);
-      case "source":
-        return FoundryAdapter.renderSourceConfig(this.item, "system.source");
-      case "starting-equipment":
+    switch (target.dataset.config) {
+      case 'movement':
+      case 'senses':
+        return FoundryAdapter.renderMovementSensesConfig(
+          this.item,
+          target.dataset.config,
+        );
+      case 'source':
+        return FoundryAdapter.renderSourceConfig(this.item, 'system.source');
+      case 'starting-equipment':
         return FoundryAdapter.openStartingEquipmentConfig(this.item);
-      case "type":
+      case 'type':
         return this._renderChild(
           new dnd5e.applications.shared.CreatureTypeConfig({
             document: this.item,
             keyPath: 'type',
           }),
         );
-    }  
+    }
   }
 
   /* -------------------------------------------- */
@@ -1074,6 +1077,11 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin<
   _onDragStart(
     event: DragEvent & { currentTarget: HTMLElement; target: HTMLElement },
   ) {
+    // Let content links (enricher items) use default drag/drop so they aren't pulled into advancement drag behaviors.
+    if (event.target.classList.contains('content-link')) {
+      return;
+    }
+
     const dragged = event.currentTarget;
 
     // Create drag data
@@ -1099,9 +1107,7 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin<
       dragged.closest('[data-id]')
     ) {
       const { id } = dragged.closest<HTMLElement>('[data-id]')!.dataset ?? {};
-      dragData = this.item.system.advancement
-        .get(id)
-        ?.toDragData();
+      dragData = this.item.system.advancement.get(id)?.toDragData();
     }
 
     if (!dragData) return;
@@ -1322,7 +1328,10 @@ export class Tidy5eItemSheetQuadrone extends TidyExtensibleDocumentSheetMixin<
   async _onDropItem(event: DragEvent, data: object) {
     const item = await Item.implementation.fromDropData(data);
 
-    if (item?.type === CONSTANTS.ITEM_TYPE_SPELL && this.item.system.activities) {
+    if (
+      item?.type === CONSTANTS.ITEM_TYPE_SPELL &&
+      this.item.system.activities
+    ) {
       this._onDropSpell(event, item);
     } else {
       this._onDropAdvancement(event, data);

--- a/src/sheets/quadrone/Tidy5eMultiActorSheetQuadroneBase.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eMultiActorSheetQuadroneBase.svelte.ts
@@ -1,5 +1,5 @@
 import { CONSTANTS } from 'src/constants';
-import { Tidy5eActorSheetQuadroneBase } from './Tidy5eActorSheetQuadroneBase.svelte';
+import { GetTidy5eActorSheetQuadroneBase } from './Tidy5eActorSheetQuadroneBase.svelte';
 import type {
   Actor5e,
   ActorInventoryTypes,
@@ -37,7 +37,7 @@ import { SettingsProvider } from 'src/settings/settings.svelte';
 export function Tidy5eMultiActorSheetQuadroneBase<
   TContext extends MultiActorQuadroneContext<any>
 >(sheetType: string) {
-  const TidyActorSheetBase = Tidy5eActorSheetQuadroneBase<TContext>(sheetType);
+  const TidyActorSheetBase = GetTidy5eActorSheetQuadroneBase<TContext>(sheetType);
 
   abstract class Tidy5eMultiActorSheetQuadroneBase extends TidyActorSheetBase {
     static DEFAULT_OPTIONS: Partial<

--- a/src/sheets/quadrone/Tidy5eNpcSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eNpcSheetQuadrone.svelte.ts
@@ -1,5 +1,5 @@
 import { CONSTANTS } from 'src/constants';
-import { Tidy5eActorSheetQuadroneBase } from './Tidy5eActorSheetQuadroneBase.svelte';
+import { GetTidy5eActorSheetQuadroneBase } from './Tidy5eActorSheetQuadroneBase.svelte';
 import type {
   Actor5e,
   ActorInventoryTypes,
@@ -41,7 +41,7 @@ import { ItemContext } from 'src/features/item/ItemContext';
 import SectionActions from 'src/features/sections/SectionActions';
 import { TidyHooks } from 'src/foundry/TidyHooks';
 
-export class Tidy5eNpcSheetQuadrone extends Tidy5eActorSheetQuadroneBase<NpcSheetQuadroneContext>(
+export class Tidy5eNpcSheetQuadrone extends GetTidy5eActorSheetQuadroneBase<NpcSheetQuadroneContext>(
   CONSTANTS.SHEET_TYPE_NPC
 ) {
   currentTabId: string;

--- a/src/sheets/quadrone/Tidy5eVehicleSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eVehicleSheetQuadrone.svelte.ts
@@ -19,7 +19,7 @@ import type {
 import VehicleSheet from './actor/VehicleSheet.svelte';
 import { mount } from 'svelte';
 import { initTidy5eContextMenu } from 'src/context-menu/tidy5e-context-menu';
-import { Tidy5eActorSheetQuadroneBase } from './Tidy5eActorSheetQuadroneBase.svelte';
+import { GetTidy5eActorSheetQuadroneBase } from './Tidy5eActorSheetQuadroneBase.svelte';
 import { VehicleSheetQuadroneRuntime } from 'src/runtime/actor/VehicleSheetQuadroneRuntime.svelte';
 import { ItemContext } from 'src/features/item/ItemContext';
 import { ConditionsAndEffects } from 'src/features/conditions-and-effects/ConditionsAndEffects';
@@ -37,7 +37,7 @@ import { isNil } from 'src/utils/data';
 
 const localize = FoundryAdapter.localize;
 
-export class Tidy5eVehicleSheetQuadrone extends Tidy5eActorSheetQuadroneBase<VehicleSheetQuadroneContext>(
+export class Tidy5eVehicleSheetQuadrone extends GetTidy5eActorSheetQuadroneBase<VehicleSheetQuadroneContext>(
   CONSTANTS.SHEET_TYPE_VEHICLE
 ) {
   currentTabId: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,11 +46,12 @@ export default defineConfig({
       fileName: 'tidy5e-sheet',
       formats: ['es'],
     },
-    rollupOptions: {
+    rolldownOptions: {
       output: {
         globals: {
           svelte: 'svelte',
         },
+        keepNames: true,
       },
     },
     sourcemap: true,


### PR DESCRIPTION
- fixed: The project build was changing class names against our will between dependency updates / compilations, causing hook names to change and breaking functionality for people who rely on base class names.
- fixed: Dragging an enricher item / content link from an advancement and dropping somewhere was not creating an item like expected.
- fixed: Tidy dependency updates brought some strange default settings to the build, causing an unwanted blur to appear on sheets in dark mode.