### PR TITLE
Quick fix - Group Skill ability abbreviation not localized

### DIFF
--- a/src/sheets/quadrone/Tidy5eMultiActorSheetQuadroneBase.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eMultiActorSheetQuadroneBase.svelte.ts
@@ -500,6 +500,7 @@ export function getTidy5eMultiActorSheetQuadroneBase<
           ([key, skill]) => [
             key,
             {
+              abilityAbbreviation: CONFIG.DND5E.abilities[skill.ability]?.abbreviation ?? skill.ability,
               ability: skill.ability,
               high: {
                 total: -Infinity,

--- a/src/sheets/quadrone/actor/group-parts/members-tab-sidebar/GroupSkills.svelte
+++ b/src/sheets/quadrone/actor/group-parts/members-tab-sidebar/GroupSkills.svelte
@@ -59,9 +59,9 @@
   >
     {#each context.skills as skill}
       {#if expanded || skill.proficient}
-        {const memberSkill = $derived(skill.identifiers.get(
-          emphasizedMember?.actor.uuid ?? '',
-        ))}
+        {const memberSkill = $derived(
+          skill.identifiers.get(emphasizedMember?.actor.uuid ?? ''),
+        )}
         {const memberProficient = $derived((memberSkill?.proficient ?? 0) > 0)}
 
         <li
@@ -85,11 +85,15 @@
         >
           <button
             type="button"
-            data-action={FoundryAdapter.userIsGm() ? "showContextMenu" : undefined}
-            data-target-selector={FoundryAdapter.userIsGm() ? "[data-context-menu]" : undefined}
+            data-action={FoundryAdapter.userIsGm()
+              ? 'showContextMenu'
+              : undefined}
+            data-target-selector={FoundryAdapter.userIsGm()
+              ? '[data-context-menu]'
+              : undefined}
             class="button button-borderless skill-ability font-label-medium"
           >
-            {skill.ability}
+            {skill.abilityAbbreviation}
           </button>
           <button
             type="button"

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1576,6 +1576,7 @@ export type GroupMemberSkillContext = GroupSkillModContext & {
 
 export type GroupSkill = {
   name: string;
+  abilityAbbreviation: string;
   ability: string;
   key: string;
   proficient: boolean;


### PR DESCRIPTION
- fixed: The group and encounter sheet ability abbreviation on the Skills sidebar section was not being properly localized.