### PR TITLE
feat/bug: Vehicle broken links TLC

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -984,6 +984,7 @@
   "TIDY5E.Vehicle.Equipment.HP.Label": "Avg. HP",
   "TIDY5E.Vehicle.Unassigned.EmptyState": "Drag and drop crew here, or click to add. Crew can then be assigned to vehicle equipment or features.",
   "TIDY5E.Vehicle.Passenger.EmptyState": "Drag and drop passengers here, or click to add.",
+  "TIDY5E.Vehicle.RemoveBrokenLinks": "Remove {value} broken link(s)",
   "TIDY5E.TotalCrewCount": "Total Crew",
   "TIDY5E.ActionsPerTurn": "Actions Per Turn",
   "TIDY5E.SheetMenu": {

--- a/src/context-menu/tidy5e-vehicle-member-context-menu.ts
+++ b/src/context-menu/tidy5e-vehicle-member-context-menu.ts
@@ -5,7 +5,7 @@ import type { Tidy5eVehicleSheetQuadrone } from 'src/sheets/quadrone/Tidy5eVehic
 
 export function configureVehicleMemberContextMenu(
   element: HTMLElement,
-  app: Tidy5eVehicleSheetQuadrone
+  app: Tidy5eVehicleSheetQuadrone,
 ) {
   ui.context.menuItems = getVehicleMemberContextOptionsQuadrone(element, app);
 
@@ -15,7 +15,7 @@ export function configureVehicleMemberContextMenu(
     getMemberUuid(element),
     getVehicleItemId(element),
     getCrewArea(element),
-    ui.context.menuItems
+    ui.context.menuItems,
   );
 }
 
@@ -27,7 +27,7 @@ export function configureVehicleMemberContextMenu(
  */
 function getVehicleMemberContextOptionsQuadrone(
   element: HTMLElement,
-  app: Tidy5eVehicleSheetQuadrone
+  app: Tidy5eVehicleSheetQuadrone,
 ) {
   const vehicleItemId = getVehicleItemId(element);
 
@@ -46,20 +46,18 @@ function getVehicleMemberContextOptionsQuadrone(
 
 function getCrewArea(element: HTMLElement) {
   return element.closest('[data-area]')?.getAttribute('data-area') as
-    | CrewArea5e
-    | undefined;
+    CrewArea5e | undefined;
 }
 
 function getVehicleItemId(element: HTMLElement) {
   return element.closest('[data-item-id]')?.getAttribute('data-item-id') as
-    | string
-    | undefined;
+    string | undefined;
 }
 
 function getVehicleItemMemberOptions(
   element: HTMLElement,
   app: Tidy5eVehicleSheetQuadrone,
-  vehicleItemId: string
+  vehicleItemId: string,
 ): ContextMenuEntry[] {
   const brokenLink = !!element.closest('.broken');
   const empty = !!element.closest('.empty');
@@ -90,10 +88,8 @@ function getVehicleItemMemberOptions(
       condition: () => !!memberUuid,
       icon: '<i class="fa-solid fa-user-minus"></i>',
       callback: async () => {
-        const actor = await fromUuid(memberUuid);
-
-        if (item) {
-          await app._unassignCrew(actor, item);
+        if (item && memberUuid) {
+          await app._unassignCrew(memberUuid, item);
         }
       },
     },
@@ -110,7 +106,7 @@ function getVehicleItemMemberOptions(
 
 function getDraftMemberOptions(
   element: HTMLElement,
-  app: Tidy5eVehicleSheetQuadrone
+  app: Tidy5eVehicleSheetQuadrone,
 ): ContextMenuEntry[] {
   const canChange = canChangeDocument(app);
 
@@ -120,7 +116,7 @@ function getDraftMemberOptions(
     {
       name: FoundryAdapter.localize('TIDY5E.RemoveSpecific', {
         name: FoundryAdapter.localize(
-          'TIDY5E.Vehicle.Member.DraftAnimal.Label'
+          'TIDY5E.Vehicle.Member.DraftAnimal.Label',
         ),
       }),
       icon: '<i class="fa-solid fa-trash"></i>',
@@ -136,59 +132,60 @@ function getDraftMemberOptions(
 
 function getCrewMemberOptions(
   element: HTMLElement,
-  app: Tidy5eVehicleSheetQuadrone
+  app: Tidy5eVehicleSheetQuadrone,
 ): ContextMenuEntry[] {
   const memberUuid = getMemberUuid(element);
 
   const assigned = !!element.closest(
-    '[data-area="crew"][data-tidy-section-key="assigned"]'
+    '[data-area="crew"][data-tidy-section-key="assigned"]',
   );
 
   const unassigned = !!element.closest(
-    '[data-area="crew"][data-tidy-section-key="unassigned"]'
+    '[data-area="crew"][data-tidy-section-key="unassigned"]',
   );
 
   const assignableItems = app.getAssignableItems();
 
   const currentlyAssignedItemId = assigned
     ? element
-      .closest('[data-assigned-item-id]')
-      ?.getAttribute('data-assigned-item-id')
+        .closest('[data-assigned-item-id]')
+        ?.getAttribute('data-assigned-item-id')
     : undefined;
 
   const area = element.closest('[data-area]')?.getAttribute('data-area') as
-    | CrewArea5e
-    | undefined;
+    CrewArea5e | undefined;
 
   const canChange = canChangeDocument(app);
 
   const assignableItemOptions: ContextMenuEntry[] = Object.values(
-    assignableItems
+    assignableItems,
   )
     .map((mountableItem) => {
       return {
         name: `${FoundryAdapter.localize(
           'TIDY5E.ContextMenuActionAssignToEntity',
-          { entityName: mountableItem.name }
+          { entityName: mountableItem.name },
         )} ${mountableItem.crew?.value ?? '0'}/${
           mountableItem.crew?.max ?? '—'
         }`,
         icon: '<i class="fa-solid fa-user-plus fa-fw"></i>',
         condition: () => area === 'crew' && canChange,
         callback: async () => {
-          const actor = await fromUuid(memberUuid);
+          if (!memberUuid) {
+            return;
+          }
 
           const currentlyAssignedItem = app.document.items.get(
-            currentlyAssignedItemId
+            currentlyAssignedItemId,
           );
 
           if (currentlyAssignedItem) {
-            await app._unassignCrew(actor, currentlyAssignedItem);
+            await app._unassignCrew(memberUuid, currentlyAssignedItem);
           }
 
           const newItemToAssign = app.document.items.get(mountableItem.id);
 
-          await app._assignCrew(actor, newItemToAssign, { src: area });
+          await app._assignCrew(memberUuid, newItemToAssign, { src: area });
         },
       };
     })
@@ -200,14 +197,16 @@ function getCrewMemberOptions(
       icon: '<i class="fa-solid fa-user-minus fa-fw"></i>',
       condition: () => !!currentlyAssignedItemId && canChange,
       callback: async () => {
-        const actor = await fromUuid(memberUuid);
+        if (!memberUuid) {
+          return;
+        }
 
         const currentlyAssignedItem = app.document.items.get(
-          currentlyAssignedItemId
+          currentlyAssignedItemId,
         );
 
         if (currentlyAssignedItemId) {
-          await app._unassignCrew(actor, currentlyAssignedItem);
+          await app._unassignCrew(memberUuid, currentlyAssignedItem);
         }
       },
     },
@@ -215,7 +214,7 @@ function getCrewMemberOptions(
     {
       name: FoundryAdapter.localize('TIDY5E.RemoveSpecific', {
         name: FoundryAdapter.localize(
-          'TIDY5E.Vehicle.Section.Crew.Unassigned.Label'
+          'TIDY5E.Vehicle.Section.Crew.Unassigned.Label',
         ),
       }),
       icon: '<i class="fa-solid fa-trash"></i>',
@@ -242,8 +241,7 @@ function getCrewMemberOptions(
 }
 function getMemberUuid(element: HTMLElement) {
   return element.closest('[data-uuid]')?.getAttribute('data-uuid') as
-    | string
-    | undefined;
+    string | undefined;
 }
 
 function canChangeDocument(app: Tidy5eVehicleSheetQuadrone) {

--- a/src/runtime/tables/TableRowActionsRuntime.svelte.ts
+++ b/src/runtime/tables/TableRowActionsRuntime.svelte.ts
@@ -574,7 +574,7 @@ class TableRowActionsRuntime {
         props: (args) => ({
           callback: () => {
             return context.sheet._unassignCrew(
-              args.data.actor,
+              args.data.actor.uuid,
               args.data.ctx.assignedTo,
             );
           },

--- a/src/sheets/quadrone/Tidy5eVehicleSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eVehicleSheetQuadrone.svelte.ts
@@ -65,10 +65,12 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
         target: HTMLElement,
       ) {
         const area =
-          target.closest('[data-area]')?.getAttribute('data-area') ?? 'crew';
+          target.closest('[data-area]')?.getAttribute('data-area') ??
+          CONSTANTS.SECTION_TYPE_CREW;
 
         return this.browseAddActor(area);
       },
+      removeBrokenLinks: Tidy5eVehicleSheetQuadrone.#onRemoveBrokenLinks,
       removeDraftAnimal: Tidy5eVehicleSheetQuadrone.#onRemoveDraftAnimal,
       removePassengers: Tidy5eVehicleSheetQuadrone.#onRemovePassengers,
       removeUnassignedCrew: Tidy5eVehicleSheetQuadrone.#onRemoveUnassignedCrew,
@@ -84,7 +86,7 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
       return;
     }
 
-    await this._assignCrew(actor, item);
+    await this._assignCrew(newCrewmateUuid, item);
   }
 
   browseActors(): Promise<Actor5e | undefined> {
@@ -135,7 +137,7 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
   }
 
   async _prepareContext(
-    options: ApplicationRenderOptions,
+    options?: ApplicationRenderOptions,
   ): Promise<VehicleSheetQuadroneContext> {
     if (options?.tidy?.soft && this._context?.data) {
       return this._context.data;
@@ -205,7 +207,7 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
       crew: {
         assigned: {
           ...SheetSections.EMPTY,
-          type: 'crew',
+          type: CONSTANTS.SECTION_TYPE_CREW,
           label: 'TIDY5E.Vehicle.Section.Crew.Assigned.Label',
           members: [],
           key: CONSTANTS.SECTION_KEY_ASSIGNED,
@@ -217,7 +219,7 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
         },
         unassigned: {
           ...SheetSections.EMPTY,
-          type: 'crew',
+          type: CONSTANTS.SECTION_TYPE_CREW,
           label: 'TIDY5E.Vehicle.Section.Crew.Unassigned.Label',
           members: [],
           key: CONSTANTS.SECTION_KEY_UNASSIGNED,
@@ -228,6 +230,8 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
           ),
         },
       },
+      crewBrokenLinks: [],
+      draftBrokenLinks: [],
       currencies,
       effects: enhancedEffectSections,
       encumbrance: await this.actor.system.getEncumbrance(),
@@ -241,7 +245,7 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
       mountableItems: {},
       passengers: {
         ...SheetSections.EMPTY,
-        type: 'passengers',
+        type: CONSTANTS.SECTION_TYPE_PASSENGERS,
         label: 'DND5E.VEHICLE.Crew.Passengers',
         members: [],
         key: CONSTANTS.SECTION_KEY_PASSENGERS,
@@ -251,6 +255,7 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
           CONSTANTS.SECTION_KEY_PASSENGERS,
         ),
       },
+      passengerBrokenLinks: [],
       quality: this.actor.system.attributes.quality?.value ?? 0,
       size: {
         key: this.actor.system.traits.size,
@@ -335,11 +340,25 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
       type: 'draft',
       key: 'draft',
       label: 'TIDY5E.Vehicle.Member.DraftAnimal.LabelPl',
-      members: await Promise.all(
-        this.actor.system.draft.value.map(async (uuid: string) => {
-          const actor = await fromUuid(uuid);
+      members: [],
+      columns: VehicleMemberColumnRuntime.getColumnSpecifications(
+        this.document,
+        CONSTANTS.TAB_STATBLOCK,
+        'draft',
+      ),
+    };
 
-          return {
+    const members = await Promise.all(
+      (this.actor.system.draft.value as string[]).map(async (uuid: string) => {
+        const actor = await fromUuid(uuid);
+
+        if (!actor) {
+          return { uuid };
+        }
+
+        return {
+          uuid,
+          value: {
             actor,
             subtitle: this._getSubtitle(actor),
             quantity: 1,
@@ -349,15 +368,18 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
                 !action.condition ||
                 action.condition({ data: { actor, ctx: undefined } }),
             ),
-          } satisfies DraftAnimalContext;
-        }),
-      ),
-      columns: VehicleMemberColumnRuntime.getColumnSpecifications(
-        this.document,
-        CONSTANTS.TAB_STATBLOCK,
-        'draft',
-      ),
-    };
+          } satisfies DraftAnimalContext,
+        };
+      }),
+    );
+
+    for (const member of members) {
+      if (member.value) {
+        drafted.members.push(member.value);
+      } else {
+        context.draftBrokenLinks.push(member.uuid);
+      }
+    }
 
     context.statblock.push(drafted);
   }
@@ -388,23 +410,37 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
       }
     }
 
-    context.crew.assigned.members = (
+    const { value: assignedCrewContextValue, broken: brokenAssignedCrewUuids } =
       await this.resolveCrewMemberContext(
         assigned,
         TableRowActionsRuntime.getAssignedCrewRowActions(context),
         assignments,
-      )
-    ).value;
+      );
+    context.crew.assigned.members = assignedCrewContextValue;
 
-    context.crew.unassigned.members = (
-      await this.resolveCrewMemberContext(
-        unassigned,
-        TableRowActionsRuntime.getUnassignedCrewPassengerRowActions(
-          context,
-          CONSTANTS.SECTION_TYPE_CREW,
-        ),
-      )
-    ).value;
+    const {
+      value: unassignedCrewContextValue,
+      broken: brokenUnassignedCrewUuids,
+    } = await this.resolveCrewMemberContext(
+      unassigned,
+      TableRowActionsRuntime.getUnassignedCrewPassengerRowActions(
+        context,
+        CONSTANTS.SECTION_TYPE_CREW,
+      ),
+    );
+    context.crew.unassigned.members = unassignedCrewContextValue;
+
+    // Add the actual number of broken passengers, even if duplicate actor UUIDs.
+    if (brokenAssignedCrewUuids.length || brokenUnassignedCrewUuids.length) {
+      for (const uuid of [
+        ...brokenAssignedCrewUuids,
+        ...brokenUnassignedCrewUuids,
+      ]) {
+        for (let i = 0; i < (crew[uuid] ?? 0); i++) {
+          context.crewBrokenLinks.push(uuid);
+        }
+      }
+    }
   }
 
   private async _preparePassengers(context: VehicleSheetQuadroneContext) {
@@ -416,23 +452,42 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
         CONSTANTS.SECTION_TYPE_PASSENGERS,
       );
 
-    context.passengers.members = (
-      await Promise.all(
-        Object.keys(groups).map(async (uuid) => {
-          const actor = await fromUuid(uuid);
-          return {
-            actor,
-            subtitle: this._getSubtitle(actor),
-            quantity: groups[uuid],
-            rowActions: rowActions.filter(
-              (action) =>
-                !action.condition ||
-                action.condition({ data: { actor, ctx: undefined } }),
-            ),
-          } satisfies PassengerMemberContext;
-        }),
-      )
-    ).filter((ctx) => !!ctx.actor);
+    const passengerResult = await Promise.all(
+      Object.keys(groups).map(async (uuid) => {
+        const actor = await fromUuid(uuid);
+
+        if (!actor) {
+          return { uuid };
+        }
+
+        const value = {
+          actor,
+          subtitle: this._getSubtitle(actor),
+          quantity: groups[uuid],
+          rowActions: rowActions.filter(
+            (action) =>
+              !action.condition ||
+              action.condition({ data: { actor, ctx: undefined } }),
+          ),
+        } satisfies PassengerMemberContext;
+
+        return {
+          uuid,
+          value,
+        };
+      }),
+    );
+
+    for (const passenger of passengerResult) {
+      if (passenger.value) {
+        context.passengers.members.push(passenger.value);
+      } else {
+        // Add the actual number of broken passengers, even if duplicate actor UUIDs.
+        for (let i = 0; i < (groups[passenger.uuid] ?? 0); i++) {
+          context.passengerBrokenLinks.push(passenger.uuid);
+        }
+      }
+    }
   }
 
   async _prepareItems(context: VehicleSheetQuadroneContext): Promise<void> {
@@ -705,7 +760,10 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
     );
 
     // Handle crew actions
-    if (item.type === 'feat' && item.system.activation?.type === 'crew') {
+    if (
+      item.type === 'feat' &&
+      item.system.activation?.type === CONSTANTS.ACTIVATION_COST_CREW
+    ) {
       if (item.system.cover === 1) {
         ctx.cover = FoundryAdapter.localize('DND5E.CoverTotal');
       } else if (item.system.cover === 0.5) {
@@ -813,6 +871,48 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
     return entries;
   }
 
+  async removeBrokenLinks(area?: CrewArea5e) {
+    const context = await this._prepareContext({ tidy: { soft: true } });
+
+    let toUpdate: Record<string, any> = {};
+
+    const itemUpdates: Promise<void>[] = [];
+
+    if (area === CONSTANTS.SECTION_TYPE_CREW || !area) {
+      let crew = this.document.system.crew.value as string[];
+      crew = crew.filter((uuid) => !context.crewBrokenLinks.includes(uuid));
+      toUpdate['system.crew.value'] = crew;
+
+      // Clear all item assignments
+      const vehicleItems = context.items.filter((i) => i.system.isMountable);
+      for (const item of vehicleItems) {
+        const repairedItemCrew = item.system.crew.value.filter(
+          (uuid: string) => !context.crewBrokenLinks.includes(uuid),
+        );
+
+        itemUpdates.push(
+          item.update({ 'system.crew.value': repairedItemCrew }),
+        );
+      }
+    }
+
+    if (area === CONSTANTS.SECTION_TYPE_PASSENGERS || !area) {
+      let passengers = this.document.system.passengers.value as string[];
+      passengers = passengers.filter(
+        (uuid) => !context.passengerBrokenLinks.includes(uuid),
+      );
+      toUpdate['system.passengers.value'] = passengers;
+    }
+
+    if (area === CONSTANTS.SECTION_TYPE_DRAFT_ANIMALS || !area) {
+      let draft = this.document.system.draft.value as string[];
+      draft = draft.filter((uuid) => !context.draftBrokenLinks.includes(uuid));
+      toUpdate['system.draft.value'] = draft;
+    }
+
+    await Promise.all([this.document.update(toUpdate), ...itemUpdates]);
+  }
+
   async removeDraftAnimal(uuid: string) {
     const draft = [...this.actor.system.draft.value];
     const removed = draft.findSplice((u) => u === uuid);
@@ -833,7 +933,11 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
       return;
     }
 
-    await this.applyDeltaToCrew('crew', uuid, `-${numberToRemove}`);
+    await this.applyDeltaToCrew(
+      CONSTANTS.SECTION_TYPE_CREW,
+      uuid,
+      `-${numberToRemove}`,
+    );
   }
 
   async removePassengers(uuid: string) {
@@ -879,7 +983,7 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
    * @protected
    */
   async _assignCrew(
-    actor: Actor5e,
+    memberUuid: string,
     item: Item5e,
     { src }: { src?: CrewArea5e } = {},
   ): Promise<void> {
@@ -888,7 +992,7 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
     let crew = foundry.utils.getProperty(item, 'system.crew.value');
 
     // Prevent assigning a non-crew-member.
-    if (src && src !== 'crew') {
+    if (src && src !== CONSTANTS.SECTION_TYPE_CREW) {
       return;
     }
 
@@ -896,25 +1000,29 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
     if (!src) {
       Object.assign(
         actorUpdates,
-        this.actor.system.getCrewUpdates('crew', actor.uuid, '+1'),
+        this.actor.system.getCrewUpdates(
+          CONSTANTS.SECTION_TYPE_CREW,
+          memberUuid,
+          '+1',
+        ),
       );
     }
 
     foundry.utils.setProperty(
       itemUpdates,
       'system.crew.value',
-      crew.concat(actor.uuid),
+      crew.concat(memberUuid),
     );
 
     await this.actor.update(actorUpdates);
   }
 
-  async _unassignCrew(actor: { uuid: string }, item: Item5e) {
+  async _unassignCrew(memberUuid: string, item: Item5e) {
     let crew = foundry.utils.getProperty(item, 'system.crew.value');
 
     crew = [...crew];
 
-    if (!crew.findSplice((u: string) => u === actor.uuid)) {
+    if (!crew.findSplice((u: string) => u === memberUuid)) {
       return;
     }
 
@@ -934,6 +1042,15 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
   /* -------------------------------------------- */
   /*  Sheet Actions                               */
   /* -------------------------------------------- */
+
+  static async #onRemoveBrokenLinks(
+    this: Tidy5eVehicleSheetQuadrone,
+    _event: Event,
+    target: HTMLElement,
+  ) {
+    const area = target.closest<HTMLElement>('[data-area]')?.dataset.area;
+    return this.removeBrokenLinks(area);
+  }
 
   static async #onRemoveDraftAnimal(
     this: Tidy5eVehicleSheetQuadrone,
@@ -1018,7 +1135,7 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
       sectionKey,
     } = foundry.applications.ux.TextEditor.getDragEventData(event);
 
-    const { area: dest = 'crew' } =
+    const { area: dest = CONSTANTS.SECTION_TYPE_CREW } =
       event.target?.closest<HTMLElement>('[data-area]')?.dataset ?? {};
 
     const { tidySectionKey: destKey } =
@@ -1033,12 +1150,16 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
     const context = await this._prepareContext({ tidy: { soft: true } });
 
     // From Assigned Crew, dropping away from Assigned
-    if (src === 'crew' && sectionKey === 'assigned' && destKey !== 'assigned') {
+    if (
+      src === CONSTANTS.SECTION_TYPE_CREW &&
+      sectionKey === 'assigned' &&
+      destKey !== 'assigned'
+    ) {
       const currentAssignedItem = context.crew.assigned.members.find(
         (m) => m.actor.uuid === document.uuid,
       )?.assignedTo;
 
-      await this._unassignCrew(document, currentAssignedItem);
+      await this._unassignCrew(document.uuid, currentAssignedItem);
     }
 
     if (src === dest) {
@@ -1046,10 +1167,10 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
     }
 
     const quantity =
-      src === 'passenger'
+      src === CONSTANTS.SECTION_TYPE_PASSENGERS
         ? context.passengers.members.find((m) => m.actor.uuid === document.uuid)
             ?.quantity
-        : src === 'crew' && sectionKey === 'unassigned'
+        : src === CONSTANTS.SECTION_TYPE_CREW && sectionKey === 'unassigned'
           ? context.crew.unassigned.members.find(
               (m) => m.actor.uuid === document.uuid,
             )?.quantity
@@ -1090,8 +1211,10 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
     actorToItemAssignments?: Record<string, string[]>,
   ): Promise<{
     value: CrewMemberContext[];
+    broken: string[];
   }> {
     const value: CrewMemberContext[] = [];
+    const broken: string[] = [];
 
     for (const [uuid, quantity] of Object.entries(group)) {
       if (!quantity) {
@@ -1101,6 +1224,7 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
       const actor = await fromUuid(uuid);
 
       if (!actor) {
+        broken.push(uuid);
         continue;
       }
 
@@ -1147,6 +1271,7 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
           a.actor.name.localeCompare(b.actor.name, game.i18n.lang)
         );
       }),
+      broken,
     };
   }
 

--- a/src/sheets/quadrone/Tidy5eVehicleSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eVehicleSheetQuadrone.svelte.ts
@@ -910,6 +910,7 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
       toUpdate['system.draft.value'] = draft;
     }
 
+    // game.release.generation <= 14 // convert to batched update
     await Promise.all([this.document.update(toUpdate), ...itemUpdates]);
   }
 

--- a/src/sheets/quadrone/actor/tabs/VehicleCrewAndPassengersTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/VehicleCrewAndPassengersTab.svelte
@@ -51,7 +51,7 @@
             context.system.crew.value.length > context.system.crew.max,
         },
       ]}
-      data-area="crew"
+      data-area={CONSTANTS.SECTION_TYPE_CREW}
     >
       <div class="pin-details">
         <div class="pin-name-container">
@@ -84,6 +84,14 @@
             placeholder="—"
           />
         </span>
+        {#if context.crewBrokenLinks.length && context.editable}
+          <a data-action="removeBrokenLinks">
+            <i class="fa-solid fa-link-broken"></i>
+            {localize('TIDY5E.Vehicle.RemoveBrokenLinks', {
+              value: context.crewBrokenLinks.length,
+            })}
+          </a>
+        {/if}
       </div>
       {#if context.system.crew.max > 0}
         <!-- svelte-ignore a11y_missing_attribute -->
@@ -111,7 +119,7 @@
             context.system.passengers.max,
         },
       ]}
-      data-area="passengers"
+      data-area={CONSTANTS.SECTION_TYPE_PASSENGERS}
     >
       <div class="pin-details">
         <div class="pin-name-container">
@@ -144,6 +152,14 @@
             placeholder="—"
           />
         </span>
+        {#if context.passengerBrokenLinks.length && context.editable}
+          <a data-action="removeBrokenLinks">
+            <i class="fa-solid fa-link-broken"></i>
+            {localize('TIDY5E.Vehicle.RemoveBrokenLinks', {
+              value: context.passengerBrokenLinks.length,
+            })}
+          </a>
+        {/if}
       </div>
       {#if context.system.passengers.max > 0}
         <!-- svelte-ignore a11y_missing_attribute -->

--- a/src/sheets/quadrone/actor/tabs/VehicleStatblockTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/VehicleStatblockTab.svelte
@@ -483,6 +483,20 @@
               {/if}
             {/snippet}
           </TidyTable>
+
+          {#if context.draftBrokenLinks.length && context.editable}
+            <button
+              type="button"
+              class="button"
+              data-action="removeBrokenLinks"
+              data-area={CONSTANTS.SECTION_TYPE_DRAFT_ANIMALS}
+            >
+              <i class="fa-solid fa-link-broken"></i>
+              {localize('TIDY5E.Vehicle.RemoveBrokenLinks', {
+                value: context.draftBrokenLinks.length,
+              })}
+            </button>
+          {/if}
         {/if}
       {/if}
     {/each}

--- a/src/sheets/quadrone/actor/vehicle-parts/VehicleItemCrewAssignments.svelte
+++ b/src/sheets/quadrone/actor/vehicle-parts/VehicleItemCrewAssignments.svelte
@@ -22,7 +22,10 @@
   const localize = FoundryAdapter.localize;
 
   let context = $derived(getVehicleSheetQuadroneContext());
-  let isBasicTheme = $derived(ThemeQuadrone.getSheetThemeSettings({ doc: context.document }).useBasicTheme ?? false);
+  let isBasicTheme = $derived(
+    ThemeQuadrone.getSheetThemeSettings({ doc: context.document })
+      .useBasicTheme ?? false,
+  );
 
   function onEmptySlotClicked(
     ev: MouseEvent & { currentTarget: EventTarget & HTMLAnchorElement },
@@ -60,6 +63,8 @@
                 <a
                   data-action="showContextMenu"
                   data-target-selector="[data-context-menu]"
+                  data-tooltip=""
+                  aria-label={localize('TIDY5E.BrokenLink')}
                 >
                   <i class="fa-solid fa-link-slash broken-link-icon"></i>
                 </a>
@@ -76,14 +81,18 @@
                         'data-action': 'showContextMenu',
                         'data-target-selector': '[data-context-menu]',
                       }
-                    : {}
-                )}
+                    : {},
+              )}
               <li
                 class="slot member-slot"
                 data-uuid={slot.actor.uuid}
                 data-context-menu={CONSTANTS.CONTEXT_MENU_TYPE_VEHICLE_MEMBER}
               >
-                <a {...memberAttributes}>
+                <a
+                  {...memberAttributes}
+                  data-tooltip=""
+                  aria-label={slot.actor.name}
+                >
                   <img src={slot.actor.img} alt={slot.actor.name} />
                 </a>
               </li>

--- a/src/sheets/quadrone/item/columns/VehicleCrewAssignToColumn.svelte
+++ b/src/sheets/quadrone/item/columns/VehicleCrewAssignToColumn.svelte
@@ -20,8 +20,13 @@
     const src =
       event.currentTarget.closest('[data-area]')?.getAttribute('data-area') ??
       'crew';
+
     const item = await fromUuid(uuid);
-    await context.sheet._assignCrew(rowDocument, item, { src });
+
+    if (item) {
+      await context.sheet._assignCrew(rowDocument.uuid, item, { src });
+    }
+
     uuid = '';
   }
 </script>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1736,6 +1736,8 @@ export type VehicleSheetQuadroneContext = {
     denomination: string;
   };
   crew: CrewSections;
+  crewBrokenLinks: string[];
+  draftBrokenLinks: string[];
   currencies: CurrencyContext[];
   effects: ActiveEffectSection[];
   encumbrance: EncumbranceContext;
@@ -1756,6 +1758,7 @@ export type VehicleSheetQuadroneContext = {
     }
   >;
   passengers: PassengerSection;
+  passengerBrokenLinks: string[];
   quality: number;
   size: ActorSizeContext;
   speeds: ActorSpeedSenseEntryContext[];


### PR DESCRIPTION
- fixed: removing broken assigned crew links from mountable items was not working
- new: when there are broken links for draft animals, crew, or passengers, an appropriate button is available to remove broken links. This also removes broken assignments to mountable items owned by the vehicle. Broken links occur when an actor is added to the vehicle, and then the actor is somehow removed from the world or compendia.
- fixed: when there are broken passenger or draft animal links, the sheet would fail to open