### PR TITLE
chore: Addressing piled up TODO items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1579,16 +1579,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/chokidar": {
@@ -2820,9 +2820,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2983,9 +2983,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -3003,7 +3003,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/src/less/shared/dnd5e2-ports.less
+++ b/src/less/shared/dnd5e2-ports.less
@@ -1,6 +1,6 @@
 .tidy5e-sheet {
 
-  /* TODO: Port to quadrone */
+  /* TODO: Convert to raw CSS */
 
   /* NPC Stat Blocks */
   .statblock.npc {

--- a/src/less/tidy5e.css
+++ b/src/less/tidy5e.css
@@ -1,4 +1,5 @@
 /* Common Styles */
+@import 'util';
 @import 'variables-quadrone.css';
 /* QUADRONE
 /* ------------------------------------------------------------ */

--- a/src/less/tidy5e.css
+++ b/src/less/tidy5e.css
@@ -1,5 +1,5 @@
 /* Common Styles */
-@import 'util';
+@import 'util.css';
 @import 'variables-quadrone.css';
 /* QUADRONE
 /* ------------------------------------------------------------ */

--- a/src/less/tidy5e.less
+++ b/src/less/tidy5e.less
@@ -1,5 +1,2 @@
-/* Common Styles */
-@import 'util';
-
 /* dnd5e integration */
 @import 'shared/dnd5e2-ports.less';

--- a/src/registry/features/row-actions.ts
+++ b/src/registry/features/row-actions.ts
@@ -68,6 +68,7 @@ export function getRowActionsRegistry(): TidyRowActionRegistry {
         condition: (args) =>
           // TODO: remove doc type logic after partitioning
           args.sheetDocument.system.isCharacter &&
+          args.data.usesSheetTab &&
           args.data.editable &&
           !args.data.unlocked,
         props: (args) => ({
@@ -190,6 +191,7 @@ export function getRowActionsRegistry(): TidyRowActionRegistry {
         condition: (args) =>
           // TODO: remove doc type logic after partitioning
           args.sheetDocument.system.isCharacter &&
+          args.data.usesSheetTab &&
           args.data.editable &&
           !args.data.unlocked,
         props: (args) => ({
@@ -265,6 +267,7 @@ export function getRowActionsRegistry(): TidyRowActionRegistry {
         condition: (args) =>
           // TODO: remove doc type logic after partitioning
           args.sheetDocument.system.isCharacter &&
+          args.data.usesSheetTab &&
           args.data.editable &&
           !args.data.unlocked,
         props: (args) => ({
@@ -403,6 +406,7 @@ export function getRowActionsRegistry(): TidyRowActionRegistry {
         condition: (args) =>
           // TODO: remove doc type logic after partitioning
           args.sheetDocument.system.isCharacter &&
+          args.data.usesSheetTab &&
           args.data.editable &&
           !args.data.unlocked,
         props: (args) => ({

--- a/src/settings/editors/special-traits-settings-editor.svelte.ts
+++ b/src/settings/editors/special-traits-settings-editor.svelte.ts
@@ -55,7 +55,7 @@ export function getSpecialTraitsSettingsEditor(
 
     // Always show the effective value, after active effects, because Special Traits application
     //  doesn't have a sheet mode mechanism to toggle views.
-    const source = document;
+    const source = document.toObject();
 
     flags.classes = Object.values(document.classes)
       .map((cls: Item5e) => ({ value: cls.id, label: cls.name }))
@@ -122,13 +122,13 @@ export function getSpecialTraitsSettingsEditor(
           {
             field: document.system.schema.fields.traits.fields.important,
             name: 'system.traits.important',
-            value: document.system.traits.important,
+            value: source.system.traits.important,
           },
         ],
       });
     }
 
-    return { flags, originalClass: document.system.details.originalClass };
+    return { flags, originalClass: source.system.details.originalClass };
   }
 
   return {

--- a/src/settings/editors/special-traits-settings-editor.svelte.ts
+++ b/src/settings/editors/special-traits-settings-editor.svelte.ts
@@ -53,8 +53,8 @@ export function getSpecialTraitsSettingsEditor(
     };
     const sections: Record<string, SpecialTraitSectionField[]> = {};
 
-    // Always show the effective value, after active effects, because Special Traits application
-    //  doesn't have a sheet mode mechanism to toggle views.
+    // Do NOT show the effective value (after active effects), because it will
+    // lead to a compounding stacking of bonuses being saved to the source data.
     const source = document.toObject();
 
     flags.classes = Object.values(document.classes)

--- a/src/sheets/quadrone/Tidy5eCharacterSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eCharacterSheetQuadrone.svelte.ts
@@ -275,18 +275,17 @@ export class Tidy5eCharacterSheetQuadrone extends getTidy5eActorSheetQuadroneBas
       );
     }
 
+    const tabs = await CharacterSheetQuadroneRuntime.getTabs(context);
+
+    const usesSheetTab = tabs.some((t) => t.id === CONSTANTS.TAB_ACTOR_ACTIONS);
+
     // Prepare owned items
-    this._prepareItems(context);
+    this._prepareItems(context, usesSheetTab);
 
     await this._prepareFacilities(context);
 
     context.skills = this._getSkillsToolsContext(context, 'skills');
     context.tools = this._getSkillsToolsContext(context, 'tools');
-
-    const tabs = await CharacterSheetQuadroneRuntime.getTabs(context);
-
-    // TODO: Incorporate user preference for whether to auto-populate or to fill with just those that are specifically indicated.
-    const usesSheetTab = tabs.some((t) => t.id === CONSTANTS.TAB_ACTOR_ACTIONS);
 
     if (usesSheetTab) {
       // TODO: create single, unified approach which takes eligible items, effects, activities,
@@ -755,7 +754,7 @@ export class Tidy5eCharacterSheetQuadrone extends getTidy5eActorSheetQuadroneBas
     return entries;
   }
 
-  _prepareItems(context: CharacterSheetQuadroneContext) {
+  _prepareItems(context: CharacterSheetQuadroneContext, usesSheetTab: boolean) {
     const eligibleItems = Array.from(this.actor.items).filter(
       (item: Item5e) => {
         // Suppress riders for disabled enchantments
@@ -836,7 +835,12 @@ export class Tidy5eCharacterSheetQuadrone extends getTidy5eActorSheetQuadroneBas
             // Contained items get row actions like any other item
             ctx.rowActions = InventoryRowActionRuntime.getRowActions({
               app: context.sheet,
-              data: context,
+              data: {
+                editable: context.editable,
+                owner: context.owner,
+                unlocked: context.unlocked,
+                usesSheetTab,
+              },
               rowDocument: item,
               sheetDocument: context.document,
             });
@@ -865,7 +869,12 @@ export class Tidy5eCharacterSheetQuadrone extends getTidy5eActorSheetQuadroneBas
 
       ctx.rowActions = InventoryRowActionRuntime.getRowActions({
         app: context.sheet,
-        data: context,
+        data: {
+          editable: context.editable,
+          owner: context.owner,
+          unlocked: context.unlocked,
+          usesSheetTab,
+        },
         rowDocument: item,
         sheetDocument: context.document,
       });
@@ -913,7 +922,12 @@ export class Tidy5eCharacterSheetQuadrone extends getTidy5eActorSheetQuadroneBas
       const ctx = (context.itemContext[item.id] ??= {});
       ctx.rowActions = SpellRowActionRuntime.getRowActions({
         app: context.sheet,
-        data: context,
+        data: {
+          editable: context.editable,
+          owner: context.owner,
+          unlocked: context.unlocked,
+          usesSheetTab,
+        },
         rowDocument: item,
         sheetDocument: context.document,
       });
@@ -952,7 +966,12 @@ export class Tidy5eCharacterSheetQuadrone extends getTidy5eActorSheetQuadroneBas
       const ctx = (context.itemContext[item.id] ??= {});
       ctx.rowActions = FeatureRowActionRuntime.getRowActions({
         app: context.sheet,
-        data: context,
+        data: {
+          editable: context.editable,
+          owner: context.owner,
+          unlocked: context.unlocked,
+          usesSheetTab,
+        },
         rowDocument: item,
         sheetDocument: context.document,
       });

--- a/src/sheets/quadrone/Tidy5eGroupSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eGroupSheetQuadrone.svelte.ts
@@ -243,6 +243,7 @@ export class Tidy5eGroupSheetQuadrone extends getTidy5eMultiActorSheetQuadroneBa
     let specials = new Map<string, GroupTrait>();
     let speeds = new Map<string, MeasurableGroupTrait<number>>();
     let tools = new Map<string, GroupTrait>();
+    let masteries = new Map<string, GroupTrait>();
 
     let skilled = new Map<string, GroupMemberQuadroneContext[]>([
       [CONSTANTS.SHEET_TYPE_CHARACTER, []],
@@ -346,6 +347,9 @@ export class Tidy5eGroupSheetQuadrone extends getTidy5eMultiActorSheetQuadroneBa
         // Abilities
         this._prepareMemberAbilities(actor, abilities);
 
+        // Masteries
+        this._prepareMemberMasteries(actor, masteries);
+
         // Skills
         skilled.get(actor.type)?.push(groupMemberContext);
         this._prepareMemberSkills(actor, skills);
@@ -403,6 +407,9 @@ export class Tidy5eGroupSheetQuadrone extends getTidy5eMultiActorSheetQuadroneBa
         languages: [...languages.values()].sort((a, b) =>
           a.label.localeCompare(b.label, game.i18n.lang),
         ),
+        masteries: [...masteries.values()].sort((a, b) =>
+          a.label.localeCompare(b.label, game.i18n.lang),
+        ),
         senses: [...senses.values()].sort((a, b) =>
           a.label.localeCompare(b.label, game.i18n.lang),
         ),
@@ -456,6 +463,18 @@ export class Tidy5eGroupSheetQuadrone extends getTidy5eMultiActorSheetQuadroneBa
 
       groupTool.identifiers.add(actor.uuid);
     });
+  }
+
+  _prepareMemberMasteries(actor: any, masteries: Map<string, GroupTrait>) {
+    for (const key of actor.system.traits?.weaponProf?.mastery?.value ?? []) {
+      const groupMastery = mapGetOrInsertComputed(masteries, key, (key) => ({
+        key,
+        label: dnd5e.documents.Trait.keyLabel(key, { trait: 'weapon' }) ?? key,
+        identifiers: new Set<string>(),
+      }));
+
+      groupMastery.identifiers.add(actor.uuid);
+    }
   }
 
   /* -------------------------------------------- */

--- a/src/sheets/quadrone/actor/NpcSheet.svelte
+++ b/src/sheets/quadrone/actor/NpcSheet.svelte
@@ -24,7 +24,6 @@
 
   let selectedTabId: string = $derived(context.currentTabId);
 
-
   // TODO: Combine these across sheets somehow?
   // Sidebar expanded setting, updates live.
   let sidebarExpandedPreference = $derived.by(() => {
@@ -45,8 +44,9 @@
     untrack(() => {
       const type = context.actor.type;
       const tabId = selectedTabId;
-      const stored = UserSheetPreferencesService.getByType(type)?.tabs?.[tabId]
-        ?.sidebarExpanded;
+      const stored =
+        UserSheetPreferencesService.getByType(type)?.tabs?.[tabId]
+          ?.sidebarExpanded;
       if (stored !== expanded) {
         UserSheetPreferencesService.setDocumentTypeTabPreference(
           type,
@@ -122,26 +122,19 @@
               data-tidy-sheet-part="sheet-header-actions-container"
             >
               {#if context.editable}
-                <button
-                  type="button"
-                  class="button button-icon-only short-rest button-gold"
-                  data-tooltip="DND5E.REST.Short.Label"
-                  aria-label={localize('DND5E.REST.Short.Label')}
-                  onclick={() => context.actor.shortRest()}
-                  disabled={!context.editable}
-                >
-                  <i class="fas fa-utensils"></i>
-                </button>
-                <button
-                  type="button"
-                  class="button button-icon-only long-rest button-gold"
-                  data-tooltip="DND5E.REST.Long.Label"
-                  aria-label={localize('DND5E.REST.Long.Label')}
-                  onclick={() => context.actor.longRest()}
-                  disabled={!context.editable}
-                >
-                  <i class="fas fa-campground"></i>
-                </button>
+                {#each Object.entries(context.config.restTypes) as [key, rest]}
+                  <button
+                    type="button"
+                    class="button button-icon-only short-rest button-gold"
+                    data-tooltip=""
+                    aria-label={localize(rest.label)}
+                    data-action="rest"
+                    data-type={key}
+                    disabled={!context.editable}
+                  >
+                    <i class={rest.icon}></i>
+                  </button>
+                {/each}
               {/if}
             </div>
           </div>
@@ -198,7 +191,9 @@
               data-type="initiative"
               data-has-roll-modes
             >
-              <span class="ability-abbr color-text-gold">{localize('DND5E.InitiativeAbbr')}</span>
+              <span class="ability-abbr color-text-gold"
+                >{localize('DND5E.InitiativeAbbr')}</span
+              >
               <span class="ability-label-container initiative-bonus">
                 <span class="modifier color-text-lightest">
                   {ini.sign}

--- a/src/sheets/quadrone/actor/group-parts/members-tab-sidebar/MembersTabSidebar.svelte
+++ b/src/sheets/quadrone/actor/group-parts/members-tab-sidebar/MembersTabSidebar.svelte
@@ -37,7 +37,9 @@
     identifiers: Map<string, GroupTraitBase<any>>,
   ) {
     return [...identifiers].map(([uuid, value]) => ({
-      context: context.memberContext.all.get(uuid) as GroupMemberQuadroneContext, // TODO: Change to reduce to avoid TS funny business
+      context: context.memberContext.all.get(
+        uuid,
+      ) as GroupMemberQuadroneContext, // TODO: Change to reduce to avoid TS funny business
       units: value.units,
       value: value.value?.toString(),
     }));
@@ -67,17 +69,19 @@
         <div class="list-values">
           <ul class="pills">
             {#each context.traits.languages as language}
-              {const isEmphasized =
-                $derived(emphasizedMember !== undefined &&
-                language.identifiers.has(emphasizedActorUuid))}
+              {const isEmphasized = $derived(
+                emphasizedMember !== undefined &&
+                  language.identifiers.has(emphasizedActorUuid),
+              )}
               {const pillState: ClassValue = $derived({
                 emphasized: isEmphasized,
                 'theme-dark': isEmphasized,
                 'trait-language': true,
                 diminished: emphasizedMember !== undefined && !isEmphasized,
               })}
-              {const pill =
-                $derived(language.identifiers.get(emphasizedActorUuid) ?? language)}
+              {const pill = $derived(
+                language.identifiers.get(emphasizedActorUuid) ?? language,
+              )}
 
               <GroupTraitPill
                 class={pillState}
@@ -110,17 +114,19 @@
         <div class="list-values">
           <ul class="pills">
             {#each context.traits.speeds as speed}
-              {const isEmphasized =
-                $derived(emphasizedMember !== undefined &&
-                speed.identifiers.has(emphasizedActorUuid))}
+              {const isEmphasized = $derived(
+                emphasizedMember !== undefined &&
+                  speed.identifiers.has(emphasizedActorUuid),
+              )}
               {const pillState: ClassValue = $derived({
                 emphasized: isEmphasized,
                 'theme-dark': isEmphasized,
                 'trait-speed': true,
                 diminished: emphasizedMember !== undefined && !isEmphasized,
               })}
-              {const pill =
-                $derived(speed.identifiers.get(emphasizedActorUuid) ?? speed)}
+              {const pill = $derived(
+                speed.identifiers.get(emphasizedActorUuid) ?? speed,
+              )}
 
               <GroupTraitPill
                 class={pillState}
@@ -152,17 +158,19 @@
         <div class="list-values">
           <ul class="pills">
             {#each context.traits.senses as sense}
-              {const isEmphasized =
-                $derived(emphasizedMember !== undefined &&
-                sense.identifiers.has(emphasizedActorUuid))}
+              {const isEmphasized = $derived(
+                emphasizedMember !== undefined &&
+                  sense.identifiers.has(emphasizedActorUuid),
+              )}
               {const pillState: ClassValue = $derived({
                 emphasized: isEmphasized,
                 'theme-dark': isEmphasized,
                 'trait-sense': true,
                 diminished: emphasizedMember !== undefined && !isEmphasized,
               })}
-              {const pill =
-                $derived(sense.identifiers.get(emphasizedActorUuid) ?? sense)}
+              {const pill = $derived(
+                sense.identifiers.get(emphasizedActorUuid) ?? sense,
+              )}
 
               <GroupTraitPill
                 class={pillState}
@@ -203,9 +211,10 @@
         <div class="list-values">
           <ul class="pills">
             {#each context.traits.specials as special}
-              {const isEmphasized =
-                $derived(emphasizedMember !== undefined &&
-                special.identifiers.has(emphasizedActorUuid))}
+              {const isEmphasized = $derived(
+                emphasizedMember !== undefined &&
+                  special.identifiers.has(emphasizedActorUuid),
+              )}
               {const pillState: ClassValue = $derived({
                 emphasized: isEmphasized,
                 'theme-dark': isEmphasized,
@@ -244,9 +253,10 @@
         <div class="list-values">
           <ul class="pills">
             {#each context.traits.tools as tool}
-              {const isEmphasized =
-                $derived(emphasizedMember !== undefined &&
-                tool.identifiers.has(emphasizedActorUuid))}
+              {const isEmphasized = $derived(
+                emphasizedMember !== undefined &&
+                  tool.identifiers.has(emphasizedActorUuid),
+              )}
               {const pillState: ClassValue = $derived({
                 emphasized: isEmphasized,
                 'theme-dark': isEmphasized,
@@ -267,6 +277,48 @@
                           s,
                         ) as GroupMemberQuadroneContext, // TODO: Change to reduce to avoid TS funny business
                     ),
+                  })}
+              />
+            {/each}
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Masteries -->
+    <div class="list-entry traits-masteries">
+      <div class="list-label flexrow">
+        <h4 class="font-weight-label">
+          <i class="fa-solid fa-circle-star"></i>
+          {localize('DND5E.WEAPON.FIELDS.mastery.label')}
+        </h4>
+      </div>
+      <div class="list-content">
+        <div class="list-values">
+          <ul class="pills">
+            {#each context.traits.masteries as mastery}
+              {const isEmphasized = $derived(
+                emphasizedMember !== undefined &&
+                  mastery.identifiers.has(emphasizedActorUuid),
+              )}
+              {const pillState: ClassValue = $derived({
+                emphasized: isEmphasized,
+                'theme-dark': isEmphasized,
+                'trait-mastery': true,
+                diminished: emphasizedMember !== undefined && !isEmphasized,
+              })}
+
+              <GroupTraitPill
+                class={pillState}
+                label={mastery.label}
+                onmouseover={(ev) =>
+                  traitTooltip?.tryShow(ev, {
+                    label: mastery.label,
+                    members: [...mastery.identifiers].map((s) => ({
+                      context: context.memberContext.all.get(
+                        s,
+                      ) as GroupMemberQuadroneContext, // TODO: Change to reduce to avoid TS funny business
+                    })),
                   })}
               />
             {/each}

--- a/src/sheets/quadrone/actor/npc-parts/NpcTraits.svelte
+++ b/src/sheets/quadrone/actor/npc-parts/NpcTraits.svelte
@@ -29,7 +29,12 @@
           <i class="fa-solid fa-dice"></i>
           {localize('DND5E.HitDice')}
         </h4>
-        <div class="flexshrink hit-dice-container">
+        <button
+          type="button"
+          data-action={context.editable ? 'rest' : ''}
+          data-type="short"
+          class="flexshrink hit-dice-container button-borderless"
+        >
           <span class="value font-label-medium"
             >{context.system.attributes.hd.value}</span
           >
@@ -37,7 +42,7 @@
           <span class="max font-label-medium"
             >{context.system.attributes.hd.max}</span
           >
-        </div>
+        </button>
         <!-- <div class="flexshrink hit-dice-container">
           <div
             class="meter progress hit-die view-only"

--- a/src/sheets/quadrone/shared/SheetPinActivity.svelte
+++ b/src/sheets/quadrone/shared/SheetPinActivity.svelte
@@ -126,25 +126,13 @@
         class="pin-name-container flexrow"
         title="{ctx.document.name} | {ctx.document.item.name}"
       >
-        <TextInput
+        {let input = $state<HTMLInputElement>()}
+        <input
+          bind:this={input}
+          type="text"
           class="pin-name"
-          document={ctx.document}
-          field="name"
           value={ctx.alias}
-          selectOnFocus={true}
           placeholder={ctx.document.name}
-          onSaveChange={(ev) => {
-            const tabId = CONFIG.TIDY5E.utils.getTabIdFromEvent(ev);
-
-            if (tabId) {
-              SheetPinsProvider.setAlias(
-                ctx.document,
-                tabId,
-                ev.currentTarget.value,
-              );
-            }
-            return false;
-          }}
         />
         <button
           type="button"
@@ -152,10 +140,6 @@
           aria-label="Save Alias"
           onclick={(ev) => {
             const tabId = CONFIG.TIDY5E.utils.getTabIdFromEvent(ev);
-
-            // TODO: Find another way to get our hands on this input than a positional approach.
-            const input =
-              ev.currentTarget.previousElementSibling?.querySelector('input');
 
             if (input && tabId) {
               SheetPinsProvider.setAlias(ctx.document, tabId, input.value);

--- a/src/sheets/quadrone/shared/SheetPinItem.svelte
+++ b/src/sheets/quadrone/shared/SheetPinItem.svelte
@@ -226,25 +226,13 @@
   <div class="pin-details">
     {#if context.unlocked && isEditing}
       <div class="pin-name-container flexrow" title={ctx.document.name}>
-        <TextInput
+        {let input = $state<HTMLInputElement>()}
+        <input
+          bind:this={input}
+          type="text"
           class="pin-name"
-          document={ctx.document}
-          field="name"
           value={ctx.alias}
-          selectOnFocus={true}
           placeholder={ctx.document.name}
-          onSaveChange={(ev) => {
-            const tabId = CONFIG.TIDY5E.utils.getTabIdFromEvent(ev);
-
-            if (tabId) {
-              SheetPinsProvider.setAlias(
-                ctx.document,
-                tabId,
-                ev.currentTarget.value,
-              );
-            }
-            return false;
-          }}
         />
         <button
           type="button"
@@ -252,10 +240,6 @@
           aria-label="Save Alias"
           onclick={(ev) => {
             const tabId = CONFIG.TIDY5E.utils.getTabIdFromEvent(ev);
-
-            // TODO: Find another way to get our hands on this input than a positional approach.
-            const input =
-              ev.currentTarget.previousElementSibling?.querySelector('input');
 
             if (input && tabId) {
               SheetPinsProvider.setAlias(ctx.document, tabId, input.value);

--- a/src/todo.md
+++ b/src/todo.md
@@ -1,126 +1,78 @@
 ## The Accretion Disk of To Do's
 
-- [ ] Encounter Member tab - Could use an empty state button that pulls compendium NPCs
-- [ ] Encounter Combat tab - Could use an empty state button that pulls compendium NPCs
-- [ ] // TODO: Eliminate `any` for ItemRowActionPropsData; will likely have to permute into types to match the domains; seems like a lot of work ahead, so make this a dedicated PR
-- [ ] review system sheets for forms handling. Are they using forms? Is there any way to prevent unwanted changes to an actor during submission?
-- [ ] Extract and share: TidyTableRowUseButton
-  - [ ] Convert to sheet action
-- [ ] Refactor: `_preparePortraitContext` at the base actor level, providing everything that each sheet type might need.
-- [ ] Favorite Facilities need "disabled" styles to indicate their state of disrepair
-- [ ] Facility Details - Harvest UI at bottom needs some flex layout applied to it.
-- [ ] Eliminate settings state rune and just use SettingsProvider. Prefer putting settings into sheet context.
-- [ ] Add section base prop `hideIfEmpty` to manage hiding tables when there are no entries. This will prevent scenarios like trying to change the `show` field based on temporary reasons to hide a table (e.g., Vehicle Spells when there are no spells), which would propagate into the section config and then permanently hide the section until reverted. `hideIfEmpty` should be a simple boolean that represents whether we generally hide a particular section when it's empty, as opposed to the actual plan for the row. Ideally, we should separate the visibility setting from the final boolean of whether the section should be shown. `visible` could be the setting prop, while `show` continues to be the final calculation. Eh... JSDoc should help with delineating their purposes, because this is necessarily nuanced to support all the functionality.
-- [ ] Our chosen d20 icon is way different in FA 7. Is this what we want? Do we want to change it up or sub in our very own SVG to insulate the design from 3rd party changes?
-- [ ] Refactor: can column loadouts be somehow pushed further back and simplified?
-- [ ] Try to fold Vehicle Actions pips into the sheet pins UI.
-  - [ ] Sortable with the others? Or fixed to the top?
-- [ ] Possibly fix usability complaint for Loyalty Score setup: <https://discord.com/channels/@me/1243307347682529423/1451341294881341480>
-- [ ] Move attunement to the item row actions as a toggle
-- [ ] Sheet Tab Configuration: "Use World Default" checkbox on the form. It basically just means `undefined` under the hood. If you do not check the box, we do not set your tabs config to `undefined`, even if it matches the world default.
-  - [ ] When checked, the shuttle should be in the appropriate state that reflects the world default.
-  - [ ] When making any changes to the shuttle, uncheck the box.
-  - [ ] The box is calculated on load one time and is not derived.
-  - [ ] Change "Use Default" button to "Use Default for All"
-  - [ ] Give the same treatment ot Configure Header Controls
-- [ ] For some reason, opening sheet tab configuration causes the actor's own flag data to be altered, so closing the sheet and triggering a suibmit will update the flag accordingly. Prevent document flags from being altered in memory when the dialog opens.
-- [ ] Create multi-select replacement
-  - [ ] Plug into Weapon Details damage types
-  - [ ] Determine where else could benefit, namely limited checkbox lists
-- [ ] Attunement, Magical indicators: <https://discord.com/channels/@me/1243307347682529423/1422428816877420564>
-- [ ] Group, Encounter: pull back all identical context prep, like inventory, to the MultiActorQuadroneContext
-  - [ ] If it can be taken another step back, to Actor base prep, then we'll save a lot on code
-- [ ] PC Sidebar Tab Selection - update tab styles to accommodate tab overflow or ellipses or both.
-- [ ] Effects tab - Conditions - Observer permissions - conditions have interactivity styles while being disabled. Pointer cursor, some highlighting (not sure if that one is supposed to be there or not when disabled)
-- [ ] Character: HD bar has a cursor pointer, but there's no interactivity related to it
-- [ ] PC - Bastion tab - progress meters have a cursor pointer but are not interactive
-- [ ] Group Sheet - Members tab - Hover Styles and cursor pointer needed for Member name+subtitle, since it functions as a button and can open the member sheet.
-- [ ] Group Sheet - Plan and task Bastions tab
-  - [ ] Prep Bastions context
-- [ ] Group Sheet, Members tab, Sidebar, Weapon Mastery indicators where relevant?
-- [ ] Image blurriness again: <https://discord.com/channels/1167985253072257115/1170003836556017755/1408567469697667082>
-- [ ] NPC: Statblock tab - include remainder of inventory items with any action economy
-- [ ] NPC: Click HD to trigger a short rest (aka the only way to spend NPC HD)
-- [ ] Show Currency "item table section" when the user has configured more than 5 currencies. <https://discord.com/channels/1167985253072257115/1170003836556017755/1410735599111114876> - include a three-dots (or some other) hyperlink indicator that will scroll the item table for currency into view.
-- [ ] Stretch - Group Sheet: Enable Sorting. Curating a solution is an option. Redesigning the item filter and item sort codebases to be more generic and flexible would be a better longterm goal.
-- [ ] Stretch, post-release, Encounter sheet - when clicking "Create a Placeholder" button, show a dialog with name, subtitle, and img page with filepicker button, autofocus and select all text on load
-- [ ] Stretch, post-release, Encounter sheet - Configuration to allow GMs to add more of these and specify their default images. Be able to drag onto combatants list from Encounter Sheet sidebar or click-to-add.
-- [ ] Stretch/discuss, post-release, Encounter sheet, member combat tracker placeholders - I want to: sideload to sidebar, then add those sideloaded actors to the tracker at configured initiative, so they can be double-clicked to open their details and roll things
-- [ ] Encounter XP bar with stops: add hook and API for passing in custom calculations. The hook should provide app and members with their quantities
-- [ ] Consider adding options like opacity, blend mode, grayscaling, etc., as advanced header options to theme settings. Based on this conversation and the cool stuff people are doing with backgrounds when we untie their hands: <https://discord.com/channels/1167985253072257115/1170021717524107274/1416750794765500437>
-- [ ] `isNil(somevalue, '')` - Let me facepalm 🤦‍♂️; empty string is already nullish. Simplify any expressions that match this logic so that they leverage type coercion of boolean type inference rather than calling a function. Test each one and be paranoid about making sure they work.
-- [ ] Refactor idea: Gather row actions as derived values of the sheet's own context state on the sheet class itself. See if it will reactively update based on context changes.
-- [ ] Effect table rows: when effect is disabled / suppressed, use the italicized / sad styles from unprepared spells and unidentified items.
-- [ ] disable all roll buttons when in observer or locked compendium view. Leverage the `canUse` helper. <https://discord.com/channels/@me/1243307347682529423/1397418208813650091>
-  - [ ] Fully remove the short/long rest buttons in the header
-  - [ ] ...
+- [ ] (anything else to do here) Refactor: Simplify DEFAULT_OPTIONS management now that option inheritance works and `visible()` callback is officially supported.
+- [ ] (I think the system fixed this; we should check ours) Bastion tab: Disabled facilities are completely nonresponsive even to a GM. It seems like at least the GM should be able to fix an accidentally broken facility. The Foundry / dnd5e way has been "if you own the sheet, you can do whatever you want to the sheet," so this particular feature as it currently exists sort of contradicts that philosophy.
 - [ ] Suggestion: Hide the Add to Sheet Tab button when the sheet tab is hidden.
   - [ ] Actor Sheet base - add abstract function `getSelectedTabIds()`; all callers must return the effective list of selected tab IDs. If the flag is nil, then return the default tab ID list. This will side-step any need for major refactors
     - [ ] Then add `isUsingActionsTab()`, which leverages `getSelectedTabIds()` and returns whether the actions tab ID is included.
   - [ ] Container sheet contents - check for the parent actor, resolve to a temp copy of a sheet, and use `isUsingActionsTab()`
-- [ ] Prepared footer macro filter:
-  - [ ] If all relevant filters are unified, decorate the button as Include or Exclude
-  - [ ] If the relevant filters do not all match, decorate as Off; a single click should be able to bring them all into the right state
-  - [ ] Configure so left click toggles Include / Off, and right click toggles Exclude / Off.
-  - [ ] When engaging the Prepared footer multi-filter, clear all others. This is a productivity filter. They can pile on manually in Advanced.
-- [ ] // TODO: Create a polymorph tab ID denylist that implementing sheet classes can opt into
-- [ ] Add sheet parts everywhere. Make this easy for the user who wants to mod this.
-  - [ ] header parts
-  - [ ] sidebar parts
-  - [ ] tab contents
-    - [ ] toolbar
+- [ ] Group Sheet, Members tab, Sidebar, Weapon Mastery indicators where relevant?
+- [ ] NPC: Click HD to trigger a short rest (aka the only way to spend NPC HD)
+- [ ] Group Sheet - Members tab - Hover Styles and cursor pointer needed for Member name+subtitle, since it functions as a button and can open the member sheet.
+- [ ] PC - Bastion tab - progress meters have a cursor pointer but are not interactive
+- [ ] (confirm fixed) Character: HD bar has a cursor pointer, but there's no interactivity related to it
+- [ ] (confirming with hightouch; might remove) Attunement, Magical indicators: <https://discord.com/channels/@me/1243307347682529423/1422428816877420564>
+- [ ] (should be resolved; confirm) For some reason, opening sheet tab configuration causes the actor's own flag data to be altered, so closing the sheet and triggering a suibmit will update the flag accordingly. Prevent document flags from being altered in memory when the dialog opens.
+- [ ] hightouch: If it's super simple (and only if it's super simple) it could be nice to hard link some of the currency/weight/item type directly to the fields (e.g. click it, opens the tab, focuses the input). But if it's not out-of-the-box it's not worth it. Just wasn't sure if it was actually possible
+- [ ] (might be done) Facility Details - Harvest UI at bottom needs some flex layout applied to it.
+- [ ] Encounter Member tab - Could use an empty state button that pulls compendium NPCs
+- [ ] Encounter Combat tab - Could use an empty state button that pulls compendium NPCs
+- [ ] Convert Sheet Pin eventing to sheet actions
+- [ ] Review how to open the door to custom sheet actions, and ensure Tidy supports that.
+- [ ] Refactor: `_preparePortraitContext` at the base actor level, providing everything that each sheet type might need.
+- [ ] Favorite Facilities need "disabled" styles to indicate their state of disrepair
+- [ ] Eliminate settings state rune and just use SettingsProvider. Prefer putting settings into sheet context.
+- [ ] // TODO: Eliminate `any` for ItemRowActionPropsData; will likely have to permute into types to match the domains; seems like a lot of work ahead, so make this a dedicated PR
+- [ ] review system sheets for forms handling. Are they using forms? Is there any way to prevent unwanted changes to an actor during submission?
+- [ ] Extract and share: TidyTableRowUseButton / Convert to sheet action
+- [ ] Add section base prop `hideIfEmpty` to manage hiding tables when there are no entries. This will prevent scenarios like trying to change the `show` field based on temporary reasons to hide a table (e.g., Vehicle Spells when there are no spells), which would propagate into the section config and then permanently hide the section until reverted. `hideIfEmpty` should be a simple boolean that represents whether we generally hide a particular section when it's empty, as opposed to the actual plan for the row. Ideally, we should separate the visibility setting from the final boolean of whether the section should be shown. `visible` could be the setting prop, while `show` continues to be the final calculation. Eh... JSDoc should help with delineating their purposes, because this is necessarily nuanced to support all the functionality.
+- [ ] Our chosen d20 icon is way different in FA 7. Is this what we want? Do we want to change it up or sub in our very own SVG to insulate the design from 3rd party changes?
+- [ ] Try to fold Vehicle Actions pips into the sheet pins UI.
+  - [ ] Sortable with the others? Or fixed to the top?
+- [ ] Possibly fix usability complaint for Loyalty Score setup: <https://discord.com/channels/@me/1243307347682529423/1451341294881341480>
+- [ ] Create multi-select replacement
+  - [ ] Plug into Weapon Details damage types
+  - [ ] Determine where else could benefit, namely limited checkbox lists
+- [ ] Effects tab - Conditions - Observer permissions - conditions have interactivity styles while being disabled. Pointer cursor, some highlighting (not sure if that one is supposed to be there or not when disabled)
+- [ ] Group Sheet - Plan and task Bastions tab
+  - [ ] Prep Bastions context
+- [ ] Image blurriness again: <https://discord.com/channels/1167985253072257115/1170003836556017755/1408567469697667082>
+- [ ] Show Currency "item table section" when the user has configured more than 5 currencies. <https://discord.com/channels/1167985253072257115/1170003836556017755/1410735599111114876> - include a three-dots (or some other) hyperlink indicator that will scroll the item table for currency into view.
+- [ ] Stretch - Group Sheet: Enable Sorting. Curating a solution is an option. Redesigning the item filter and item sort codebases to be more generic and flexible would be a better longterm goal.
+- [ ] Stretch, post-release, Encounter sheet - Configuration to allow GMs to add more of these and specify their default images. Be able to drag onto combatants list from Encounter Sheet sidebar or click-to-add.
+- [ ] Stretch/discuss, post-release, Encounter sheet, member combat tracker placeholders - I want to: sideload to sidebar, then add those sideloaded actors to the tracker at configured initiative, so they can be double-clicked to open their details and roll things
+- [ ] Consider adding options like opacity, blend mode, grayscaling, etc., as advanced header options to theme settings. Based on this conversation and the cool stuff people are doing with backgrounds when we untie their hands: <https://discord.com/channels/1167985253072257115/1170021717524107274/1416750794765500437>
+- [ ] `isNil(somevalue, '')` - Let me facepalm 🤦‍♂️; empty string is already nullish. Simplify any expressions that match this logic so that they leverage type coercion of boolean type inference rather than calling a function. Test each one and be paranoid about making sure they work.
+- [ ] Effect table rows: when effect is disabled / suppressed, use the italicized / sad styles from unprepared spells and unidentified items.
+- [ ] disable all roll buttons when in observer or locked compendium view. Leverage the `canUse` helper. <https://discord.com/channels/@me/1243307347682529423/1397418208813650091>
+  - [ ] Fully remove the short/long rest buttons in the header
   - [ ] ...
+- [ ] Prepared Spells footer button filter: Open preparation formula dialog rather than doing a filter
+- [ ] // TODO: Create a polymorph tab ID denylist that implementing sheet classes can opt into
 - [ ] Make constants for the sheet parts. Pull sheet part constants into their own file, possibly.
-- [ ] Foundry package page: revamp
-- [ ] Add World Setting to disable ruletips in Tidy
-- [ ] Only show Action tab control when the action tab is in use.
-  - This is way more difficult than it has any business being. The ActorSheetRuntime refactor might be needed to make this viable.
-- [ ] Propagate Table Row Actions to Activities tables
-- [ ] Propagate Table Row Actions to Effects tables
-- [ ] Propagate Data-Driven Columns to Activities tables
-- [ ] Propagate Data-Driven Columns to Effects tables
-- [ ] All section configs: pass in callback for preparing sections to view, so that we're not processing this during non-option-sheet renders. It should only render on option sheet prerender.
 - [ ] Configure {TabId}: include a hook that allows people to pass in their own settings.
 - [ ] Resolve TODO -  // TODO: Make this a callback to send through to the component for preparing sections properly
-- [ ] Effect Summary eagerly refreshes. Add suppression to HTML enrichment to only when the effect summary is shown.
+- [ ] (this should be resolved now) Effect Summary eagerly refreshes. Add suppression to HTML enrichment to only when the effect summary is shown.
 - [ ] Ensure all item sheets enforce this Unidentified UI feature:
   - [ ] (Non-container sheets only) Sidebar sections all hidden except Sections section and pill switches
 - [ ] (stretch) Implement generic width / priority observer feature that can be used to control pinned filter visibility generically and then be used for other purposes later.
   - [ ] Propagate this to all action bars
-- [ ] Extract the Tidy Table rendering components for churning out columns from column specs. This functionality will be reused for Effects and Activity tables.
 - [ ] (lowest priority: the system should probably work this out first) Figure out: can get it so I can add Artisan's tools ("art") to Favorites? It represents all Artisan's Tools.
 - [ ] Bastion tab idea: Include an actual Add button in addition to the Compendium button. People should be allowed to add a new Bastion directly to a sheet.
-- [ ] Bastion tab: Disabled facilities are completely nonresponsive even to a GM. It seems like at least the GM should be able to fix an accidentally broken facility. The Foundry / dnd5e way has been "if you own the sheet, you can do whatever you want to the sheet," so this particular feature as it currently exists sort of contradicts that philosophy.
 - [ ] Discuss: new Action List option: "Require Item to be Equipped for Cast Activity Spells" - would have an explanation detailing that this requirement is in addition to the standard Attunement requirements | <https://discord.com/channels/1167985253072257115/1169792539545587733/1384379958801076255>
-- [ ] // TODO: Consider deferring enrichment to tab rendering, so tab selection can preclude it.
-- [ ] Refactor: Simplify DEFAULT_OPTIONS management now that option inheritance works and `visible()` callback is officially supported.
-- [ ] Research: Leveraging Foundry data models to validate, clean up, and control my flag data; and what about new user settings?
 - [ ] (Stretch) Advanced Settings Section - do you know what specific CSS variable alterations you want to make to Tidy? Put 'em here. An array of 0 to many direct variable overrides. If someone goes real deep into Tidy and wants to submit some community theme JSON, they may do so.
 - [ ] (Stretch) **Theming**: Community Theme submissions - they'll go in a dedicated folder in github and, with an active internet connection, can be pulled directly from within Foundry
 - [ ] (Stretch) **Theme Settings**: Saved Themes in campaign world - be able to create multiple themes and save them to the game world for all to enjoy
 - [ ] **Theme Settings**: Add support for Item Sidebar Width?
-- [ ] Item cards
-  - [ ] ~~Implement a shared portal for item cards. All attached item cards will use the one portal anchor. This is so the card can live outside the sheet's overflow hiding window content, so we don't have to worry about compromising design.~~ Can item cards leverage a shared dialog component so they can ignore overflow?
-  - [ ] Have item cards be targeted via `.tidy5e-sheet.classic....` etc.
-  - [ ] Test spell info on item summary and cards
-  - [x] ~~For fun, test with PopOut!~~
-  - [ ] Use popovers 💖
-  - [ ] Have or reuse options for show/hide timing
 - [x] Swap left and right areas in tab selection (left = selected, right = hidden)
-- [ ] Refactor: As feasible, where able, start pivoting from Objects to Maps. It's apparently more performant.
 - [ ] Wiki: document tab registration and show off Mestre Mahakala's final product as an example of interacting with external data sources and making a very unique tab. <https://discord.com/channels/@me/1243307347682529423/1388371150291210290>
-- [ ] Bug? Secret button doesn't work on Item Description in Actor sheet
-  - Does not work on default sheets or Tidy classic.
 - [ ] (Take our time on this one; it's never been solved by any sheet, except for vertical tabs) Implement Responsive Tab Strip
 - [ ] Magical Tattoos: provide first-class favorite card. Expand system to accommodate custom favorite card renderers so that it can be registered thus.
 - [ ] (Take your time on this one, maybe after the overhaul is complete) Refactor: consider combining the actor sheet runtimes into a single collective like Item Sheet Runtime. Then, consider extracting a common base class 🔥.
-- [ ] (PC: Feature tab) Implement alternate section groupings - <https://discord.com/channels/1167985253072257115/1170021717524107274/1382889612959158355> | include toggle option as sheet flag in tab settings.
-- [ ] add a class to section headers when there are no search results `.search-no-results`
   - Note: Section headers disappear when there are no results. I'm guessing I noted this wrong. Are we instead wanting to put a `search-no-results` class on the container for all the sections on that tab? Is it a means of showing a No Results UI?
 - [ ] // TODO: Item and Container Sheets duplicate this functionality; consolidate somewhere
 - [ ] Like with the getSheetContext() functions, make other common ones, like getMessageBus() and getTabId(). At this point, should they be housed in a containing static class or exported object constant?
 - [ ] Wonky formulas like `0 + 2 + 1d4 + 0 / 2` are clearly able to be simplified when reading them with human eyes. Is there a way with standard Foundry/dnd5e APIs to resolve all deterministic parts and make the formula look like `2 + 1d4`, or even better, `1d4 + 2`? Update, Zhell has some input on how to simplify: <https://github.com/foundryvtt/dnd5e/issues/5466#issuecomment-3211554904>
-- [ ] Stretch: Sheet config Visibility tab - For each tab entry, trim away options whose value is less than the established world value. If no world visibility is set, then do not trim. (Punting for later, because this is enough complexity that I don't want to bother with it at the moment.)
 - [ ] DocumentTag upgrade - show rich preview of found document
 - [ ] Create DocumentTags - Support multiple tags, show rich previews of found documents
 - [ ] Stretch: Update Content Registration API to allow an array of Elements during the HTML Content callback
@@ -130,7 +82,6 @@
 - [ ] accountForExternalSections is not being used quite right. It needs to happen after any callers have updated context with their own data. How do we account for this?
 - [ ] // TODO: Make the character sheet handle bastion tab check. This is violating separation of concerns.
 - [ ] Inline the custom Tidy modifications for spellbook preparation; ensure modules can still add spells / sections and have Tidy perform a post-operation to backfill spell section keys / Tidy props.
-- [ ] There are some layout changes to Rider effects: <https://discord.com/channels/170995199584108546/670336046164213761/1453597835550396529> ; what is Tidy doing currently, and can we do something differently?
 - [ ] Vehicle Sheet 💡: Show assignments and excess crew max empty slots in item sheet sidebar, entitled "Assigned Crew {assignedCount}"
 
 ## hightouch To Do
@@ -147,136 +98,3 @@
 - [ ] Item sheet sidebar background image (low)
 - [ ] Sidebar.svelte - comment: hightouch, please make this nice, lol | item HP UI
 - [ ] (Lower priority) Currency footer scalability - given a world script (paste it at the bottom of `main.svelte.ts` for quick testing), Tidy has trouble actually showing currency amounts when the user uses a large number of currencies. To combat this, we could potentially switch to a grid auto-fill (or auto-fit, depending on preference) column template with a min width specified. This would also require some additional attention on the inventory-footer container query for the same content. See below for sample script. Reference: <https://discord.com/channels/@me/1243307347682529423/1409228016176992378>
-
-### Post-Beta Stretch Goals
-
-- [ ] Compact Sheet - take the current sheet and apply compacting styles to it and offer as a User setting.
-- [ ] High Contrast support - add theming changes to support Foundry's high contrast settings.
-- [ ] Increased Mobile/Tablet support.
-
-### Deferred tasks from last item batch review
-
-OK I think I found one thing on features. Recharge recovery only shows if it's the first recovery option
-<https://discord.com/channels/@me/1243307347682529423/1362996587584028683>
-> This one is hard to reason about. The standard UI doesn't provide recharge info for non-first recharge recoveries. I'd like to think this over some more.
-
-OK then tattoos the one thing I see is that some of the tattoos like the Absorbing tattoos have Reaction-based abilities. But the sidebar is looking for a defined value
-<https://discord.com/channels/@me/1243307347682529423/1363003038482038836>
-> The issue was that there's a Damages label that is empty with the absorbing tattoo. It is possibly just a weird setup. The fix I did for now was to filter out damage labels that are null/undefined/empty.
-
-### Bonus
-
-- [ ] Activity card / summary: Activities can be summarized via activity.activationLabels
-  - all: activation, duration, range, reach, target
-  - item is weapon with no overrides: attack: range, reach
-
-### To Include on Actor Phase
-
-- [ ] Effects tab
-  - [ ] Info / Suppression UI <https://discord.com/channels/@me/1243307347682529423/1351751313515479131>
-  - Repro: Put on a ring of protection but don't equip/attune to it.
-
-### Stretch
-
-- [ ] hightouch: If it's super simple (and only if it's super simple) it could be nice to hard link some of the currency/weight/item type directly to the fields (e.g. click it, opens the tab, focuses the input). But if it's not out-of-the-box it's not worth it. Just wasn't sure if it was actually possible
-
-### Paradigm 5: Containers are always manual additions**
-
-- Containers and items within are opt-in only and are not automatically included.
-- Containers display if added, and can be expanded, no special treatment or filtering applied to contents.
-- Items within a container display only if manually added, with visual indicators
-
-Pros:
-Should be performant, and doesn't clutter the tab with auto-additions for container-heavy tables. Model also works for Activities.
-
-Cons:
-Manual
-
-## To Do Graveyard
-
-- [x] Review and refine empty states on the Statblock tab
-  - [x] Weapons do not have an empty state.
-  - [x] Equipment empty state says it pulls from the compendium browser but instead creates an item. It would be more familiar if it just claimed to create an item.
-    - [x] Additionally, it presents the full Add Item dialog instead of just fast-forwarding creation to a correctly-configured Equipment vehicle item.
-  - [x] Features do no have an empty state.
-- [x] Draft Animals need their own columns. The default sheets fixate on creature size and carrying capacity.
-- [x] Eliminate container panel and config from quadrone
-  - [x] Create quadrone-specific item contexts
-    - [x] Actor Base
-      - [x] Shared props: containerContents, activities, ... 
-    - [x] Character
-    - [x] NPC
-    - [x] Vehicle
-    - [x] Multi-actor
-  - [x] Remove containerPanelItems
-  - [x] Remove showContainerPanel
-  - [x] Remove container panel settings UI
-- [x] Implement section origins
-  - [x] Extract any shareable table components that are needed
-  - [x] Prepare the data
-  - [x] Create new tab component that is meant to accommodate both section arrangements
-  - [x] Set up logic to choose between origin and action sections and hardcode to Origin for now
-  - [x] Fix: Sheet tab Feature sections don't have columns
-  - [x] Make the default order Inventory, Spellbook, Features
-  - [x] Ensure Action sections are handled in new character sheet tab component
-  - [x] Fix: Custom sections for Sheet tab should be pulling from the Action Section flag instead of the regular one
-  - [x] Combine items with equivalent section keys into "custom" sections with the fallback / action tab columns
-  - [x] Implement Search
-  - [x] Implement Sort button
-  - [x] Implement Manual Sort via drag/drop
-  - [x] Implement Section Config
-  - [x] Implement Filters
-  - [x] Fix: No Add buttons allowed on sheet tab sections
-  - [x] Fix: Nested container contents not showing when expanded in Sheet tab
-  - [x] Set up World setting for default Sheet tab section organization
-  - [x] Set up per-sheet toggle for Sheet tab section organization
-  - [x] Replace hardcoded Origin section setup with determined current setting, starting with sheet flag and falling back to world setting
-  - [x] Fix: There are build errors
-  - [x] Fix: Sheet tab Prepared filter doesn't seem to work quite right
-  - [x] Clean up: the 'custom' section type needs a constant
-  - [x] World setting: Character sheet tab: Automatically Include Usable Items
-  - [x] Sheet section config flag: Automatically Include Usable Items
-  - [x] Refactor: Create type for sheet tab inclusion mode and propagate
-  - [x] Refactor: pull derived inclusion setting into context variable and ensure all callers can access it reactively
-    - [x] Sheet prep
-    - [x] ActionsTabToggleButton
-    - [x] Context menu
-  - [x] Do some perf tests around how long it takes to prepare the origin sections
-    - On average, 5-15ms on a high-end machine. Optimizing perf here would make a difference more likely when there are thousands upon thousands of items being included.
-  - [x] Do not include the "CharacterSheetTabToggleButton" in TableRowActionsRuntime arrays when there's not a PC involved.
-  - [x] Ensure manual sort is based on Sheet tab sort order (if possible)
-  - [x] Decide how drop behaviors should work
-    - [x] Support drop to sort using flag sort key on sheet tab
-    - [x] Support drop to transfer sections
-  - [x] It would be nice if we could have one ItemTable component that works for all item table use cases...
-    - [x] Differences between existing tables
-      - [x] actionSubtitle versus subtitle: expose snippets with args, where default is subtitle
-      - [x] Spell table
-        - [x] Table Header row conditional classes and attributes
-        - [x] Table Header primary cell end of content (slots content)
-        - [x] Item table row conditional rowClass
-  - [x] Decide what to do about contained items and whether they should surface their parent container
-  - [x] Handle Contained Items with "Paradigm 5"
-- [x] Handle dragstart for activities on item sheets
-- [x] Handle dragstart for activities on actor sheets?
-- [x] Handle dragstart for effects
-  - [x] Actor Base sheet
-  - [x] Item sheet
-- [x] Need to refactor: Resize Observation and Column Loadout. There are so many places in a given tab where resize observers are needed for inline activities that it imposes a noticeable performance hit. Also, with every adjustment, column loadout is redone and re-ordered, which is unnecessary. Eliminate ColumnLoadout class and instead simply calculate column setup in section preparation, since that has to be done, anyway.
-  - [x] Identify all resize observers which can be removed.
-  - [x] ~~Consider optimizing nested container inline width management at this time; apply spacer calculations to the final total for each level of nesting. It doesn't have to be perfect.~~
-  - [x] Reduce ResizeObservers down to just 1 globally managed singleton.
-- [x] Try revisiting the Expandable containers. Is there a more performant way that doesn't involve hooking into transition events? Update: better yet, enjoy transition events only once, at time of expanded state change. Additionally, separate expanded state change from the application of expanded class so that we can control when the transition occurs 🔥
-- [x] Character Sheet - Sheet tab upgrade
-  - [x] Add preference / flag: "Auto-populate Items"
-  - [x] Add preference / flag: "Organize Items by Action Economy" / "Organize Items by Origin Sections"
-  - [x] Ensure column loadout for each section is based on whether the items are of a contiguous type or of mixed company
-- [x] Implement "Auto-populate Items" unchecked
-- [x] Implement "Organize Items by Origin Sections" and alternating column loadout
-- [x] Are we able to reunite AbilityScore and AbilityScoreNPC, or are they too divergent from each other?
-- [x] PC and NPC Sheets
-  - [x] Update class/subclass/background/species rows to View on double-click and Edit on middle-click
-- [x] NPC: Add tools section to the sidebar if NPC sheets even supports it
-- [x] Tools card header - has cursor hover style without interactivity
-- [x] Find and purge any outstanding drag handlers / task out their replacements
-- [x] Stretch - Group Sheet: Explore Section-wide rename for group members. The rename logic is easy. The UI decisions are a little murkier. Consider context menu on the section header, as well as a horiz 3-dots menu on sheet unlock where the add button would be.

--- a/src/todo.md
+++ b/src/todo.md
@@ -1,6 +1,5 @@
 ## The Accretion Disk of To Do's
 
-- [ ] Group Sheet, Members tab, Sidebar, Weapon Mastery indicators where relevant?
 - [ ] NPC: Click HD to trigger a short rest (aka the only way to spend NPC HD)
 - [ ] Group Sheet - Members tab - Hover Styles and cursor pointer needed for Member name+subtitle, since it functions as a button and can open the member sheet.
 - [ ] PC - Bastion tab - progress meters have a cursor pointer but are not interactive

--- a/src/todo.md
+++ b/src/todo.md
@@ -1,7 +1,5 @@
 ## The Accretion Disk of To Do's
 
-- [ ] NPC: Click HD to trigger a short rest (aka the only way to spend NPC HD)
-- [ ] Group Sheet - Members tab - Hover Styles and cursor pointer needed for Member name+subtitle, since it functions as a button and can open the member sheet.
 - [ ] PC - Bastion tab - progress meters have a cursor pointer but are not interactive
 - [ ] (confirm fixed) Character: HD bar has a cursor pointer, but there's no interactivity related to it
 - [ ] (confirming with hightouch; might remove) Attunement, Magical indicators: <https://discord.com/channels/@me/1243307347682529423/1422428816877420564>
@@ -79,6 +77,8 @@
 
 ## hightouch To Do
 
+- [ ] Group Sheet - Members tab - Hover Styles and cursor pointer needed for Member name+subtitle, since it functions as a button and can open the member sheet.
+- [ ] NPC Sheet - Important NPC - Sidebar - HD value/max button, border changes from none to solid and causes visual shifting when clicking it.
 - [ ] Clicking and holding on the initiative button shows a red square.
 - [ ] Surface edit icon in non-edit mode Biography tab
 - [ ] Add fallback image for broken image links (text appears today)

--- a/src/todo.md
+++ b/src/todo.md
@@ -1,9 +1,5 @@
 ## The Accretion Disk of To Do's
 
-- [ ] Suggestion: Hide the Add to Sheet Tab button when the sheet tab is hidden.
-  - [ ] Actor Sheet base - add abstract function `getSelectedTabIds()`; all callers must return the effective list of selected tab IDs. If the flag is nil, then return the default tab ID list. This will side-step any need for major refactors
-    - [ ] Then add `isUsingActionsTab()`, which leverages `getSelectedTabIds()` and returns whether the actions tab ID is included.
-  - [ ] Container sheet contents - check for the parent actor, resolve to a temp copy of a sheet, and use `isUsingActionsTab()`
 - [ ] Group Sheet, Members tab, Sidebar, Weapon Mastery indicators where relevant?
 - [ ] NPC: Click HD to trigger a short rest (aka the only way to spend NPC HD)
 - [ ] Group Sheet - Members tab - Hover Styles and cursor pointer needed for Member name+subtitle, since it functions as a button and can open the member sheet.

--- a/src/todo.md
+++ b/src/todo.md
@@ -1,7 +1,5 @@
 ## The Accretion Disk of To Do's
 
-- [ ] (anything else to do here) Refactor: Simplify DEFAULT_OPTIONS management now that option inheritance works and `visible()` callback is officially supported.
-- [ ] (I think the system fixed this; we should check ours) Bastion tab: Disabled facilities are completely nonresponsive even to a GM. It seems like at least the GM should be able to fix an accidentally broken facility. The Foundry / dnd5e way has been "if you own the sheet, you can do whatever you want to the sheet," so this particular feature as it currently exists sort of contradicts that philosophy.
 - [ ] Suggestion: Hide the Add to Sheet Tab button when the sheet tab is hidden.
   - [ ] Actor Sheet base - add abstract function `getSelectedTabIds()`; all callers must return the effective list of selected tab IDs. If the flag is nil, then return the default tab ID list. This will side-step any need for major refactors
     - [ ] Then add `isUsingActionsTab()`, which leverages `getSelectedTabIds()` and returns whether the actions tab ID is included.

--- a/src/todo.md
+++ b/src/todo.md
@@ -1,6 +1,5 @@
 ## The Accretion Disk of To Do's
 
-- [ ] // TODO: Find another way to get our hands on this input than a positional approach.
 - [ ] Encounter Member tab - Could use an empty state button that pulls compendium NPCs
 - [ ] Encounter Combat tab - Could use an empty state button that pulls compendium NPCs
 - [ ] // TODO: Eliminate `any` for ItemRowActionPropsData; will likely have to permute into types to match the domains; seems like a lot of work ahead, so make this a dedicated PR

--- a/src/todo.md
+++ b/src/todo.md
@@ -1,11 +1,6 @@
 ## The Accretion Disk of To Do's
 
-- [ ] PC - Bastion tab - progress meters have a cursor pointer but are not interactive
-- [ ] (confirm fixed) Character: HD bar has a cursor pointer, but there's no interactivity related to it
-- [ ] (confirming with hightouch; might remove) Attunement, Magical indicators: <https://discord.com/channels/@me/1243307347682529423/1422428816877420564>
-- [ ] (should be resolved; confirm) For some reason, opening sheet tab configuration causes the actor's own flag data to be altered, so closing the sheet and triggering a suibmit will update the flag accordingly. Prevent document flags from being altered in memory when the dialog opens.
 - [ ] hightouch: If it's super simple (and only if it's super simple) it could be nice to hard link some of the currency/weight/item type directly to the fields (e.g. click it, opens the tab, focuses the input). But if it's not out-of-the-box it's not worth it. Just wasn't sure if it was actually possible
-- [ ] (might be done) Facility Details - Harvest UI at bottom needs some flex layout applied to it.
 - [ ] Encounter Member tab - Could use an empty state button that pulls compendium NPCs
 - [ ] Encounter Combat tab - Could use an empty state button that pulls compendium NPCs
 - [ ] Convert Sheet Pin eventing to sheet actions
@@ -77,8 +72,11 @@
 
 ## hightouch To Do
 
+- [ ] Facility Details - Harvest UI at bottom needs some better layout applied to it. "Greenhouse" is an example of a facility with Harvest capabilities built in.
+- [ ] (confirming with hightouch; might remove) Attunement, Magical indicators: <https://discord.com/channels/@me/1243307347682529423/1422428816877420564>
 - [ ] Group Sheet - Members tab - Hover Styles and cursor pointer needed for Member name+subtitle, since it functions as a button and can open the member sheet.
 - [ ] NPC Sheet - Important NPC - Sidebar - HD value/max button, border changes from none to solid and causes visual shifting when clicking it.
+- [ ] PC - Bastion tab - progress meters have a cursor pointer but are not interactive
 - [ ] Clicking and holding on the initiative button shows a red square.
 - [ ] Surface edit icon in non-edit mode Biography tab
 - [ ] Add fallback image for broken image links (text appears today)

--- a/src/types/row-actions.types.ts
+++ b/src/types/row-actions.types.ts
@@ -41,6 +41,12 @@ export type CommonConditionContextData = {
    * is not read-only / inside a locked compendium.
    */
   editable: boolean;
+
+  /**
+   * Any additional custom contextual data that is needed internally
+   * for the module to provide more flexibility and features.
+   */
+  [customContextData: string]: any;
 };
 
 /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1577,6 +1577,7 @@ export type GroupTraits = {
   specials: GroupTrait[];
   speeds: MeasurableGroupTrait<number>[];
   tools: GroupTrait[];
+  masteries: GroupTrait[];
 };
 
 export type TravelPaceConfigEntry = {
@@ -1931,4 +1932,4 @@ export type AggregatePinTabInfo = {
   tabId: string;
   /** Unlocalized tab name. */
   tabName: string;
-}
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import path, { resolve } from 'path';
 const s_PACKAGE_ID = 'modules/tidy5e-sheet';
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   root: 'src/',
   base: `/${s_PACKAGE_ID}/`,
   publicDir: path.resolve(__dirname, 'public'),
@@ -35,7 +35,83 @@ export default defineConfig({
       src: path.resolve('./src'),
     },
   },
-  plugins: [svelte({ configFile: '../svelte.config.js' })],
+  plugins: [
+    svelte({ configFile: '../svelte.config.js' }),
+    {
+      name: 'vite-css-layer-injector',
+      enforce: 'pre',
+      transform(code, id) {
+        if (mode !== 'development' || !id.endsWith('.css')) {
+          return;
+        }
+
+        // Extract all @import rules
+        const importRegex = /@import\s+(['"][^'"]+['"])([^;]*);/g;
+
+        let imports: { full: string; path: string; rest: string }[] = [];
+
+        let remainder = code
+          .replace(importRegex, (full, path, rest) => {
+            imports.push({ full, path, rest });
+            return ''; // remove import from remainder
+          })
+          .trim();
+
+        // Rewrite imports to include layer(modules) if missing
+        const rewrittenImports = imports.map(({ full, path, rest }) => {
+          if (/layer\s*\(/.test(rest)) {
+            return full; // already has a layer(...)
+          }
+          return `@import ${path} layer(modules);`;
+        });
+
+        // If there are no imports at all, wrap whole file
+        if (imports.length === 0) {
+          return {
+            code: `@layer modules {\n${code}\n}`,
+            map: null,
+          };
+        }
+
+        // If imports exist but remainder is empty, only rewrite imports
+        if (remainder.length === 0) {
+          return {
+            code: rewrittenImports.join('\n'),
+            map: null,
+          };
+        }
+
+        // If imports exist and remainder exists, rejoin them all.
+        // Wrap the remainder in the modules layer if layering is not already being used.
+        const effectiveRemainder = remainder.includes('@layer')
+          ? remainder
+          : `@layer modules {\n${remainder}\n}`;
+
+        return {
+          code: rewrittenImports.join('\n') + '\n' + effectiveRemainder,
+          map: null,
+        };
+      },
+    },
+    {
+      name: 'vite-less-layer-wrapper',
+      enforce: 'pre',
+      transform(code, id) {
+        if (
+          mode !== 'development' ||
+          !id.endsWith('.less') ||
+          code.includes('@layer')
+        ) {
+          return;
+        }
+
+        return {
+          code: `@layer modules {\n${code}\n}`,
+          map: null,
+        };
+      },
+    },
+  ],
   build: {
     cssCodeSplit: true,
     outDir: path.resolve(__dirname, 'dist'),
@@ -58,4 +134,4 @@ export default defineConfig({
     sourcemap: true,
     minify: 'esbuild',
   },
-});
+}));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,137 +1,156 @@
-import { defineConfig } from 'vite';
+import { defineConfig, PluginOption } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import path, { resolve } from 'path';
 
 const s_PACKAGE_ID = 'modules/tidy5e-sheet';
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  root: 'src/',
-  base: `/${s_PACKAGE_ID}/`,
-  publicDir: path.resolve(__dirname, 'public'),
-  esbuild: {
-    target: ['es2022'],
-    minifyIdentifiers: false,
-    minifySyntax: true,
-    minifyWhitespace: true,
-    keepNames: true,
-  },
-  server: {
-    port: 30001,
-    proxy: {
-      // Serves static files from main Foundry server.
-      [`^(/${s_PACKAGE_ID}/(assets|lang|packs|tidy5e-sheet.css))`]:
-        'http://localhost:30000',
-
-      // All other paths besides package ID path are served from main Foundry server.
-      [`^(?!/${s_PACKAGE_ID}/)`]: 'http://localhost:30000',
-
-      // Enable socket.io from main Foundry server.
-      '/socket.io': { target: 'ws://localhost:30000', ws: true },
-    },
-  },
-  resolve: {
-    alias: {
-      src: path.resolve('./src'),
-    },
-  },
-  plugins: [
+export default defineConfig(({ mode }) => {
+  const plugins: PluginOption[] = [
     svelte({ configFile: '../svelte.config.js' }),
-    {
-      name: 'vite-css-layer-injector',
-      enforce: 'pre',
-      transform(code, id) {
-        if (mode !== 'development' || !id.endsWith('.css')) {
-          return;
-        }
+  ];
 
-        // Extract all @import rules
-        const importRegex = /@import\s+(['"][^'"]+['"])([^;]*);/g;
+  if (mode === 'development') {
+    plugins.push(getViteCssLayerInjectorPlugin(), getViewLessLayerWrapper());
+  }
 
-        let imports: { full: string; path: string; rest: string }[] = [];
+  return {
+    root: 'src/',
+    base: `/${s_PACKAGE_ID}/`,
+    publicDir: path.resolve(__dirname, 'public'),
+    esbuild: {
+      target: ['es2022'],
+      minifyIdentifiers: false,
+      minifySyntax: true,
+      minifyWhitespace: true,
+      keepNames: true,
+    },
+    server: {
+      port: 30001,
+      proxy: {
+        // Serves static files from main Foundry server.
+        [`^(/${s_PACKAGE_ID}/(assets|lang|packs|tidy5e-sheet.css))`]:
+          'http://localhost:30000',
 
-        let remainder = code
-          .replace(importRegex, (full, path, rest) => {
-            imports.push({ full, path, rest });
-            return ''; // remove import from remainder
-          })
-          .trim();
+        // All other paths besides package ID path are served from main Foundry server.
+        [`^(?!/${s_PACKAGE_ID}/)`]: 'http://localhost:30000',
 
-        // Rewrite imports to include layer(modules) if missing
-        const rewrittenImports = imports.map(({ full, path, rest }) => {
-          if (/layer\s*\(/.test(rest)) {
-            return full; // already has a layer(...)
-          }
-          return `@import ${path} layer(modules);`;
-        });
-
-        // If there are no imports at all, wrap whole file
-        if (imports.length === 0) {
-          return {
-            code: `@layer modules {\n${code}\n}`,
-            map: null,
-          };
-        }
-
-        // If imports exist but remainder is empty, only rewrite imports
-        if (remainder.length === 0) {
-          return {
-            code: rewrittenImports.join('\n'),
-            map: null,
-          };
-        }
-
-        // If imports exist and remainder exists, rejoin them all.
-        // Wrap the remainder in the modules layer if layering is not already being used.
-        const effectiveRemainder = remainder.includes('@layer')
-          ? remainder
-          : `@layer modules {\n${remainder}\n}`;
-
-        return {
-          code: rewrittenImports.join('\n') + '\n' + effectiveRemainder,
-          map: null,
-        };
+        // Enable socket.io from main Foundry server.
+        '/socket.io': { target: 'ws://localhost:30000', ws: true },
       },
     },
-    {
-      name: 'vite-less-layer-wrapper',
-      enforce: 'pre',
-      transform(code, id) {
-        if (
-          mode !== 'development' ||
-          !id.endsWith('.less') ||
-          code.includes('@layer')
-        ) {
-          return;
-        }
+    resolve: {
+      alias: {
+        src: path.resolve('./src'),
+      },
+    },
+    plugins,
+    build: {
+      cssCodeSplit: true,
+      outDir: path.resolve(__dirname, 'dist'),
+      emptyOutDir: true,
+      target: ['es2022'],
+      lib: {
+        entry: './main.svelte.ts',
+        name: 'Tidy5e-Sheet-Kgar',
+        fileName: 'tidy5e-sheet',
+        formats: ['es'],
+      },
+      rolldownOptions: {
+        output: {
+          globals: {
+            svelte: 'svelte',
+          },
+          keepNames: true,
+        },
+      },
+      sourcemap: true,
+      minify: 'esbuild',
+    },
+  };
+});
 
+/**
+ * @returns A vite plugin that ensures CSS `@imports` with no specified layer 
+ *          are given the "modules" layer, and the remainder (when it doesn't have any layer
+ *          specifications) is wrapped with the modules layer.
+ */
+function getViteCssLayerInjectorPlugin(): PluginOption {
+  return {
+    name: 'vite-css-layer-injector',
+    enforce: 'pre',
+    transform(code, id) {
+      if (!id.endsWith('.css')) {
+        return;
+      }
+
+      // Extract all @import rules
+      const importRegex = /@import\s+(['"][^'"]+['"])([^;]*);/g;
+
+      let imports: { full: string; path: string; rest: string }[] = [];
+
+      let remainder = code
+        .replace(importRegex, (full, path, rest) => {
+          imports.push({ full, path, rest });
+          return ''; // remove import from remainder
+        })
+        .trim();
+
+      // Rewrite imports to include layer(modules) if missing
+      const rewrittenImports = imports.map(({ full, path, rest }) => {
+        if (/layer\s*\(/.test(rest)) {
+          return full; // already has a layer(...)
+        }
+        return `@import ${path} layer(modules);`;
+      });
+
+      // If there are no imports at all, wrap whole file
+      if (imports.length === 0) {
         return {
           code: `@layer modules {\n${code}\n}`,
           map: null,
         };
-      },
+      }
+
+      // If imports exist but remainder is empty, only rewrite imports
+      if (remainder.length === 0) {
+        return {
+          code: rewrittenImports.join('\n'),
+          map: null,
+        };
+      }
+
+      // If imports exist and remainder exists, rejoin them all.
+      // Wrap the remainder in the modules layer if layering is not already being used.
+      const effectiveRemainder = remainder.includes('@layer')
+        ? remainder
+        : `@layer modules {\n${remainder}\n}`;
+
+      return {
+        code: rewrittenImports.join('\n') + '\n' + effectiveRemainder,
+        map: null,
+      };
     },
-  ],
-  build: {
-    cssCodeSplit: true,
-    outDir: path.resolve(__dirname, 'dist'),
-    emptyOutDir: true,
-    target: ['es2022'],
-    lib: {
-      entry: './main.svelte.ts',
-      name: 'Tidy5e-Sheet-Kgar',
-      fileName: 'tidy5e-sheet',
-      formats: ['es'],
+  };
+}
+
+/**
+ * @returns A vite plugin that wrapps LESS files with no specified `@layer` with
+ *          the Foundry modules layer.
+ */
+function getViewLessLayerWrapper(): PluginOption {
+  return {
+    name: 'vite-less-layer-wrapper',
+    enforce: 'pre',
+    transform(code, id) {
+      if (!id.endsWith('.less') || code.includes('@layer')) {
+        return;
+      }
+
+      return {
+        code: `@layer modules {\n${code}\n}`,
+        map: null,
+      };
     },
-    rolldownOptions: {
-      output: {
-        globals: {
-          svelte: 'svelte',
-        },
-        keepNames: true,
-      },
-    },
-    sourcemap: true,
-    minify: 'esbuild',
-  },
-}));
+  };
+}


### PR DESCRIPTION
- new: the bookmark row action for show/hiding an item in the Character "Sheet" tab will now be excluded if the Sheet tab is not visible.
- new: Group Sheet - Member tab sidebar - Mastery section added to the bottom with group member weapon mastery info.
- new: NPC rest buttons now use the CONFIG.DND5E.restTypes data.
- new: You can now click the Hit Dice "Value/Max" on Important NPCs' sidebar to trigger a short rest.
- fixed: When an active effect is boosting certain global bonuses (e.g., Ring of Protection), the bonus shows up in the Settings dialog form for Special Traits, and on save, the bonuses compound. Check your sheets; your players may have excessively high saving throws. To correct, take off any bonuses from Special Traits that should not be there.