### PR TITLE
[#1746] checkbox data-name form change handling fix

### DIFF
--- a/src/mixins/TidyDocumentSheetMixin.svelte.ts
+++ b/src/mixins/TidyDocumentSheetMixin.svelte.ts
@@ -303,6 +303,8 @@ export function getTidyExtensibleDocumentSheetMixin<
           new Event('input', { bubbles: true, cancelable: true }),
         );
         // intentionally skip the form change event
+      } else if (event.target.type === 'checkbox') {
+        event.target.checked = !!value;
       } else {
         event.target.value = value;
       }
@@ -588,6 +590,8 @@ export function getTidyExtensibleDocumentSheetMixin<
           : valueToSave;
 
         await this._updateNumericProperty(doc, prop, valueAsNumber);
+      } else if (event.target.type === 'checkbox') {
+        await doc.update({ [prop]: event.target.checked });
       } else {
         await doc.update({ [prop]: valueToSave });
       }

--- a/src/todo.md
+++ b/src/todo.md
@@ -1,5 +1,6 @@
 ## The Accretion Disk of To Do's
 
+- [ ] Is there a Foundry native way to process any form input type into its proper update value from the element itself during form change events?
 - [ ] Revise/Centralize/Streamline Section Transfer On Drop. It should not rely on sorting. Sorting and drop creation should both invoke a doc-sheet-mix base class function where an update operation is to be done. Based on the data provided, the section transfer portion should be managed as a follow up append to the update data, only when the drop is not a drop-create scenario. 
   - Goal: Drop any sortable/drop-creatable onto a section table and have section transfer work without the requirement of having a sort operation done.
   - Secondary Goal: generalize the create vs. sort process so that no code duplication is required for handling the common task of section transfer after a non-creation entity drop.


### PR DESCRIPTION
#1746 

- fixed: Checkbox changes were not saving for data-name elements.