### PR TITLE
Action Section revision

### DIFF
--- a/src/context-menu/tidy5e-item-context-menu-quadrone.ts
+++ b/src/context-menu/tidy5e-item-context-menu-quadrone.ts
@@ -36,6 +36,8 @@ export function getItemContextOptionsQuadrone(
 
   const tabId = CONFIG.TIDY5E.utils.getTabIdFromElement(element);
 
+  const showActionSectionConfig = SheetSections.showActionSectionConfig(item.parent);
+
   let options: ContextMenuEntry[] = [];
 
   // Common - these are standard options, or they're options that Tidy offers which interface with standard foundry behaviors.
@@ -324,7 +326,8 @@ export function getItemContextOptionsQuadrone(
     condition: () =>
       item.isOwner &&
       SheetSections.itemSupportsCustomSections(item.type) &&
-      app.currentTabId !== CONSTANTS.TAB_ACTOR_ACTIONS &&
+      (app.currentTabId !== CONSTANTS.TAB_ACTOR_ACTIONS ||
+        !showActionSectionConfig) &&
       !FoundryAdapter.isLockedInCompendium(item),
     group: 'customize',
     callback: () =>
@@ -360,6 +363,7 @@ export function getItemContextOptionsQuadrone(
     name: actionSectionContextName,
     icon: '<i class="fas fa-diagram-cells"></i>',
     condition: () =>
+      showActionSectionConfig &&
       item.isOwner &&
       SheetSections.itemSupportsCustomSections(item.type) &&
       app.currentTabId === CONSTANTS.TAB_ACTOR_ACTIONS &&

--- a/src/features/sections/CharacterSheetSections.ts
+++ b/src/features/sections/CharacterSheetSections.ts
@@ -210,7 +210,6 @@ export class CharacterSheetSections {
     tabId: string,
     feats: Item5e[],
     options: Partial<CharacterFeatureSection>,
-    customSectionFlag: 'section' | 'actionSection' = 'section',
   ): FeatureSection[] {
     let featuresMap: Record<string, FeatureSection> = {};
 
@@ -252,7 +251,7 @@ export class CharacterSheetSections {
 
     for (let feat of feats) {
       // custom section
-      let customSection = TidyFlags[customSectionFlag].get(feat);
+      let customSection = TidyFlags.section.get(feat);
 
       if (!isNil(customSection)) {
         // Partition/Create Custom Section and add item

--- a/src/features/sections/Inventory.ts
+++ b/src/features/sections/Inventory.ts
@@ -87,7 +87,10 @@ export class Inventory {
     defaultInventoryTypes: string[];
     /** When creating a custom section during this operation, merge in these options over the defaults.  */
     customSectionOptions?: Partial<InventorySection>;
-    /** The custom section flag to use when looking for a custom section name. */
+    /** 
+     * The custom section flag to use when looking for a custom section name. 
+     * @deprecated game.release.generation < 14
+    */
     customSectionFlag?: 'section' | 'actionSection';
   }) {
     const {

--- a/src/features/sections/SectionActions.ts
+++ b/src/features/sections/SectionActions.ts
@@ -16,8 +16,8 @@ import type { AdvancementSection, Item5e } from 'src/types/item.types';
 import { CONSTANTS } from 'src/constants';
 
 class SectionActions {
-  getActionHeaderActions(
-    actor: Actor5e,
+  getSheetTabHeaderActions(
+    character: Actor5e,
     owner: boolean,
     unlocked: boolean,
     section: TidyItemSectionBase,
@@ -26,15 +26,21 @@ class SectionActions {
       return [];
     }
 
+    const sectionConfigFlag =
+      SheetSections.getSheetTabSectionOrganizationForDocument(character) ===
+      CONSTANTS.SECTION_ORGANIZATION_ACTION
+        ? TidyFlags.actionSection.prop
+        : TidyFlags.section.prop;
+
     const renameCommand = this.getActorItemSectionRenameCommand(
-      actor,
+      character,
       unlocked,
       section,
-      TidyFlags.actionSection.prop,
+      sectionConfigFlag,
     );
 
     const runtimeCommands = ActorItemRuntime.getActorItemSectionCommands({
-      document: actor,
+      document: character,
       section,
       unlocked,
     });

--- a/src/features/sections/SheetSections.ts
+++ b/src/features/sections/SheetSections.ts
@@ -32,7 +32,7 @@ import type { Activity5e, CharacterFavorite } from 'src/foundry/dnd5e.types';
 import { error } from 'src/utils/logging';
 import { getSortedActions } from '../actions/actions.svelte';
 import { SpellUtils } from 'src/utils/SpellUtils';
-import { settings } from 'src/settings/settings.svelte';
+import { settings, SettingsProvider } from 'src/settings/settings.svelte';
 import { FoundryAdapter } from 'src/foundry/foundry-adapter';
 import UserPreferencesService from '../user-preferences/UserPreferencesService';
 import type { SpellcastingConfigEntry } from 'src/foundry/config.types';
@@ -984,6 +984,24 @@ export class SheetSections {
         CONSTANTS.ITEM_TYPE_RACE,
         CONSTANTS.ITEM_TYPE_FACILITY,
       ].includes(item.type) && !Inventory.isItemInventoryType(item)
+    );
+  }
+
+  static showActionSectionConfig(actor: Actor5e | undefined) {
+    return (
+      actor &&
+      actor.type === CONSTANTS.SHEET_TYPE_CHARACTER &&
+      this.getSheetTabSectionOrganizationForDocument(actor) ===
+        CONSTANTS.SECTION_ORGANIZATION_ACTION
+    );
+  }
+
+  static getSheetTabSectionOrganizationForDocument(
+    document: any,
+  ): 'action' | 'origin' {
+    return (
+      TidyFlags.characterSheetTabSectionOrganization.get(document) ??
+      SettingsProvider.settings.characterSheetTabOrganization.get()
     );
   }
 }

--- a/src/sheets/quadrone/Tidy5eCharacterSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eCharacterSheetQuadrone.svelte.ts
@@ -326,7 +326,7 @@ export class Tidy5eCharacterSheetQuadrone extends getTidy5eActorSheetQuadroneBas
 
       actionSections.forEach((section) => {
         section.type = CONSTANTS.SECTION_TYPE_FEATURE;
-        section.sectionActions = SectionActions.getActionHeaderActions(
+        section.sectionActions = SectionActions.getSheetTabHeaderActions(
           this.actor,
           this.actor.isOwner,
           context.unlocked,
@@ -346,9 +346,8 @@ export class Tidy5eCharacterSheetQuadrone extends getTidy5eActorSheetQuadroneBas
   }
 
   getSheetTabSectionOrganization(): 'action' | 'origin' {
-    return (
-      TidyFlags.characterSheetTabSectionOrganization.get(this.document) ??
-      SettingsProvider.settings.characterSheetTabOrganization.get()
+    return SheetSections.getSheetTabSectionOrganizationForDocument(
+      this.document,
     );
   }
 
@@ -525,7 +524,7 @@ export class Tidy5eCharacterSheetQuadrone extends getTidy5eActorSheetQuadroneBas
 
     sheetTabSections.forEach(
       (section) =>
-        (section.sectionActions = SectionActions.getActionHeaderActions(
+        (section.sectionActions = SectionActions.getSheetTabHeaderActions(
           this.document,
           context.owner,
           context.unlocked,

--- a/src/sheets/quadrone/Tidy5eCharacterSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eCharacterSheetQuadrone.svelte.ts
@@ -227,7 +227,6 @@ export class Tidy5eCharacterSheetQuadrone extends getTidy5eActorSheetQuadroneBas
         mod: this.actor.system.attributes.encumbrance.mod,
       },
       skills: [],
-      sheetTabSectionMode: this.getSheetTabSectionOrganization(),
       sheetTabSections: [],
       showDeathSaves: this._showDeathSaves,
       species: species
@@ -308,7 +307,10 @@ export class Tidy5eCharacterSheetQuadrone extends getTidy5eActorSheetQuadroneBas
 
     const sortMode = sheetTabPreferences?.sort ?? 'm';
 
-    if (context.sheetTabSectionMode === CONSTANTS.SECTION_ORGANIZATION_ORIGIN) {
+    const sheetTabSectionMode =
+      SheetSections.getSheetTabSectionOrganizationForDocument(this.document);
+
+    if (sheetTabSectionMode === CONSTANTS.SECTION_ORGANIZATION_ORIGIN) {
       const sheetTabSections = this.createSheetTabOriginSections(context);
       context.sheetTabSections = SheetSections.configureActionsQuadrone(
         sheetTabSections,

--- a/src/sheets/quadrone/Tidy5eCharacterSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eCharacterSheetQuadrone.svelte.ts
@@ -30,10 +30,7 @@ import * as Bastion from 'src/features/facility/Bastion';
 import { ThemeQuadrone } from 'src/theme/theme-quadrone.svelte';
 import { getTidy5eActorSheetQuadroneBase } from './Tidy5eActorSheetQuadroneBase.svelte';
 import { TidyFlags } from 'src/foundry/TidyFlags';
-import type {
-  Activity5e,
-  CharacterFavorite,
-} from 'src/foundry/dnd5e.types';
+import type { Activity5e, CharacterFavorite } from 'src/foundry/dnd5e.types';
 import { FoundryAdapter } from 'src/foundry/foundry-adapter';
 import { isNil } from 'src/utils/data';
 import type { TidyDocumentSheetRenderOptions } from 'src/mixins/TidyDocumentSheetMixin.svelte';
@@ -230,6 +227,7 @@ export class Tidy5eCharacterSheetQuadrone extends getTidy5eActorSheetQuadroneBas
         mod: this.actor.system.attributes.encumbrance.mod,
       },
       skills: [],
+      sheetTabSectionMode: this.getSheetTabSectionOrganization(),
       sheetTabSections: [],
       showDeathSaves: this._showDeathSaves,
       species: species
@@ -304,18 +302,13 @@ export class Tidy5eCharacterSheetQuadrone extends getTidy5eActorSheetQuadroneBas
   }
 
   prepareSheetTabSections(context: CharacterSheetQuadroneContext) {
-    const sectionMode:
-      | typeof CONSTANTS.SECTION_ORGANIZATION_ACTION
-      | typeof CONSTANTS.SECTION_ORGANIZATION_ORIGIN =
-      this.getSheetTabSectionOrganization();
-
     const sheetTabPreferences = UserSheetPreferencesService.getByType(
       this.actor.type,
     )?.tabs?.[CONSTANTS.TAB_ACTOR_ACTIONS];
 
     const sortMode = sheetTabPreferences?.sort ?? 'm';
 
-    if (sectionMode === CONSTANTS.SECTION_ORGANIZATION_ORIGIN) {
+    if (context.sheetTabSectionMode === CONSTANTS.SECTION_ORGANIZATION_ORIGIN) {
       const sheetTabSections = this.createSheetTabOriginSections(context);
       context.sheetTabSections = SheetSections.configureActionsQuadrone(
         sheetTabSections,
@@ -352,7 +345,7 @@ export class Tidy5eCharacterSheetQuadrone extends getTidy5eActorSheetQuadroneBas
     }
   }
 
-  private getSheetTabSectionOrganization(): 'action' | 'origin' {
+  getSheetTabSectionOrganization(): 'action' | 'origin' {
     return (
       TidyFlags.characterSheetTabSectionOrganization.get(this.document) ??
       SettingsProvider.settings.characterSheetTabOrganization.get()
@@ -410,7 +403,6 @@ export class Tidy5eCharacterSheetQuadrone extends getTidy5eActorSheetQuadroneBas
         customSectionOptions: {
           canCreate: true,
         },
-        customSectionFlag: 'actionSection',
       });
     }
 
@@ -422,7 +414,6 @@ export class Tidy5eCharacterSheetQuadrone extends getTidy5eActorSheetQuadroneBas
       {
         canCreate: true,
       },
-      'actionSection',
     );
 
     // Features
@@ -434,7 +425,6 @@ export class Tidy5eCharacterSheetQuadrone extends getTidy5eActorSheetQuadroneBas
         {
           canCreate: true,
         },
-        'actionSection',
       );
 
     const applyStandardItemHeaderActions = (section: TidyItemSectionBase) => {

--- a/src/sheets/quadrone/Tidy5eContainerSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eContainerSheetQuadrone.svelte.ts
@@ -41,7 +41,7 @@ import { isNil } from 'src/utils/data';
 import { TidyFlags } from 'src/foundry/TidyFlags';
 import { mapGetOrInsert } from 'src/utils/map';
 import SectionActions from 'src/features/sections/SectionActions';
-import { delay } from 'src/utils/asynchrony';
+import { SheetSections } from 'src/features/sections/SheetSections';
 
 export class Tidy5eContainerSheetQuadrone
   extends getTidyExtensibleDocumentSheetMixin<
@@ -275,6 +275,9 @@ export class Tidy5eContainerSheetQuadrone
     const owner = this.item.isOwner;
 
     const context: ContainerSheetQuadroneContext = {
+      actionSectionEnabled: SheetSections.showActionSectionConfig(
+        this.document.parent,
+      ),
       canIdentify: FoundryAdapter.canIdentify(this.document),
       capacity: capacityContext,
       concealDetails:

--- a/src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte.ts
@@ -307,6 +307,7 @@ export class Tidy5eItemSheetQuadrone extends getTidyExtensibleDocumentSheetMixin
     const target = this.item.type === 'spell' ? this.item.system.target : null;
 
     const context: ItemSheetQuadroneContext = {
+      actionSectionEnabled: , // todo figure it out
       activities: [
         {
           key: CONSTANTS.TAB_ITEM_ACTIVITIES,

--- a/src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte.ts
+++ b/src/sheets/quadrone/Tidy5eItemSheetQuadrone.svelte.ts
@@ -307,7 +307,9 @@ export class Tidy5eItemSheetQuadrone extends getTidyExtensibleDocumentSheetMixin
     const target = this.item.type === 'spell' ? this.item.system.target : null;
 
     const context: ItemSheetQuadroneContext = {
-      actionSectionEnabled: , // todo figure it out
+      actionSectionEnabled: SheetSections.showActionSectionConfig(
+        this.document.parent,
+      ),
       activities: [
         {
           key: CONSTANTS.TAB_ITEM_ACTIVITIES,
@@ -622,7 +624,9 @@ export class Tidy5eItemSheetQuadrone extends getTidyExtensibleDocumentSheetMixin
         { available: [], executable: [] },
       );
 
-      context.facilityContext = await Bastions.buildChosenFacilityContext(this.item);
+      context.facilityContext = await Bastions.buildChosenFacilityContext(
+        this.item,
+      );
     }
 
     if (

--- a/src/sheets/quadrone/item/parts/Sidebar.svelte
+++ b/src/sheets/quadrone/item/parts/Sidebar.svelte
@@ -501,9 +501,6 @@
 
   {#if showCustomSections}
     {const sectionLabel = $derived(SheetSections.getSectionLabel(context.item))}
-    {const actionSectionLabel = $derived(
-      SheetSections.getActionSectionLabel(context.item),
-    )}
     {const sectionType = $derived(
       context.item.parent?.system.isCharacter
         ? 'Sheet'
@@ -539,30 +536,37 @@
             {section}
           </span>
         </a>
-        <!-- svelte-ignore a11y_missing_attribute -->
-        <a
-          role="button"
-          tabindex="0"
-          class="pill interactive wrapped no-row-gap centered"
-          class:disabled={!context.editable}
-          data-tooltip="TIDY5E.Section.SectionSelectorChooseActionSectionTooltip"
-          onclick={() =>
-            context.sheet._renderChild(
-              new SectionSelectorApplication({
-                flag: TidyFlags.actionSection.prop,
-                sectionType: localize('TIDY5E.Section.ActionLabel'),
-                callingDocument: context.item,
-                document: context.item,
-              }),
-            )}
-        >
-          <span class="text-normal">
-            {actionSectionLabel}
-          </span>
-          <span class="hyphens-auto">
-            {actionSection}
-          </span>
-        </a>
+
+        {#if context.actionSectionEnabled}
+          {const actionSectionLabel = $derived(
+            SheetSections.getActionSectionLabel(context.item),
+          )}
+
+          <!-- svelte-ignore a11y_missing_attribute -->
+          <a
+            role="button"
+            tabindex="0"
+            class="pill interactive wrapped no-row-gap centered"
+            class:disabled={!context.editable}
+            data-tooltip="TIDY5E.Section.SectionSelectorChooseActionSectionTooltip"
+            onclick={() =>
+              context.sheet._renderChild(
+                new SectionSelectorApplication({
+                  flag: TidyFlags.actionSection.prop,
+                  sectionType: localize('TIDY5E.Section.ActionLabel'),
+                  callingDocument: context.item,
+                  document: context.item,
+                }),
+              )}
+          >
+            <span class="text-normal">
+              {actionSectionLabel}
+            </span>
+            <span class="hyphens-auto">
+              {actionSection}
+            </span>
+          </a>
+        {/if}
       </div>
     </div>
   {/if}

--- a/src/types/item.types.ts
+++ b/src/types/item.types.ts
@@ -171,6 +171,8 @@ export type ActivitySectionQuadrone = TidySectionBase & {
 };
 
 export type ItemSheetQuadroneContext = {
+  /** The target sheet or its parent supports an aggregate/action section (e.g., action-economy Character Sheet tab or statblock NPC tab) */
+  actionSectionEnabled: boolean;
   activities: ActivitySectionQuadrone[];
   activationTypes: GroupableSelectOption[];
   advancement: AdvancementSection[];
@@ -376,6 +378,8 @@ export type CurrencyContext = {
 };
 
 export type ContainerSheetQuadroneContext = {
+  /** The target sheet or its parent supports an aggregate/action section (e.g., action-economy Character Sheet tab or statblock NPC tab) */
+  actionSectionEnabled: boolean;
   capacity: ContainerCapacityContext;
   canIdentify: boolean;
   concealDetails: boolean;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1396,6 +1396,9 @@ export type CharacterSheetQuadroneContext = {
   itemContext: Record<string, CharacterItemQuadroneContext>;
   orphanedSubclasses: Item5e[];
   senses: CharacterSpeedSenseContext;
+  sheetTabSectionMode:
+    | typeof CONSTANTS.SECTION_ORGANIZATION_ACTION
+    | typeof CONSTANTS.SECTION_ORGANIZATION_ORIGIN;
   sheetTabSections: SheetTabSection[]; // TODO: Got a better name?
   showDeathSaves: boolean;
   sidebarTabs: Tab[];

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1396,9 +1396,6 @@ export type CharacterSheetQuadroneContext = {
   itemContext: Record<string, CharacterItemQuadroneContext>;
   orphanedSubclasses: Item5e[];
   senses: CharacterSpeedSenseContext;
-  sheetTabSectionMode:
-    | typeof CONSTANTS.SECTION_ORGANIZATION_ACTION
-    | typeof CONSTANTS.SECTION_ORGANIZATION_ORIGIN;
   sheetTabSections: SheetTabSection[]; // TODO: Got a better name?
   showDeathSaves: boolean;
   sidebarTabs: Tab[];


### PR DESCRIPTION
- change: the "Action Section" configuration now only shows for items embedded in Character sheets where the Sheet tab organization is set to "Action economy". The extra section config button will now be hidden from the item sheet sidebar when not relevant.
- change: when determining custom sections for the Character Sheet tab when organization is set to "Item or feature type", the regular section configuration will be used, meaning you do not have to reapply sections on the sheet tab if you've got a specific setup on the tab of origin.