### PR TITLE
quick fix - NPC Concentration

### DIFF
--- a/src/sheets/quadrone/Tidy5eNpcSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eNpcSheetQuadrone.svelte.ts
@@ -90,6 +90,8 @@ export class Tidy5eNpcSheetQuadrone extends getTidy5eActorSheetQuadroneBase<NpcS
       return this._context.data;
     }
 
+    this._concentration = this.actor.concentration;
+
     const actorContext = (await super._prepareContext(
       options,
     )) as ActorSheetQuadroneContext;


### PR DESCRIPTION
- fixed: NPC Effects tab wasn't showing Concentration Break row action.