### PR TITLE
[#1766] quick fix - container item use

### DIFF
--- a/src/mixins/TidyDocumentSheetMixin.svelte.ts
+++ b/src/mixins/TidyDocumentSheetMixin.svelte.ts
@@ -689,7 +689,9 @@ export function getTidyExtensibleDocumentSheetMixin<
         (sheetDocument.id === itemId || !itemId);
       const item = sheetDocumentIsRelatedItem
         ? sheetDocument
-        : sheetDocument?.items?.get(itemId);
+        : sheetDocument.type === CONSTANTS.ITEM_TYPE_CONTAINER
+          ? sheetDocument.system.getContainedItem(itemId)
+          : sheetDocument?.items?.get(itemId);
 
       const { activityId } =
         target.closest<HTMLElement>('[data-activity-id]')?.dataset ?? {};


### PR DESCRIPTION
- fixed: When on the container sheet, clicking to use items like consumables was not working properly.

#1766 