### PR TITLE
Effect Context Menu - "View Item"

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -117,7 +117,7 @@
   "TIDY5E.ContextMenuActionUnprepare": "Unprepare",
   "TIDY5E.ContextMenuActionEdit": "Edit",
   "TIDY5E.ContextMenuActionView": "View",
-  "TIDY5E.ContextMenuActionViewItem": "View Item",
+  "TIDY5E.ContextMenuActionViewItem": "View Source Item",
   "TIDY5E.ContextMenuActionDelete": "Delete",
   "TIDY5E.ContextMenuActionPickColor": "Pick Color",
   "TIDY5E.ContextMenuActionPinToAttributes": "Pin to Attributes",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -117,6 +117,7 @@
   "TIDY5E.ContextMenuActionUnprepare": "Unprepare",
   "TIDY5E.ContextMenuActionEdit": "Edit",
   "TIDY5E.ContextMenuActionView": "View",
+  "TIDY5E.ContextMenuActionViewItem": "View Item",
   "TIDY5E.ContextMenuActionDelete": "Delete",
   "TIDY5E.ContextMenuActionPickColor": "Pick Color",
   "TIDY5E.ContextMenuActionPinToAttributes": "Pin to Attributes",

--- a/src/context-menu/tidy5e-active-effect-context-menu-quadrone.ts
+++ b/src/context-menu/tidy5e-active-effect-context-menu-quadrone.ts
@@ -7,7 +7,7 @@ import { warn } from 'src/utils/logging';
 export function getActiveEffectContextOptionsQuadrone(
   effect: any,
   app: any,
-  element: HTMLElement
+  element: HTMLElement,
 ) {
   const effectParent = effect.parent;
 
@@ -27,7 +27,7 @@ export function getActiveEffectContextOptionsQuadrone(
 
   const isConcentrationEffect = FoundryAdapter.isConcentrationEffect(
     effect,
-    app
+    app,
   );
 
   const isInFavorites = !!element.closest('.favorites');
@@ -35,6 +35,16 @@ export function getActiveEffectContextOptionsQuadrone(
   const isFav = FoundryAdapter.isEffectFavorited(effect, actor);
 
   let tidy5eKgarContextOptions: ContextMenuEntry[] = [
+    {
+      name: 'TIDY5E.ContextMenuActionViewItem',
+      icon: '<i class="fas fa-eye fa-fw"></i>',
+      group: 'common',
+      callback: () =>
+        app._renderChild(effect.item.sheet, {
+          mode: CONSTANTS.SHEET_MODE_PLAY,
+        }),
+      condition: () => !!effect.item,
+    },
     {
       name: effect.disabled
         ? 'DND5E.ContextMenuActionEnable'
@@ -84,7 +94,7 @@ export function getActiveEffectContextOptionsQuadrone(
               name: effect.name,
             }),
           },
-          { save: true }
+          { save: true },
         ),
       condition: () => !isInFavorites && canEditEffect(effect),
       group: 'common',

--- a/src/context-menu/tidy5e-active-effect-context-menu-quadrone.ts
+++ b/src/context-menu/tidy5e-active-effect-context-menu-quadrone.ts
@@ -43,7 +43,9 @@ export function getActiveEffectContextOptionsQuadrone(
         app._renderChild(effect.item.sheet, {
           mode: CONSTANTS.SHEET_MODE_PLAY,
         }),
-      condition: () => !!effect.item,
+      condition: () =>
+        !!effect.item &&
+        app.document.documentName !== CONSTANTS.DOCUMENT_NAME_ITEM,
     },
     {
       name: effect.disabled


### PR DESCRIPTION
"View Item" has its own localization key. I wasn't sure if we wanted to do a formatted one like "View {type}" or just "View Item". I opted for "View Item" but am open to doing it differently.

For an active effect from an item, when showing context menu on the actor, "View Item" appears:

<img width="650" height="390" alt="image" src="https://github.com/user-attachments/assets/de67bb43-95a2-4c6e-af90-064cb2d0a4e9" />

And it'll open the relevant item:

<img width="897" height="801" alt="image" src="https://github.com/user-attachments/assets/104889d7-84c3-4648-a7f2-99c92cdad84e" />

Not so for an actor's own effect:

<img width="727" height="280" alt="image" src="https://github.com/user-attachments/assets/a0daebf5-9f1e-48c1-a2d2-2a9ccac92244" />

And not so when using the Item sheet's context menu:

<img width="619" height="456" alt="image" src="https://github.com/user-attachments/assets/28d6fb94-495e-4788-8715-bd981cd559fe" />
