### PR TITLE
chores and fixes

### DIFF
--- a/src/features/sections/CharacterSheetSections.ts
+++ b/src/features/sections/CharacterSheetSections.ts
@@ -263,7 +263,7 @@ export class CharacterSheetSections {
             key: customSection,
             title: FoundryAdapter.localize(customSection),
             options,
-            custom: true,
+            isCustom: true,
           }));
 
         section.items.push(feat);
@@ -324,7 +324,7 @@ export class CharacterSheetSections {
         key: s,
         options,
         title: FoundryAdapter.localize(s),
-        custom: true,
+        isCustom: true,
       });
     });
 
@@ -377,14 +377,20 @@ export class CharacterSheetSections {
     key: string;
     title: string;
     options: Partial<TidyItemSectionBase>;
-    custom?: boolean;
+    isCustom?: boolean;
   }): FeatureSection {
-    let custom = args.custom
+    const custom = args.isCustom
       ? {
           creationItemTypes: [CONSTANTS.ITEM_TYPE_FEAT],
           section: args.key,
         }
       : undefined;
+
+    const dataset: Record<string, unknown> = args.isCustom
+      ? {
+          [TidyFlags.section.prop]: args.key,
+        }
+      : {};
 
     return {
       type: CONSTANTS.SECTION_TYPE_FEATURE,
@@ -393,7 +399,7 @@ export class CharacterSheetSections {
       items: [],
       label: args.title,
       show: true,
-      dataset: {},
+      dataset,
       custom,
       canCreate: true,
       columns: FeatureColumnRuntime.getColumnSpecifications({

--- a/src/sheets/quadrone/Tidy5eNpcSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eNpcSheetQuadrone.svelte.ts
@@ -413,6 +413,12 @@ export class Tidy5eNpcSheetQuadrone extends getTidy5eActorSheetQuadroneBase<NpcS
         dataset: dataset,
         canCreate: true,
         columns,
+        custom: !isNil(customSectionName)
+          ? {
+              section: customSectionName,
+              creationItemTypes: [CONSTANTS.ITEM_TYPE_FEAT],
+            }
+          : undefined,
       };
     };
 

--- a/src/sheets/quadrone/Tidy5eVehicleSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eVehicleSheetQuadrone.svelte.ts
@@ -559,7 +559,11 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
       },
     };
 
-    const createFeatureSection = (key: string, label: string) => {
+    const createFeatureSection = (
+      key: string,
+      label: string,
+      customSectionName?: string,
+    ) => {
       const section: FeatureSection = {
         type: CONSTANTS.SECTION_TYPE_FEATURE,
         items: [],
@@ -579,6 +583,12 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
           owner: context.owner,
           unlocked: context.unlocked,
         }),
+        custom: !isNil(customSectionName)
+          ? {
+              section: customSectionName,
+              creationItemTypes: [],
+            }
+          : undefined,
       };
 
       return section;
@@ -726,6 +736,7 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
         const section = (features[customSectionName] ??= createFeatureSection(
           customSectionName,
           customSectionName,
+          customSectionName,
         ));
 
         section.items.push(item);
@@ -768,6 +779,7 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
         const newSharedSection = createFeatureSection(
           section.key,
           section.label,
+          section.custom?.section,
         );
         sectionsMap[section.key] = newSharedSection;
         newSharedSection.items.push(...mappedItems, ...incomingItems);

--- a/src/sheets/quadrone/Tidy5eVehicleSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eVehicleSheetQuadrone.svelte.ts
@@ -562,7 +562,7 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
     const createFeatureSection = (
       key: string,
       label: string,
-      customSectionName?: string,
+      isCustom?: boolean,
     ) => {
       const section: FeatureSection = {
         type: CONSTANTS.SECTION_TYPE_FEATURE,
@@ -583,9 +583,9 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
           owner: context.owner,
           unlocked: context.unlocked,
         }),
-        custom: !isNil(customSectionName)
+        custom: isCustom
           ? {
-              section: customSectionName,
+              section: key,
               creationItemTypes: [],
             }
           : undefined,
@@ -736,7 +736,7 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
         const section = (features[customSectionName] ??= createFeatureSection(
           customSectionName,
           customSectionName,
-          customSectionName,
+          true,
         ));
 
         section.items.push(item);
@@ -779,7 +779,7 @@ export class Tidy5eVehicleSheetQuadrone extends getTidy5eActorSheetQuadroneBase<
         const newSharedSection = createFeatureSection(
           section.key,
           section.label,
-          section.custom?.section,
+          !isNil(section.custom?.section),
         );
         sectionsMap[section.key] = newSharedSection;
         newSharedSection.items.push(...mappedItems, ...incomingItems);

--- a/src/sheets/quadrone/actor/tabs/EncounterCombatTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/EncounterCombatTab.svelte
@@ -132,7 +132,10 @@
           ),
         )}
 
-        <TidyTable key={section.key}>
+        <TidyTable
+          key={section.key}
+          data-custom-section={section.custom ? true : null}
+        >
           {#snippet header()}
             <TidyTableHeaderRow class={!isBasicTheme ? 'theme-dark' : ''}>
               <TidyTableHeaderCell primary={true}>

--- a/src/sheets/quadrone/actor/tabs/EncounterMembersTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/EncounterMembersTab.svelte
@@ -96,7 +96,10 @@
           ),
         )}
 
-        <TidyTable key={section.key}>
+        <TidyTable
+          key={section.key}
+          data-custom-section={section.custom ? true : null}
+        >
           {#snippet header()}
             <TidyTableHeaderRow class={!isBasicTheme ? 'theme-dark' : ''}>
               <TidyTableHeaderCell primary={true}>

--- a/src/sheets/quadrone/actor/tabs/VehicleCrewAndPassengersTab.svelte
+++ b/src/sheets/quadrone/actor/tabs/VehicleCrewAndPassengersTab.svelte
@@ -203,7 +203,11 @@
                 section.columns,
               ),
         )}
-        <TidyTable key={section.key} data-area={section.type}>
+        <TidyTable
+          key={section.key}
+          data-area={section.type}
+          data-custom-section={section.custom ? true : null}
+        >
           {#snippet header(expanded)}
             <TidyTableHeaderRow class={!isBasicTheme ? 'theme-dark' : ''}>
               <TidyTableHeaderCell primary={true} class="header-label-cell">

--- a/src/sheets/quadrone/item/columns/ActivityTimeColumn.svelte
+++ b/src/sheets/quadrone/item/columns/ActivityTimeColumn.svelte
@@ -34,7 +34,7 @@
 
 {#if !isNil(text, '')}
   <span class="overflow-wrap-anywhere" data-tooltip={tooltipContent.trim()}>
-    {!isNil(inferredActivation?.value)
+    {@html !isNil(inferredActivation?.value)
       ? inferredActivation?.value + '&nbsp;'
       : ''}
     {localize(text).trim()}

--- a/src/todo.md
+++ b/src/todo.md
@@ -1,6 +1,8 @@
 ## The Accretion Disk of To Do's
 
-- [ ] NPC Statblock - drag/drop to custom section is not working. It removes the custom section altogether. Doesn't happen on an inventory tab, for example.
+- [ ] Vehicle Statblock - when dropping a custom section feature onto the empty feature table, it doesn't transfer. Can I do anything reasonable about that?
+  - It's probably because the section transfer is part of sorting, and if it is dropped on the empty table's header, there's no sorting to occur. This raises the question, should it be doing section transfer during sort, or should it be a separate process, to follow dropCreate or sort?
+- [ ] Custom sections require 2 things: `section.custom` and `dataset[TidyFlags.section.prop]` (or actionSection equivalent). Is there a good way to streamline this? Having to remember it each time is a little awkward and prone to be forgotten.
 - [ ] Create DocumentTags - Support multiple tags
 - [ ] Stretch - Group Sheet: Enable Sorting. Curating a solution is an option. Redesigning the item filter and item sort codebases to be more generic and flexible would be a better longterm goal.
 - [ ] Ensure all item sheets enforce this Unidentified UI feature:

--- a/src/todo.md
+++ b/src/todo.md
@@ -1,5 +1,6 @@
 ## The Accretion Disk of To Do's
 
+- [ ] NPC Statblock - drag/drop to custom section is not working. It removes the custom section altogether. Doesn't happen on an inventory tab, for example.
 - [ ] Create DocumentTags - Support multiple tags
 - [ ] Stretch - Group Sheet: Enable Sorting. Curating a solution is an option. Redesigning the item filter and item sort codebases to be more generic and flexible would be a better longterm goal.
 - [ ] Ensure all item sheets enforce this Unidentified UI feature:

--- a/src/todo.md
+++ b/src/todo.md
@@ -1,7 +1,11 @@
 ## The Accretion Disk of To Do's
 
-- [ ] Vehicle Statblock - when dropping a custom section feature onto the empty feature table, it doesn't transfer. Can I do anything reasonable about that?
-  - It's probably because the section transfer is part of sorting, and if it is dropped on the empty table's header, there's no sorting to occur. This raises the question, should it be doing section transfer during sort, or should it be a separate process, to follow dropCreate or sort?
+- [ ] Revise/Centralize/Streamline Section Transfer On Drop. It should not rely on sorting. Sorting and drop creation should both invoke a doc-sheet-mix base class function where an update operation is to be done. Based on the data provided, the section transfer portion should be managed as a follow up append to the update data, only when the drop is not a drop-create scenario. 
+  - Goal: Drop any sortable/drop-creatable onto a section table and have section transfer work without the requirement of having a sort operation done.
+  - Secondary Goal: generalize the create vs. sort process so that no code duplication is required for handling the common task of section transfer after a non-creation entity drop.
+  - Scenario: Vehicle Statblock - when dropping a custom section feature onto the empty feature table, it doesn't transfer. Section transfer is part of sorting for item drops to actors and for item drops to containers, and if it is dropped on the empty table's header, there's no sorting to occur. This raises the question, should it be doing section transfer during sort, or should it be a separate process, to follow dropCreate or sort?
+  - Search for usages of `FoundryAdapter.getSectionUpdateForDropTarget`
+  - `Tidy5eMultiActorSheetQuadroneBase._onDropActor` duplicates this effort
 - [ ] Custom sections require 2 things: `section.custom` and `dataset[TidyFlags.section.prop]` (or actionSection equivalent). Is there a good way to streamline this? Having to remember it each time is a little awkward and prone to be forgotten.
 - [ ] Create DocumentTags - Support multiple tags
 - [ ] Stretch - Group Sheet: Enable Sorting. Curating a solution is an option. Redesigning the item filter and item sort codebases to be more generic and flexible would be a better longterm goal.


### PR DESCRIPTION
- fixed: Activity Time column was showing `&nbsp;`.
- fixed: drag/drop to transfer items between custom and regular sections was not working for Character Features and NPC Statblock entries.