### PR TITLE
feat: Click to Copy Document Sheet Name

### DIFF
--- a/src/mixins/TidyDocumentSheetMixin.svelte.ts
+++ b/src/mixins/TidyDocumentSheetMixin.svelte.ts
@@ -89,6 +89,8 @@ export function getTidyExtensibleDocumentSheetMixin<
       actions: {
         'activity-use': TidyDocumentSheet.#useActivity,
         configureTab: TidyDocumentSheet.#configureTab,
+        copyInnerText: TidyDocumentSheet.#copyInnerText,
+        copyValue: TidyDocumentSheet.#copyValue,
         currency: TidyDocumentSheet.#currency,
         deleteDocument: TidyDocumentSheet.#deleteDocument,
         editDocument: TidyDocumentSheet.#showDocument,
@@ -1111,6 +1113,33 @@ export function getTidyExtensibleDocumentSheetMixin<
       });
 
       return this._renderChild(settings);
+    }
+
+    /* -------------------------------------------- */
+
+    static async #copyInnerText(
+      this: TidyDocumentSheet,
+      event: Event,
+      target: HTMLElement,
+    ) {
+      this._copyValue(target.innerText);
+    }
+
+    _copyValue(value: string | undefined) {
+      game.clipboard.copyPlainText(value);
+      ui.notifications.info(game.i18n.format('DND5E.Copied', { value }), {
+        console: false,
+      });
+    }
+
+    /* -------------------------------------------- */
+
+    static async #copyValue(
+      this: TidyDocumentSheet,
+      event: Event,
+      target: HTMLElement,
+    ) {
+      this._copyValue(target.dataset.value);
     }
 
     /* -------------------------------------------- */

--- a/src/sheets/quadrone/actor/ActorLimitedSheet.svelte
+++ b/src/sheets/quadrone/actor/ActorLimitedSheet.svelte
@@ -44,7 +44,11 @@
 
 <header class="sheet-header limited-sheet flexcol theme-dark">
   <div class="sheet-header-content flexrow">
-    <h1 class="actor-name flex1">{context.actor.name}</h1>
+    <h1 class="actor-name flex1">
+      <a data-action="copyInnerText" class="cursor highlight-on-hover">
+        {context.actor.name}
+      </a>
+    </h1>
     <div class="actor-vitals-container">
       <ActorPortrait />
     </div>

--- a/src/sheets/quadrone/actor/CharacterSheet.svelte
+++ b/src/sheets/quadrone/actor/CharacterSheet.svelte
@@ -140,7 +140,9 @@
                 data-tidy-sheet-part="actor-name"
                 data-tooltip={context.actor.name}
               >
-                {context.actor.name}
+                <a data-action="copyInnerText" class="cursor highlight-on-hover">
+                  {context.actor.name}
+                </a>
               </h1>
             {/if}
             {#if context.editable}

--- a/src/sheets/quadrone/actor/EncounterSheet.svelte
+++ b/src/sheets/quadrone/actor/EncounterSheet.svelte
@@ -54,7 +54,9 @@
                 data-tidy-sheet-part="actor-name"
                 data-tooltip={context.actor.name}
               >
-                {context.actor.name}
+                <a data-action="copyInnerText" class="cursor highlight-on-hover">
+                  {context.actor.name}
+                </a>
               </h1>
             {/if}
           </div>

--- a/src/sheets/quadrone/actor/GroupSheet.svelte
+++ b/src/sheets/quadrone/actor/GroupSheet.svelte
@@ -50,7 +50,9 @@
             data-tidy-sheet-part="actor-name"
             data-tooltip={context.actor.name}
           >
-            {context.actor.name}
+            <a data-action="copyInnerText" class="cursor highlight-on-hover">
+              {context.actor.name}
+            </a>
           </h1>
         {/if}
       </div>

--- a/src/sheets/quadrone/actor/NpcSheet.svelte
+++ b/src/sheets/quadrone/actor/NpcSheet.svelte
@@ -114,7 +114,12 @@
                 data-tidy-sheet-part="actor-name"
                 data-tooltip={context.actor.name}
               >
-                {context.actor.name}
+                <a
+                  data-action="copyInnerText"
+                  class="cursor highlight-on-hover"
+                >
+                  {context.actor.name}
+                </a>
               </h1>
             {/if}
             <div

--- a/src/sheets/quadrone/actor/VehicleSheet.svelte
+++ b/src/sheets/quadrone/actor/VehicleSheet.svelte
@@ -40,8 +40,9 @@
     untrack(() => {
       const type = context.actor.type;
       const tabId = selectedTabId;
-      const stored = UserSheetPreferencesService.getByType(type)?.tabs?.[tabId]
-        ?.sidebarExpanded;
+      const stored =
+        UserSheetPreferencesService.getByType(type)?.tabs?.[tabId]
+          ?.sidebarExpanded;
       if (stored !== expanded) {
         UserSheetPreferencesService.setDocumentTypeTabPreference(
           type,
@@ -72,7 +73,14 @@
                 class="actor-name flex1 h2"
               />
             {:else}
-              <h1 class="actor-name flex1">{context.actor.name}</h1>
+              <h1 class="actor-name flex1">
+                <a
+                  data-action="copyInnerText"
+                  class="cursor highlight-on-hover"
+                >
+                  {context.actor.name}
+                </a>
+              </h1>
             {/if}
             <!-- <div
               class={['sheet-header-actions', 'flexrow']}
@@ -113,7 +121,9 @@
               data-type="initiative"
               data-has-roll-modes
             >
-              <span class="ability-abbr">{localize('DND5E.InitiativeAbbr')}</span>
+              <span class="ability-abbr"
+                >{localize('DND5E.InitiativeAbbr')}</span
+              >
               <span class="ability-label-container initiative-bonus">
                 <span class="modifier color-text-lightest">
                   {ini.sign}

--- a/src/sheets/quadrone/item/BackgroundSheet.svelte
+++ b/src/sheets/quadrone/item/BackgroundSheet.svelte
@@ -7,6 +7,7 @@
   import Tabs from 'src/components/tabs/Tabs.svelte';
   import TabContents from 'src/components/tabs/TabContents.svelte';
   import ItemName from './parts/header/ItemName.svelte';
+  import { InputAttachments } from 'src/attachments/input-attachments.svelte';
 
   let context = $derived(getItemSheetContextQuadrone());
 
@@ -26,15 +27,12 @@
       <ul class="pills stacked">
         <li>
           <a
+            role="button"
+            tabindex="0"
             class="pill interactive centered wrapped copy-to-clipboard"
-            onclick={() => {
-              const value = context.item.system.identifier;
-              game.clipboard.copyPlainText(value);
-              ui.notifications.info(
-                game.i18n.format('DND5E.Copied', { value }),
-                { console: false },
-              );
-            }}
+            data-action="copyValue"
+            data-value={context.item.system.identifier}
+            {@attach InputAttachments.triggerClickOnKeydown}
           >
             <span class="centered text-normal">
               {localize('DND5E.Identifier')}

--- a/src/sheets/quadrone/item/ClassSheet.svelte
+++ b/src/sheets/quadrone/item/ClassSheet.svelte
@@ -76,14 +76,8 @@
         <li>
           <a
             class="pill interactive centered wrapped copy-to-clipboard"
-            onclick={() => {
-              const value = context.item.system.identifier;
-              game.clipboard.copyPlainText(value);
-              ui.notifications.info(
-                game.i18n.format('DND5E.Copied', { value }),
-                { console: false },
-              );
-            }}
+            data-action="copyValue"
+            data-value={context.item.system.identifier}
           >
             <span class="text-normal">
               {localize('DND5E.Identifier')}

--- a/src/sheets/quadrone/item/SubclassSheet.svelte
+++ b/src/sheets/quadrone/item/SubclassSheet.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { CONSTANTS } from 'src/constants';
   import ItemNameHeaderOrchestrator from './parts/ItemNameHeaderOrchestrator.svelte';
   import Sidebar from './parts/Sidebar.svelte';
   import { FoundryAdapter } from 'src/foundry/foundry-adapter';
@@ -8,6 +7,7 @@
   import TabContents from 'src/components/tabs/TabContents.svelte';
   import ItemName from './parts/header/ItemName.svelte';
   import SpellcastingSidebarPills from './parts/SpellcastingSidebarPills.svelte';
+  import { InputAttachments } from 'src/attachments/input-attachments.svelte';
 
   let context = $derived(getItemSheetContextQuadrone());
 
@@ -28,16 +28,9 @@
         <li>
           <a
             class="pill interactive centered wrapped copy-to-clipboard"
-            onclick={() => {
-              const value = context.item.system.identifier;
-              game.clipboard.copyPlainText(value);
-              ui.notifications.info(
-                game.i18n.format('DND5E.Copied', { value }),
-                {
-                  console: false,
-                },
-              );
-            }}
+            data-action="copyValue"
+            data-value={context.item.system.identifier}
+            {@attach InputAttachments.triggerClickOnKeydown}
           >
             <span class="text-normal">
               {localize('DND5E.Identifier')}
@@ -50,16 +43,9 @@
         <li>
           <a
             class="pill interactive centered wrapped copy-to-clipboard"
-            onclick={() => {
-              const value = context.item.system.identifier;
-              game.clipboard.copyPlainText(value);
-              ui.notifications.info(
-                game.i18n.format('DND5E.Copied', { value }),
-                {
-                  console: false,
-                },
-              );
-            }}
+            data-action="copyValue"
+            data-value={context.item.system.classIdentifier}
+            {@attach InputAttachments.triggerClickOnKeydown}
           >
             <span class="text-normal">
               {localize('DND5E.ClassIdentifier')}

--- a/src/sheets/quadrone/item/parts/Sidebar.svelte
+++ b/src/sheets/quadrone/item/parts/Sidebar.svelte
@@ -15,7 +15,7 @@
   import { ItemContext } from 'src/features/item/ItemContext';
   import { coalesce } from 'src/utils/formatting';
   import TextInputQuadrone from 'src/components/inputs/TextInputQuadrone.svelte';
-  import { settings } from 'src/settings/settings.svelte';
+  import { InputAttachments } from 'src/attachments/input-attachments.svelte';
 
   let context = $derived(getContainerOrItemSheetContextQuadrone());
 
@@ -183,9 +183,12 @@
     if (!isNil(proficiencyPill)) {
       result.push(proficiencyPill);
     }
-    
+
     if (!isNil(context.system.mastery)) {
-      result.push(CONFIG.DND5E.weaponMasteries[context.system.mastery]?.label ?? context.system.mastery);
+      result.push(
+        CONFIG.DND5E.weaponMasteries[context.system.mastery]?.label ??
+          context.system.mastery,
+      );
     }
 
     let props =
@@ -261,7 +264,7 @@
       {const effectiveHpValue = $derived(context.system.hp.value ?? 0)}
       {const effectiveHpMax = $derived(context.system.hp.max ?? 0)}
       {const pct = $derived(
-        effectiveHpMax > 0 ? (effectiveHpValue / effectiveHpMax) * 100 : 0
+        effectiveHpMax > 0 ? (effectiveHpValue / effectiveHpMax) * 100 : 0,
       )}
       <li>
         <span
@@ -302,7 +305,7 @@
       </li>
     {/if}
     {#if 'equipped' in context.system && context.editable}
-      {const checkedIconClass = 
+      {const checkedIconClass =
         'fas fa-hand-fist equip-icon fa-fw color-text-default'}
       {const uncheckedIconClass = 'far fa-hand fa-fw'}
       {const equipped = $derived(context.system.equipped)}
@@ -363,7 +366,9 @@
       </li>
     {/if}
     {#if context.item.actor && FoundryAdapter.canPrepareSpell(context.item)}
-      {const spellIconClasses = $derived(FoundryAdapter.getSpellIcon(context.item))}
+      {const spellIconClasses = $derived(
+        FoundryAdapter.getSpellIcon(context.item),
+      )}
       <li>
         <PillSwitch
           checked={context.system.prepared ==
@@ -401,8 +406,9 @@
         <h4>{localize('DND5E.ACTIVITY.SECTIONS.Activation')}</h4>
         <ul class="pills stacked">
           {#each sidebarActivations as activation}
-            {const activationText =
-              $derived(activation?.toString().replace(/NaN/g, '—') ?? '')}
+            {const activationText = $derived(
+              activation?.toString().replace(/NaN/g, '—') ?? '',
+            )}
             <li class="pill activation-pill">
               {activationText
                 ? activationText.charAt(0).toUpperCase() +
@@ -443,28 +449,9 @@
                 role="button"
                 tabindex="0"
                 class="pill interactive centered wrapped copy-to-clipboard"
-                onclick={() => {
-                  game.clipboard.copyPlainText(scaleValue.toCopy);
-                  ui.notifications.info(
-                    game.i18n.format('DND5E.Copied', {
-                      value: scaleValue.toCopy,
-                    }),
-                    { console: false },
-                  );
-                }}
-                onkeydown={(ev) => {
-                  if (ev.key === 'Enter' || ev.key === ' ') {
-                    ev.preventDefault();
-                    ev.stopPropagation();
-                    game.clipboard.copyPlainText(scaleValue.toCopy);
-                    ui.notifications.info(
-                      game.i18n.format('DND5E.Copied', {
-                        value: scaleValue.toCopy,
-                      }),
-                      { console: false },
-                    );
-                  }
-                }}
+                data-action="copyValue"
+                data-value={scaleValue.toCopy}
+                {@attach InputAttachments.triggerClickOnKeydown}
               >
                 {#if !context.item.actor}
                   {scaleValue.title}
@@ -514,12 +501,14 @@
 
   {#if showCustomSections}
     {const sectionLabel = $derived(SheetSections.getSectionLabel(context.item))}
-    {const actionSectionLabel = $derived(SheetSections.getActionSectionLabel(
-      context.item,
-    ))}
-    {const sectionType = $derived(context.item.parent?.system.isCharacter
-      ? 'Sheet'
-      : 'TIDY5E.Section.Label')}
+    {const actionSectionLabel = $derived(
+      SheetSections.getActionSectionLabel(context.item),
+    )}
+    {const sectionType = $derived(
+      context.item.parent?.system.isCharacter
+        ? 'Sheet'
+        : 'TIDY5E.Section.Label',
+    )}
     <div>
       <h4>{localize('TIDY5E.Section.LabelPl')}</h4>
       <div class="pills stacked">

--- a/src/sheets/quadrone/item/parts/header/ItemName.svelte
+++ b/src/sheets/quadrone/item/parts/header/ItemName.svelte
@@ -25,6 +25,8 @@
   />
 {:else}
   <div class="document-name" data-tooltip={context.item.name}>
-    {context.item.name}
+    <a data-action="copyInnerText" class="cursor highlight-on-hover">
+      {context.item.name}
+    </a>
   </div>
 {/if}


### PR DESCRIPTION
- new: Click the name of any Tidy Actor or Item sheet while in Play Mode to copy that text to your clipboard. No more hand-typing big NPC names if you fancy a click instead.